### PR TITLE
add public accessor for the pool._timeout value

### DIFF
--- a/lib/sqlalchemy/pool/impl.py
+++ b/lib/sqlalchemy/pool/impl.py
@@ -182,6 +182,9 @@ class QueuePool(Pool):
     def size(self):
         return self._pool.maxsize
 
+    def timeout(self):
+        return self._pool._timeout
+
     def checkedin(self):
         return self._pool.qsize()
 

--- a/test/engine/test_pool.py
+++ b/test/engine/test_pool.py
@@ -1113,6 +1113,12 @@ class QueuePoolTest(PoolTestBase):
         lazy_gc()
         assert not pool._refs
 
+    def test_timeout_accessor(self):
+        expected_timeout = 123
+        p = self._queuepool_fixture(
+            timeout=expected_timeout)
+        assert p.timeout() == expected_timeout
+
     @testing.requires.timing_intensive
     def test_timeout(self):
         p = self._queuepool_fixture(


### PR DESCRIPTION
fixes : https://github.com/sqlalchemy/sqlalchemy/issues/3689


