### PR TITLE
Add missing attribute in hybrid.py docs

### DIFF
--- a/lib/sqlalchemy/ext/hybrid.py
+++ b/lib/sqlalchemy/ext/hybrid.py
@@ -509,7 +509,7 @@ reference the instrumented attribute back to the hybrid object::
 
         last_name = Column(String)
 
-        @FirstNameOnly.overrides.expression
+        @FirstNameOnly.name.overrides.expression
         def name(cls):
             return func.concat(cls.first_name, ' ', cls.last_name)
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Just adding a missing attribute in the docs which made me scratch my head for a few minutes!

I might have misunderstood something, but using this:

```python
@Charge.overrides.expression
    def user_id(cls):
```

Gives me this error:

```sh
    @Charge.overrides.expression
E   AttributeError: type object 'Charge' has no attribute 'overrides'
```

But if I add the property it's fine:

```python
@Charge.user_id.overrides.expression
    def user_id(cls):
```

Just for the sake of completeness (in case it matters), I also have a getter in the class before that:

```python
@Charge.user_id.getter
    def user_id(self):
```

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
