### PR TITLE
Fixes: #4492 Unicode table name lower exception fix for Python 2.7

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2556,7 +2556,7 @@ class MySQLDialect(default.DefaultDialect):
         col_tuples = [
             (
                 lower(rec["referred_schema"] or default_schema_name),
-                lower(rec["referred_table"]),
+                lower(str(rec["referred_table"])),
                 col_name,
             )
             for rec in fkeys
@@ -2598,7 +2598,7 @@ class MySQLDialect(default.DefaultDialect):
                             lower(
                                 fkey["referred_schema"] or default_schema_name
                             ),
-                            lower(fkey["referred_table"]),
+                            lower(str(fkey["referred_table"])),
                         )
                     ][col.lower()]
                     for col in fkey["referred_columns"]


### PR DESCRIPTION
### Description
This is a follow-up on #4492 

This PR handle for Python 2.7 Unicode table name lower conversion exception. While DB Migration in Python 2.7, by default as SQLAlchemy try to lower table name but table name is in Unicode so raised the exception. So before lower convert table name to str.

### Checklist
This pull request is:

- [ ] A short code fix
    - Fixes: #4492 Python 2.7 Unicode table name lower conversion exception
    - Good to go, no new issue or new tests are needed