### PR TITLE
Add Pipenv* and .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ sqlnet.log
 *.rej
 test/test_schema.db
 *test_schema.db
-
+.idea
+/Pipfile*


### PR DESCRIPTION
I started working on the `text().expressions()` feature and noticed that `.gitignore` doesn't include `.idea`(PyCharm) or `Pipfile*` (Pipenv). I assume these are fairly commonly used tools, and should be ignored by default.