### PR TITLE
(pgdialect) strip schema quotes from enum names

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2611,7 +2611,7 @@ class PGDialect(default.DefaultDialect):
         attype = re.sub(r'\(.*\)', '', format_type)
 
         # strip quotes from case sensitive enum names
-        attype = re.sub(r'^"|"$', '', attype)
+        attype = re.sub(r'^"|"$|\b"', '', attype)
 
         # strip '[]' from integer[], etc. and check if an array
         attype, is_array = _handle_array_type(attype)


### PR DESCRIPTION
When an enum has a funky schema name and needs to be quoted, postgres' table description will show it as `"my-funky-schema".my_enum` -- i.e. only the schema part will be quoted, but not the whole qualified string name.

In order to match it up against the PGDialect's built-up list of enum, which do not quote identifiers (it will be keyed as `my-funky-schema.my_enum`), `_get_column_info()` needs a small addition to its quote stripping regex.

Tested against postgresql server 9.4.