### PR TITLE
Fixed #4474 - function as defaults for SQLite columns requires brackets

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -468,15 +468,16 @@ When using the per-:class:`.Engine` execution option, note that
 import datetime
 import re
 
-from ... import exc
-from ... import processors
-from ... import schema as sa_schema
-from ... import sql
-from ... import types as sqltypes
-from ... import util
-from ...engine import default
-from ...engine import reflection
-from ...sql import compiler
+from sqlalchemy import exc
+from sqlalchemy import processors
+from sqlalchemy import schema as sa_schema
+from sqlalchemy import sql
+from sqlalchemy import types as sqltypes
+from sqlalchemy import util
+from sqlalchemy.engine import default
+from sqlalchemy.engine import reflection
+from sqlalchemy.sql import compiler
+from sqlalchemy.sql import functions
 from ...types import BLOB  # noqa
 from ...types import BOOLEAN  # noqa
 from ...types import CHAR  # noqa
@@ -908,6 +909,8 @@ class SQLiteDDLCompiler(compiler.DDLCompiler):
         colspec = self.preparer.format_column(column) + " " + coltype
         default = self.get_column_default_string(column)
         if default is not None:
+            if isinstance(column.server_default.arg, functions.Function):
+                default = '(' + default + ')'
             colspec += " DEFAULT " + default
 
         if not column.nullable:

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -3,6 +3,7 @@
 """SQLite-specific tests."""
 import datetime
 import os
+import sqlite3
 
 from sqlalchemy import and_
 from sqlalchemy import bindparam
@@ -460,6 +461,21 @@ class DefaultsTest(fixtures.TestBase, AssertsCompiledSQL):
         eq_(
             testing.db.execute(t.select().order_by(t.c.x)).fetchall(),
             [(False,), (True,)],
+        )
+
+    @testing.provide_metadata
+    def test_function_default(self):
+        t = Table(
+            "t",
+            self.metadata,
+            Column("x", String, server_default=func.sqlite_version()),
+        )
+        t.create(testing.db)
+        testing.db.execute(t.insert())
+        testing.db.execute(t.insert().values(x="Test"))
+        eq_(
+            testing.db.execute(t.select().order_by(t.c.x)).fetchall(),
+            [(sqlite3.sqlite_version,), ("Test",)],
         )
 
     def test_old_style_default(self):


### PR DESCRIPTION
This pull request fixes #4474 