### PR TITLE
CheckIn and checkouts not displaying on set echo_pool=True. Look…

### DIFF
--- a/lib/sqlalchemy/pool/base.py
+++ b/lib/sqlalchemy/pool/base.py
@@ -495,7 +495,7 @@ class _ConnectionRecord(object):
         )
         _refs.add(rec)
         if echo:
-            pool.logger.debug(
+            pool.logger.info(
                 "Connection %r checked out from pool", dbapi_connection
             )
         return fairy
@@ -659,7 +659,7 @@ def _finalize_fairy(
 
     if connection is not None:
         if connection_record and echo:
-            pool.logger.debug(
+            pool.logger.info(
                 "Connection %r being returned to pool", connection
             )
 


### PR DESCRIPTION
As mentioned in SQLAlchemy docs, 
'sqlalchemy.pool' - controls connection pool logging. set to logging.INFO or lower to log connection pool checkouts/checkins.
However, the checkouts and checkins to pool were not shown when I set echoflag to True. As in the source code, changed logging.debug to logging.info so that it could match what documentation suggested. 