### PR TITLE
Fixes: #4485 Adding setter to should_evaluate_none property

### DIFF
--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -2216,6 +2216,10 @@ class JSON(Indexable, TypeEngine):
     def should_evaluate_none(self):
         return not self.none_as_null
 
+    @should_evaluate_none.setter
+    def should_evaluate_none(self, value):
+        self.none_as_null = value
+
     @util.memoized_property
     def _str_impl(self):
         return String(_expect_unicode=True)

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -249,6 +249,9 @@ class AdaptTest(fixtures.TestBase):
                         or t1.__dict__[k] is None
                     )
 
+            eval_none = t1.should_evaluate_none
+            eq_(t1.evaluates_none().should_evaluate_none, not eval_none)
+
     def test_python_type(self):
         eq_(types.Integer().python_type, int)
         eq_(types.Numeric().python_type, decimal.Decimal)


### PR DESCRIPTION
Fixes #4485 

- Made changes according to Mike Bayer's suggestion to fix #4485 
- Added setter to should_evaluate_none property 
- Added test to make sure evaluates_none() works for all types

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
