### PR TITLE
Add the write_timeout option for mysql.

### DIFF
--- a/doc/build/changelog/unreleased_12/4381.rst
+++ b/doc/build/changelog/unreleased_12/4381.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tag: feature, mysql
+    :tickets: 4381
+
+    Added support for the ``write_timeout`` flag accepted by mysqlclient and pymysql to 
+    be passed in the URL string.

--- a/lib/sqlalchemy/dialects/mysql/mysqldb.py
+++ b/lib/sqlalchemy/dialects/mysql/mysqldb.py
@@ -162,6 +162,7 @@ class MySQLDialect_mysqldb(MySQLDialect):
         util.coerce_kw_type(opts, 'compress', bool)
         util.coerce_kw_type(opts, 'connect_timeout', int)
         util.coerce_kw_type(opts, 'read_timeout', int)
+        util.coerce_kw_type(opts, 'write_timeout', int)
         util.coerce_kw_type(opts, 'client_flag', int)
         util.coerce_kw_type(opts, 'local_infile', int)
         # Note: using either of the below will cause all strings to be

--- a/test/dialect/mysql/test_dialect.py
+++ b/test/dialect/mysql/test_dialect.py
@@ -54,6 +54,7 @@ class DialectTest(fixtures.TestBase):
             ('compress', True),
             ('connect_timeout', 30),
             ('read_timeout', 30),
+            ('write_timeout', 30),
             ('client_flag', 1234),
             ('local_infile', 1234),
             ('use_unicode', False),


### PR DESCRIPTION
As MySQLdb support read_timeout and write_timeout option, and
sqlalchemy just support read_timeout option. So sqlalchemy need to add
write_timeout option.