### PR TITLE
Set a reading order to the compatibility import file

### DIFF
--- a/lib/sqlalchemy/util/compat.py
+++ b/lib/sqlalchemy/util/compat.py
@@ -283,6 +283,7 @@ def nested(*managers):
 
     exits = []
     vars = []
+    exc = (None, None, None)
     try:
         for mgr in managers:
             exit = mgr.__exit__
@@ -302,7 +303,6 @@ def nested(*managers):
                 exc = sys.exc_info()
         if exc != (None, None, None):
             reraise(exc[0], exc[1], exc[2])
-    exc = (None, None, None)
 
 
 def raise_from_cause(exception, exc_info=None):


### PR DESCRIPTION
The order is as follows:
1. Imports, in the same format of "import X"
2. Members denoting versions of python
3. Members of imports that are shadowed for usage across the system
4. Global variables
5. If conditions of imports. (internally organized by this order)
6. Function definitions