### PR TITLE
Docs: import related classes when using string name

### DIFF
--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -182,7 +182,9 @@ class RelationshipProperty(StrategizedProperty):
         callables that evaluate the string as Python code, using the
         Declarative class-registry as a namespace.  This allows the lookup of
         related classes to be automatic via their string name, and removes the
-        need to import related classes at all into the local module space::
+        need to import related classes at all into the local module
+        space. (It does **not** remove the need to import related classes
+        at application startup.)
 
             from sqlalchemy.ext.declarative import declarative_base
 


### PR DESCRIPTION
It's [not obvious](https://stackoverflow.com/questions/11046039/sqlalchemy-import-tables-with-relationships#comment21905251_11052469) that when referring to related classes via string name, said classes still need to be imported early enough. Hopefully this doc patch clarifies.

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
