### PR TITLE
Added getter for query._execution_options

### DIFF
--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -332,6 +332,15 @@ class Connection(Connectable):
         self.dialect.set_connection_execution_options(c, opt)
         return c
 
+    def get_execution_options(self):
+        """ Get the non-SQL options which will take effect during execution.
+
+        .. seealso::
+
+            :meth:`.Connection.execution_options`
+        """
+        return self._execution_options
+
     @property
     def closed(self):
         """Return True if this connection is closed."""
@@ -1934,6 +1943,15 @@ class Engine(Connectable, log.Identified):
 
         """
         return OptionEngine(self, opt)
+
+    def get_execution_options(self):
+        """ Get the non-SQL options which will take effect during execution.
+
+        .. seealso::
+
+            :meth:`.Engine.execution_options`
+        """
+        return self._execution_options
 
     @property
     def name(self):

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -1554,6 +1554,15 @@ class Query(object):
         """
         return self.with_hint(None, text, dialect_name)
 
+    def get_execution_options(self):
+        """ Get the non-SQL options which will take effect during execution.
+
+        .. seealso::
+
+            :meth:`.Query.execution_options`
+        """
+        return self._execution_options
+
     @_generative()
     def execution_options(self, **kwargs):
         """ Set non-SQL options which take effect during execution.

--- a/test/engine/test_execute.py
+++ b/test/engine/test_execute.py
@@ -1272,6 +1272,21 @@ class ExecutionOptionsTest(fixtures.TestBase):
         c2_branch = c2.connect()
         eq_(c2_branch._execution_options, {"foo": "bar"})
 
+    def test_get_engine_execution_options(self):
+        engine = testing_engine("sqlite://")
+        engine.dialect = Mock()
+        e2 = engine.execution_options(foo="bar")
+
+        eq_(e2.get_execution_options(), {"foo": "bar"})
+
+    def test_get_connection_execution_options(self):
+        engine = testing_engine("sqlite://", options=dict(_initialize=False))
+        engine.dialect = Mock()
+        conn = engine.connect()
+        c = conn.execution_options(foo="bar")
+
+        eq_(c.get_execution_options(), {"foo": "bar"})
+
 
 class EngineEventsTest(fixtures.TestBase):
     __requires__ = ("ad_hoc_engines",)

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -5205,17 +5205,25 @@ class ExecutionOptionsTest(QueryTest):
         sess = create_session(bind=testing.db, autocommit=False)
 
         q1 = sess.query(User)
-        assert q1._execution_options == dict()
+        eq_(q1._execution_options, dict())
         q2 = q1.execution_options(foo="bar", stream_results=True)
         # q1's options should be unchanged.
-        assert q1._execution_options == dict()
+        eq_(q1._execution_options, dict())
         # q2 should have them set.
-        assert q2._execution_options == dict(foo="bar", stream_results=True)
+        eq_(q2._execution_options, dict(foo="bar", stream_results=True))
         q3 = q2.execution_options(foo="not bar", answer=42)
-        assert q2._execution_options == dict(foo="bar", stream_results=True)
+        eq_(q2._execution_options, dict(foo="bar", stream_results=True))
 
         q3_options = dict(foo="not bar", stream_results=True, answer=42)
-        assert q3._execution_options == q3_options
+        eq_(q3._execution_options, q3_options)
+
+    def test_get_options(self):
+        User = self.classes.User
+
+        sess = create_session(bind=testing.db, autocommit=False)
+
+        q = sess.query(User).execution_options(foo="bar", stream_results=True)
+        eq_(q.get_execution_options(), dict(foo="bar", stream_results=True))
 
     def test_options_in_connection(self):
         User = self.classes.User


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
[This recipe](https://github.com/sqlalchemy/sqlalchemy/wiki/FilteredQuery) uses the private variable `query._execution_options`. This change adds a getter for this variable.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
