### PR TITLE
Add type stubs link to the docs

### DIFF
--- a/doc/build/core/type_basics.rst
+++ b/doc/build/core/type_basics.rst
@@ -26,6 +26,9 @@ Functions that accept a type (such as :func:`~sqlalchemy.schema.Column`) will
 typically accept a type class or instance; ``Integer`` is equivalent
 to ``Integer()`` with no construction arguments in this case.
 
+If you are using PEP 484 static type checkers for Python, you can use
+`type stubs for SQLAlchemy (alpha) <https://github.com/dropbox/sqlalchemy-stubs>`_.
+
 .. _types_generic:
 
 Generic Types


### PR DESCRIPTION
### Description

This is a follow-up on https://github.com/sqlalchemy/sqlalchemy/issues/4315

This PR adds a link to type stubs for SQLAlchemy to the docs. The package also includes a [mypy](https://github.com/python/mypy) plugin for more precise type checking. The project is still an early alpha but may be already interesting for some people.

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
