### PR TITLE
Fix typo in 1.3 changelog: mssql unicode issue is #4442, not #4222

### DIFF
--- a/doc/build/changelog/changelog_13.rst
+++ b/doc/build/changelog/changelog_13.rst
@@ -42,7 +42,7 @@
 
     .. change::
        :tags: bug, mssql
-       :tickets: 4222
+       :tickets: 4442
 
        The ``literal_processor`` for the :class:`.Unicode` and
        :class:`.UnicodeText` datatypes now render an ``N`` character in front of


### PR DESCRIPTION
### Description
There is a typo linking the change to the incorrect github issue number. Currently links to #4222 , should be #4442

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
