### PR TITLE
Prevents an error when trying to cast a UUID to UUID

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -444,7 +444,7 @@ class _PGUUID(UUID):
             nonetype = type(None)
 
             def process(value):
-                if value is not None:
+                if value is not None and not isinstance(value, _python_UUID):
                     value = _python_UUID(value)
                 return value
             return process


### PR DESCRIPTION
First off, thank you for sqlalchemy. We think it is great!

We often get the following stacktrace when trying to insert UUIDs. I believe this patch should fix the problem. If there is something that I am missing or we can do to prevent this problem in the first place I would love to know.

Once again, thanks!

```python
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
~/anaconda/envs/drugdiscovery/lib/python3.6/site-packages/sqlalchemy/engine/base.py in _execute_context(self, dialect, constructor, statement, parameters, *args)
   1126 
-> 1127             context = constructor(dialect, self, conn, *args)
   1128         except BaseException as e:

~/anaconda/envs/drugdiscovery/lib/python3.6/site-packages/sqlalchemy/engine/default.py in _init_compiled(cls, dialect, connection, dbapi_connection, compiled, parameters)
    694                         )
--> 695                         for key in compiled_params
    696                     )

~/anaconda/envs/drugdiscovery/lib/python3.6/site-packages/sqlalchemy/engine/default.py in <genexpr>(.0)
    694                         )
--> 695                         for key in compiled_params
    696                     )

~/anaconda/envs/drugdiscovery/lib/python3.6/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py in process(value)
    447                 if value is not None:
--> 448                     value = _python_UUID(value)
    449                 return value

~/anaconda/envs/drugdiscovery/lib/python3.6/uuid.py in __init__(self, hex, bytes, bytes_le, fields, int, version)
    136         if hex is not None:
--> 137             hex = hex.replace('urn:', '').replace('uuid:', '')
    138             hex = hex.strip('{}').replace('-', '')

AttributeError: 'UUID' object has no attribute 'replace'
```