### PR TITLE
Fixes: #4406 Added port comparison in __eq__() and __ne__() method to…

### DIFF
--- a/doc/build/changelog/unreleased_13/4406.rst
+++ b/doc/build/changelog/unreleased_13/4406.rst
@@ -1,0 +1,11 @@
+.. change::
+   :tags: bug, engine
+   :tickets: 4406
+
+   Comparing two objects of :class:`.URL` using ``__eq__()`` did not take port
+   number into consideration, two objects differing only by port number were
+   considered equal. Port comparison is now added in ``__eq__()`` method of
+   :class:`.URL`, objects differing by port number are now not equal. Additionally,
+   ``__ne__()`` was not implemented for :class:`.URL` which caused unexpected
+   result when ``!=`` was used in Python2, since there are no implied
+   relationships among the comparison operators in Python2.

--- a/lib/sqlalchemy/engine/url.py
+++ b/lib/sqlalchemy/engine/url.py
@@ -120,7 +120,11 @@ class URL(object):
             and self.host == other.host
             and self.database == other.database
             and self.query == other.query
+            and self.port == other.port
         )
+
+    def __ne__(self, other):
+        return not self == other
 
     @property
     def password(self):

--- a/test/engine/test_parseconnect.py
+++ b/test/engine/test_parseconnect.py
@@ -8,7 +8,7 @@ from sqlalchemy.dialects import plugins
 from sqlalchemy.dialects import registry
 from sqlalchemy.engine.default import DefaultDialect
 import sqlalchemy.engine.url as url
-from sqlalchemy.testing import assert_raises
+from sqlalchemy.testing import assert_raises, ne_
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
@@ -144,6 +144,26 @@ class ParseConnectTest(fixtures.TestBase):
             str(u),
             "dialect://user:pass@host/db?arg1=param1&arg2=param2&arg2=param3",
         )
+
+
+class UrlTest(fixtures.TestBase):
+    def test_comparison(self):
+        components = ('drivername', 'username', 'password', 'host',
+                      'database', 'query', 'port')
+
+        common_url = "dbtype://username:password" \
+                     "@[2001:da8:2004:1000:202:116:160:90]:80/database?foo=bar"
+        url1 = url.make_url(common_url)
+        url2 = url.make_url(common_url)
+
+        eq_(url1, url2)
+        assert not url1 != url2
+
+        for curr_component in components:
+            setattr(url2, curr_component, 'new_changed_value')
+            ne_(url1, url2)
+            assert not url1 == url2
+            setattr(url2, curr_component, getattr(url1, curr_component))
 
 
 class DialectImportTest(fixtures.TestBase):


### PR DESCRIPTION
I have implemented `__ne__()` to negate `==`  and added port comparison.

In Python3, `!=` is the negation of `==` by default(Documentation [here](https://stackoverflow.com/questions/4352244/python-should-i-implement-ne-operator-based-on-eq/30676267#30676267)). But in Python2 there is no implied relationship between the two operators(Documentation [here](https://stackoverflow.com/questions/4352244/python-should-i-implement-ne-operator-based-on-eq/30676267#30676267)) which is causing the unexpected behaviour when `!=` is used.

According to [this](http://stackoverflow.com/a/30676267/916568), implementing `__ne__()` in terms of `not self == other` is preferred over `not self.__eq__(other)` to avoid any confusions when subclassing since a user would always expect `a != b` to negate `a == b`, hence `not self == other` is used.

I have added a quick write-up for the change log just in case this change looks good. 

This pull request is:
- [x] A short code fix

**Have a nice day!**
