### PR TITLE
Add test to as_interface when no cls or methods

### DIFF
--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -2305,6 +2305,10 @@ class AsInterfaceTest(fixtures.TestBase):
     class Object(object):
         pass
 
+    def test_no_cls_no_methods(self):
+        obj = object()
+        assert_raises(TypeError, util.as_interface, obj)
+
     def test_instance(self):
         obj = object()
         assert_raises(TypeError, util.as_interface, obj, cls=self.Something)


### PR DESCRIPTION
Fixes #4511

### Description
The `as_interface` function requires that an argument be provided for at least one of the parameters `cls` or `methods`. There was no test that tested the case when neither of these arguments were provided.


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
