### PR TITLE
Add standalone orm.close_all method and deprecate SessionMaker.close_all

### DIFF
--- a/doc/build/orm/session_api.rst
+++ b/doc/build/orm/session_api.rst
@@ -20,6 +20,8 @@ Session and sessionmaker()
 Session Utilities
 -----------------
 
+.. autofunction:: close_all
+
 .. autofunction:: make_transient
 
 .. autofunction:: make_transient_to_detached

--- a/lib/sqlalchemy/orm/__init__.py
+++ b/lib/sqlalchemy/orm/__init__.py
@@ -40,6 +40,7 @@ from .relationships import foreign  # noqa
 from .relationships import RelationshipProperty  # noqa
 from .relationships import remote  # noqa
 from .scoping import scoped_session  # noqa
+from .session import close_all  # noqa
 from .session import make_transient  # noqa
 from .session import make_transient_to_detached  # noqa
 from .session import object_session  # noqa

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -59,6 +59,10 @@ class _SessionClassMethods(object):
     """Class-level methods for :class:`.Session`, :class:`.sessionmaker`."""
 
     @classmethod
+    @util.deprecated("1.3",
+                     """The :meth:`.Session.close_all` method is deprecated and be removed in a future release.
+                     Please refer to :func:`.session.close_all`.
+                     """)
     def close_all(cls):
         """Close *all* sessions in memory."""
 
@@ -3202,6 +3206,22 @@ class sessionmaker(_SessionClassMethods):
             self.class_.__name__,
             ", ".join("%s=%r" % (k, v) for k, v in self.kw.items()),
         )
+
+
+def close_all():
+    """Close all sessions in memory.
+
+    This function consults a global registry of all :class:`.Session` objects and calls
+    :meth:`.Session.close` on them, which resets them to a clean state.
+
+    This function is not for general use but may be useful for test suites within the teardown
+    scheme.
+
+    .. versionadded:: 1.3
+    """
+
+    for sess in _sessions.values():
+        sess.close()
 
 
 def make_transient(instance):

--- a/lib/sqlalchemy/testing/fixtures.py
+++ b/lib/sqlalchemy/testing/fixtures.py
@@ -246,7 +246,7 @@ class RemovesEvents(object):
 class _ORMTest(object):
     @classmethod
     def teardown_class(cls):
-        sa.orm.session.Session.close_all()
+        sa.orm.session.close_all()
         sa.orm.clear_mappers()
 
 
@@ -287,7 +287,7 @@ class MappedTest(_ORMTest, TablesTest, assertions.AssertsExecutionResults):
         self._setup_each_inserts()
 
     def teardown(self):
-        sa.orm.session.Session.close_all()
+        sa.orm.session.close_all()
         self._teardown_each_mappers()
         self._teardown_each_classes()
         self._teardown_each_tables()

--- a/test/ext/declarative/test_basic.py
+++ b/test/ext/declarative/test_basic.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import class_mapper
 from sqlalchemy.orm import clear_mappers
+from sqlalchemy.orm import close_all as close_all_sessions
 from sqlalchemy.orm import column_property
 from sqlalchemy.orm import composite
 from sqlalchemy.orm import configure_mappers
@@ -60,7 +61,7 @@ class DeclarativeTestBase(
         Base = decl.declarative_base(testing.db)
 
     def teardown(self):
-        Session.close_all()
+        close_all_sessions()
         clear_mappers()
         Base.metadata.drop_all()
 

--- a/test/ext/declarative/test_inheritance.py
+++ b/test/ext/declarative/test_inheritance.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.declarative import has_inherited_table
 from sqlalchemy.orm import class_mapper
 from sqlalchemy.orm import clear_mappers
+from sqlalchemy.orm import close_all as close_all_sessions
 from sqlalchemy.orm import configure_mappers
 from sqlalchemy.orm import create_session
 from sqlalchemy.orm import deferred
@@ -39,7 +40,7 @@ class DeclarativeTestBase(fixtures.TestBase, testing.AssertsExecutionResults):
         Base = decl.declarative_base(testing.db)
 
     def teardown(self):
-        Session.close_all()
+        close_all_sessions()
         clear_mappers()
         Base.metadata.drop_all()
 

--- a/test/ext/declarative/test_mixin.py
+++ b/test/ext/declarative/test_mixin.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import base as orm_base
 from sqlalchemy.orm import class_mapper
 from sqlalchemy.orm import clear_mappers
+from sqlalchemy.orm import close_all as close_all_sessions
 from sqlalchemy.orm import column_property
 from sqlalchemy.orm import configure_mappers
 from sqlalchemy.orm import create_session
@@ -41,7 +42,7 @@ class DeclarativeTestBase(fixtures.TestBase, testing.AssertsExecutionResults):
         Base = decl.declarative_base(testing.db)
 
     def teardown(self):
-        Session.close_all()
+        close_all_sessions()
         clear_mappers()
         Base.metadata.drop_all()
 

--- a/test/orm/test_eager_relations.py
+++ b/test/orm/test_eager_relations.py
@@ -14,6 +14,7 @@ from sqlalchemy import testing
 from sqlalchemy import text
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm import backref
+from sqlalchemy.orm import close_all as close_all_sessions
 from sqlalchemy.orm import column_property
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm import create_session
@@ -5054,7 +5055,7 @@ class CyclicalInheritingEagerTestTwo(
         session.add_all([rscott, alien, brunner])
         session.commit()
 
-        session.close_all()
+        close_all_sessions()
         self.d = session.query(Director).options(joinedload("*")).first()
         assert len(list(session)) == 3
 

--- a/test/orm/test_session.py
+++ b/test/orm/test_session.py
@@ -7,6 +7,7 @@ from sqlalchemy import String
 from sqlalchemy import testing
 from sqlalchemy.orm import attributes
 from sqlalchemy.orm import backref
+from sqlalchemy.orm import close_all
 from sqlalchemy.orm import create_session
 from sqlalchemy.orm import exc as orm_exc
 from sqlalchemy.orm import joinedload
@@ -147,6 +148,27 @@ class TransScopingTest(_fixtures.FixtureTest):
 
 class SessionUtilTest(_fixtures.FixtureTest):
     run_inserts = None
+
+    def test_close_all(self):
+        users, User = self.tables.users, self.classes.User
+
+        mapper(User, users)
+
+        s1 = Session()
+        u1 = User()
+        s1.add(u1)
+
+        s2 = Session()
+        u2 = User()
+        s2.add(u2)
+
+        assert u1 in s1
+        assert u2 in s2
+
+        close_all()
+
+        assert u1 not in s1
+        assert u2 not in s2
 
     def test_object_session_raises(self):
         User = self.classes.User

--- a/test/orm/test_subquery_relations.py
+++ b/test/orm/test_subquery_relations.py
@@ -7,6 +7,7 @@ from sqlalchemy import String
 from sqlalchemy import testing
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm import clear_mappers
+from sqlalchemy.orm import close_all as close_all_sessions
 from sqlalchemy.orm import create_session
 from sqlalchemy.orm import deferred
 from sqlalchemy.orm import joinedload
@@ -2666,7 +2667,7 @@ class CyclicalInheritingEagerTestTwo(
         session.add_all([rscott, alien, brunner])
         session.commit()
 
-        session.close_all()
+        close_all_sessions()
         d = session.query(Director).options(subqueryload("*")).first()
         assert len(list(session)) == 3
 


### PR DESCRIPTION
When calling SessionMaker.close_all, it closes all the opened sessions
by sqlalchemy, which can be error-prone and confusing, if called from a
SessionMaker instance.

This commit makes this function standalone, as it is not conceptually
linked to a sessionmaker anyway, and deprecates the old one.

Fixes #4412