### PR TITLE
Add case insensitivity feature to GenericFunction.

### DIFF
--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -60,7 +60,7 @@ def register_function(identifier, fn, package="_default"):
     identifier = identifier.lower()
 
     # Check if a function with the same lowercase identifier is registered.
-    if identifier in _registry[package]:
+    if identifier in _case_sensitive_reg[package]:
         if (
             raw_identifier not in _case_sensitive_reg[package][identifier]
         ):

--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -71,9 +71,9 @@ def register_function(identifier, fn, package="_default"):
                     raw_identifier),
                 sa_exc.SADeprecationWarning)
         else:
-                warnings.warn(
-                    "The GenericFunction '{}' is already registered and "
-                    "is going to be overriden.".format(identifier))
+            warnings.warn(
+                "The GenericFunction '{}' is already registered and "
+                "is going to be overriden.".format(identifier))
 
         # If a function with the same lowercase identifier is registered, then
         # these 2 functions are considered as case-sensitive.

--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -93,7 +93,7 @@ def register_function(identifier, fn, package="_default"):
                 "different letter cases and might interact with '{}'. "
                 "GenericFunction objects will be fully case-insensitive in a "
                 "future release.".format(
-                    list(case_sensitive_reg[identifier].keys()),
+                    sorted(case_sensitive_reg[identifier].keys()),
                     raw_identifier))
 
         else:

--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -60,31 +60,32 @@ def register_function(identifier, fn, package="_default"):
     identifier = identifier.lower()
 
     # Check if a function with the same lowercase identifier is registered.
-    if identifier in _case_sensitive_reg[package]:
+    if identifier in _registry[package]:
         if (
             raw_identifier not in _case_sensitive_reg[package][identifier]
         ):
-            warnings.warn(
+            util.warn_deprecated(
                 "GenericFunction(s) '{}' are already registered with "
                 "different letter cases and might interact with {}.".format(
                     _case_sensitive_reg[package][identifier],
-                    raw_identifier),
-                sa_exc.SADeprecationWarning)
+                    raw_identifier))
+            # If a function with the same lowercase identifier is registered,
+            # then these 2 functions are considered as case-sensitive.
+            if len(_case_sensitive_reg[package][identifier]) == 1:
+                old_fn = reg[identifier]
+                del reg[identifier]
+                reg[_case_sensitive_reg[package][identifier][0]] = old_fn
         else:
             warnings.warn(
                 "The GenericFunction '{}' is already registered and "
-                "is going to be overriden.".format(identifier))
+                "is going to be overriden.".format(identifier),
+                sa_exc.SAWarning)
 
-        # If a function with the same lowercase identifier is registered, then
-        # these 2 functions are considered as case-sensitive.
-        if len(_case_sensitive_reg[package][identifier]) == 1:
-            old_fn = reg[identifier]
-            del reg[identifier]
-            reg[_case_sensitive_reg[package][identifier][0]] = old_fn
         reg[raw_identifier] = fn
     else:
         reg[identifier] = fn
 
+    # Add the raw_identifier to the case-sensitive registry
     if raw_identifier not in _case_sensitive_reg[package][identifier]:
         _case_sensitive_reg[package][identifier].append(raw_identifier)
 

--- a/test/sql/test_deprecations.py
+++ b/test/sql/test_deprecations.py
@@ -41,15 +41,6 @@ from sqlalchemy.testing import not_in_
 class DeprecationWarningsTest(fixtures.TestBase):
     __backend__ = True
 
-    def setup(self):
-        self._registry = deepcopy(functions._registry)
-        self._case_sensitive_registry = deepcopy(
-            functions._case_sensitive_registry)
-
-    def teardown(self):
-        functions._registry = self._registry
-        functions._case_sensitive_registry = self._case_sensitive_registry
-
     def test_ident_preparer_force(self):
         preparer = testing.db.dialect.identifier_preparer
         preparer.quote("hi")
@@ -154,6 +145,20 @@ class DeprecationWarningsTest(fixtures.TestBase):
                 extend_existing=True,
                 autoload_with=testing.db,
             )
+
+
+class CaseSensitiveFunctionDeprecationsTest(fixtures.TestBase):
+
+    def setup(self):
+        self._registry = deepcopy(functions._registry)
+        self._case_sensitive_registry = deepcopy(
+            functions._case_sensitive_registry)
+        functions._registry.clear()
+        functions._case_sensitive_registry.clear()
+
+    def teardown(self):
+        functions._registry = self._registry
+        functions._case_sensitive_registry = self._case_sensitive_registry
 
     def test_case_sensitive(self):
         reg = functions._registry['_default']

--- a/test/sql/test_deprecations.py
+++ b/test/sql/test_deprecations.py
@@ -154,6 +154,9 @@ class DeprecationWarningsTest(fixtures.TestBase):
             )
 
     def test_case_sensitive(self):
+        reg = functions._registry
+        cs_reg = functions._case_sensitive_reg
+
         class MYFUNC(GenericFunction):
             type = DateTime
 
@@ -161,6 +164,12 @@ class DeprecationWarningsTest(fixtures.TestBase):
         assert isinstance(func.MyFunc().type, DateTime)
         assert isinstance(func.mYfUnC().type, DateTime)
         assert isinstance(func.myfunc().type, DateTime)
+
+        assert "myfunc" in reg['_default']
+        assert "MYFUNC" not in reg['_default']
+        assert "MyFunc" not in reg['_default']
+        assert "myfunc" in cs_reg['_default']
+        assert cs_reg['_default']['myfunc'] == ['MYFUNC']
 
         with testing.expect_deprecated():
             class MyFunc(GenericFunction):
@@ -173,38 +182,75 @@ class DeprecationWarningsTest(fixtures.TestBase):
         with pytest.raises(AssertionError):
             assert isinstance(func.myfunc().type, Integer)
 
+        assert "myfunc" not in reg['_default']
+        assert "MYFUNC" in reg['_default']
+        assert "MyFunc" in reg['_default']
+        assert "myfunc" in cs_reg['_default']
+        assert cs_reg['_default']['myfunc'] == ['MYFUNC', 'MyFunc']
+
     def test_replace_function_case_sensitive(self):
+        reg = functions._registry
+        cs_reg = functions._case_sensitive_reg
 
-        class replacable_func(GenericFunction):
-            __return_type__ = Integer
-            identifier = 'replacable_func'
+        class replaceable_func(GenericFunction):
+            type = Integer
+            identifier = 'REPLACEABLE_FUNC'
 
-        assert isinstance(func.Replacable_Func().type, Integer)
-        assert isinstance(func.RePlAcaBlE_fUnC().type, Integer)
-        assert isinstance(func.replacable_func().type, Integer)
+        assert isinstance(func.REPLACEABLE_FUNC().type, Integer)
+        assert isinstance(func.Replaceable_Func().type, Integer)
+        assert isinstance(func.RePlAcEaBlE_fUnC().type, Integer)
+        assert isinstance(func.replaceable_func().type, Integer)
+
+        assert "replaceable_func" in reg['_default']
+        assert "REPLACEABLE_FUNC" not in reg['_default']
+        assert "Replaceable_Func" not in reg['_default']
+        assert "replaceable_func" in cs_reg['_default']
+        assert cs_reg['_default']['replaceable_func'] == ['REPLACEABLE_FUNC']
 
         with testing.expect_deprecated():
-            class Replacable_Func(GenericFunction):
-                __return_type__ = DateTime
-                identifier = 'Replacable_Func'
+            class Replaceable_Func(GenericFunction):
+                type = DateTime
+                identifier = 'Replaceable_Func'
 
-        assert isinstance(func.Replacable_Func().type, DateTime)
-        assert isinstance(func.RePlAcaBlE_fUnC().type, NullType)
-        assert isinstance(func.replacable_func().type, Integer)
+        assert isinstance(func.REPLACEABLE_FUNC().type, Integer)
+        assert isinstance(func.Replaceable_Func().type, DateTime)
+        assert isinstance(func.RePlAcEaBlE_fUnC().type, NullType)
+        assert isinstance(func.replaceable_func().type, NullType)
+
+        assert "replaceable_func" not in reg['_default']
+        assert "REPLACEABLE_FUNC" in reg['_default']
+        assert "Replaceable_Func" in reg['_default']
+        assert "replaceable_func" in cs_reg['_default']
+        assert cs_reg['_default']['replaceable_func'] == ['REPLACEABLE_FUNC',
+                                                          'Replaceable_Func']
 
         with expect_warnings():
-            class replacable_func_override(GenericFunction):
-                __return_type__ = DateTime
-                identifier = 'replacable_func'
+            class replaceable_func_override(GenericFunction):
+                type = DateTime
+                identifier = 'REPLACEABLE_FUNC'
+
+        with testing.expect_deprecated():
+            class replaceable_func_lowercase(GenericFunction):
+                type = String
+                identifier = 'replaceable_func'
 
         with expect_warnings():
-            class Replacable_Func_override(GenericFunction):
-                __return_type__ = Integer
-                identifier = 'Replacable_Func'
+            class Replaceable_Func_override(GenericFunction):
+                type = Integer
+                identifier = 'Replaceable_Func'
 
-        assert isinstance(func.Replacable_Func().type, Integer)
-        assert isinstance(func.RePlAcaBlE_fUnC().type, NullType)
-        assert isinstance(func.replacable_func().type, DateTime)
+        assert isinstance(func.REPLACEABLE_FUNC().type, DateTime)
+        assert isinstance(func.Replaceable_Func().type, Integer)
+        assert isinstance(func.RePlAcEaBlE_fUnC().type, NullType)
+        assert isinstance(func.replaceable_func().type, String)
+
+        assert "replaceable_func" in reg['_default']
+        assert "REPLACEABLE_FUNC" in reg['_default']
+        assert "Replaceable_Func" in reg['_default']
+        assert "replaceable_func" in cs_reg['_default']
+        assert cs_reg['_default']['replaceable_func'] == ['REPLACEABLE_FUNC',
+                                                          'Replaceable_Func',
+                                                          'replaceable_func']
 
 
 class DDLListenerDeprecationsTest(fixtures.TestBase):

--- a/test/sql/test_deprecations.py
+++ b/test/sql/test_deprecations.py
@@ -42,12 +42,12 @@ from sqlalchemy.testing.assertions import expect_warnings
 class DeprecationWarningsTest(fixtures.TestBase):
     __backend__ = True
 
-    def setup_method(self):
+    def setup(self):
         self._registry = deepcopy(functions._registry)
         self._case_sensitive_registry = deepcopy(
             functions._case_sensitive_registry)
 
-    def teardown_method(self):
+    def teardown(self):
         functions._registry = self._registry
         functions._case_sensitive_registry = self._case_sensitive_registry
 

--- a/test/sql/test_deprecations.py
+++ b/test/sql/test_deprecations.py
@@ -36,7 +36,6 @@ from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import in_
 from sqlalchemy.testing import mock
 from sqlalchemy.testing import not_in_
-from sqlalchemy.testing.assertions import expect_warnings
 
 
 class DeprecationWarningsTest(fixtures.TestBase):
@@ -174,7 +173,14 @@ class DeprecationWarningsTest(fixtures.TestBase):
         in_("myfunc", cs_reg)
         eq_(set(cs_reg['myfunc'].keys()), set(['MYFUNC']))
 
-        with testing.expect_deprecated():
+        with testing.expect_deprecated(
+            "GenericFunction 'MyFunc' is already registered with"
+            " different letter case, so the previously registered function "
+            "'MYFUNC' is switched into case-sensitive mode. "
+            "GenericFunction objects will be fully case-insensitive in a "
+            "future release.",
+            regex=False
+        ):
             class MyFunc(GenericFunction):
                 type = Integer
 
@@ -185,7 +191,7 @@ class DeprecationWarningsTest(fixtures.TestBase):
         with pytest.raises(AssertionError):
             assert isinstance(func.myfunc().type, Integer)
 
-        not_in_("myfunc", reg)
+        eq_(reg["myfunc"], functions._CASE_SENSITIVE)
         not_in_("MYFUNC", reg)
         not_in_("MyFunc", reg)
         in_("myfunc", cs_reg)
@@ -210,7 +216,14 @@ class DeprecationWarningsTest(fixtures.TestBase):
         in_("replaceable_func", cs_reg)
         eq_(set(cs_reg['replaceable_func'].keys()), set(['REPLACEABLE_FUNC']))
 
-        with testing.expect_deprecated():
+        with testing.expect_deprecated(
+            "GenericFunction 'Replaceable_Func' is already registered with"
+            " different letter case, so the previously registered function "
+            "'REPLACEABLE_FUNC' is switched into case-sensitive mode. "
+            "GenericFunction objects will be fully case-insensitive in a "
+            "future release.",
+            regex=False
+        ):
             class Replaceable_Func(GenericFunction):
                 type = DateTime
                 identifier = 'Replaceable_Func'
@@ -220,24 +233,38 @@ class DeprecationWarningsTest(fixtures.TestBase):
         assert isinstance(func.RePlAcEaBlE_fUnC().type, NullType)
         assert isinstance(func.replaceable_func().type, NullType)
 
-        not_in_("replaceable_func", reg)
+        eq_(reg["replaceable_func"], functions._CASE_SENSITIVE)
         not_in_("REPLACEABLE_FUNC", reg)
         not_in_("Replaceable_Func", reg)
         in_("replaceable_func", cs_reg)
         eq_(set(cs_reg['replaceable_func'].keys()),
             set(['REPLACEABLE_FUNC', 'Replaceable_Func']))
 
-        with expect_warnings():
+        with testing.expect_warnings(
+            "The GenericFunction 'REPLACEABLE_FUNC' is already registered and "
+            "is going to be overriden.",
+            regex=False
+        ):
             class replaceable_func_override(GenericFunction):
                 type = DateTime
                 identifier = 'REPLACEABLE_FUNC'
 
-        with testing.expect_deprecated():
+        with testing.expect_deprecated(
+            "GenericFunction(s) '['REPLACEABLE_FUNC', 'Replaceable_Func']' "
+            "are already registered with different letter cases and might "
+            "interact with 'replaceable_func'. GenericFunction objects will "
+            "be fully case-insensitive in a future release.",
+            regex=False
+        ):
             class replaceable_func_lowercase(GenericFunction):
                 type = String
                 identifier = 'replaceable_func'
 
-        with expect_warnings():
+        with testing.expect_warnings(
+            "The GenericFunction 'Replaceable_Func' is already registered and "
+            "is going to be overriden.",
+            regex=False
+        ):
             class Replaceable_Func_override(GenericFunction):
                 type = Integer
                 identifier = 'Replaceable_Func'
@@ -247,7 +274,7 @@ class DeprecationWarningsTest(fixtures.TestBase):
         assert isinstance(func.RePlAcEaBlE_fUnC().type, NullType)
         assert isinstance(func.replaceable_func().type, String)
 
-        not_in_("replaceable_func", reg)
+        eq_(reg["replaceable_func"], functions._CASE_SENSITIVE)
         not_in_("REPLACEABLE_FUNC", reg)
         not_in_("Replaceable_Func", reg)
         in_("replaceable_func", cs_reg)

--- a/test/sql/test_deprecations.py
+++ b/test/sql/test_deprecations.py
@@ -172,7 +172,7 @@ class DeprecationWarningsTest(fixtures.TestBase):
         not_in_("MYFUNC", reg)
         not_in_("MyFunc", reg)
         in_("myfunc", cs_reg)
-        eq_(list(cs_reg['myfunc'].keys()), ['MYFUNC'])
+        eq_(set(cs_reg['myfunc'].keys()), set(['MYFUNC']))
 
         with testing.expect_deprecated():
             class MyFunc(GenericFunction):
@@ -189,7 +189,7 @@ class DeprecationWarningsTest(fixtures.TestBase):
         not_in_("MYFUNC", reg)
         not_in_("MyFunc", reg)
         in_("myfunc", cs_reg)
-        eq_(list(cs_reg['myfunc'].keys()), ['MYFUNC', 'MyFunc'])
+        eq_(set(cs_reg['myfunc'].keys()), set(['MYFUNC', 'MyFunc']))
 
     def test_replace_function_case_sensitive(self):
         reg = functions._registry['_default']
@@ -208,8 +208,7 @@ class DeprecationWarningsTest(fixtures.TestBase):
         not_in_("REPLACEABLE_FUNC", reg)
         not_in_("Replaceable_Func", reg)
         in_("replaceable_func", cs_reg)
-        eq_(list(cs_reg['replaceable_func'].keys()),
-            ['REPLACEABLE_FUNC'])
+        eq_(set(cs_reg['replaceable_func'].keys()), set(['REPLACEABLE_FUNC']))
 
         with testing.expect_deprecated():
             class Replaceable_Func(GenericFunction):
@@ -225,8 +224,8 @@ class DeprecationWarningsTest(fixtures.TestBase):
         not_in_("REPLACEABLE_FUNC", reg)
         not_in_("Replaceable_Func", reg)
         in_("replaceable_func", cs_reg)
-        eq_(list(cs_reg['replaceable_func'].keys()),
-            ['REPLACEABLE_FUNC', 'Replaceable_Func'])
+        eq_(set(cs_reg['replaceable_func'].keys()),
+            set(['REPLACEABLE_FUNC', 'Replaceable_Func']))
 
         with expect_warnings():
             class replaceable_func_override(GenericFunction):
@@ -252,8 +251,8 @@ class DeprecationWarningsTest(fixtures.TestBase):
         not_in_("REPLACEABLE_FUNC", reg)
         not_in_("Replaceable_Func", reg)
         in_("replaceable_func", cs_reg)
-        eq_(list(cs_reg['replaceable_func'].keys()),
-            ['REPLACEABLE_FUNC', 'Replaceable_Func', 'replaceable_func'])
+        eq_(set(cs_reg['replaceable_func'].keys()),
+            set(['REPLACEABLE_FUNC', 'Replaceable_Func', 'replaceable_func']))
 
 
 class DDLListenerDeprecationsTest(fixtures.TestBase):

--- a/test/sql/test_deprecations.py
+++ b/test/sql/test_deprecations.py
@@ -1,6 +1,7 @@
 #! coding: utf-8
 
 from copy import deepcopy
+
 import pytest
 
 from sqlalchemy import bindparam
@@ -22,8 +23,8 @@ from sqlalchemy import text
 from sqlalchemy import util
 from sqlalchemy.engine import default
 from sqlalchemy.schema import DDL
-from sqlalchemy.sql import util as sql_util
 from sqlalchemy.sql import functions
+from sqlalchemy.sql import util as sql_util
 from sqlalchemy.sql.functions import GenericFunction
 from sqlalchemy.sql.sqltypes import NullType
 from sqlalchemy.testing import assert_raises

--- a/test/sql/test_deprecations.py
+++ b/test/sql/test_deprecations.py
@@ -157,8 +157,8 @@ class DeprecationWarningsTest(fixtures.TestBase):
             )
 
     def test_case_sensitive(self):
-        reg = functions._registry
-        cs_reg = functions._case_sensitive_registry
+        reg = functions._registry['_default']
+        cs_reg = functions._case_sensitive_registry['_default']
 
         class MYFUNC(GenericFunction):
             type = DateTime
@@ -168,11 +168,11 @@ class DeprecationWarningsTest(fixtures.TestBase):
         assert isinstance(func.mYfUnC().type, DateTime)
         assert isinstance(func.myfunc().type, DateTime)
 
-        in_("myfunc", reg['_default'])
-        not_in_("MYFUNC", reg['_default'])
-        not_in_("MyFunc", reg['_default'])
-        in_("myfunc", cs_reg['_default'])
-        eq_(list(cs_reg['_default']['myfunc'].keys()), ['MYFUNC'])
+        in_("myfunc", reg)
+        not_in_("MYFUNC", reg)
+        not_in_("MyFunc", reg)
+        in_("myfunc", cs_reg)
+        eq_(list(cs_reg['myfunc'].keys()), ['MYFUNC'])
 
         with testing.expect_deprecated():
             class MyFunc(GenericFunction):
@@ -185,15 +185,15 @@ class DeprecationWarningsTest(fixtures.TestBase):
         with pytest.raises(AssertionError):
             assert isinstance(func.myfunc().type, Integer)
 
-        not_in_("myfunc", reg['_default'])
-        in_("MYFUNC", reg['_default'])
-        in_("MyFunc", reg['_default'])
-        in_("myfunc", cs_reg['_default'])
-        eq_(list(cs_reg['_default']['myfunc'].keys()), ['MYFUNC', 'MyFunc'])
+        not_in_("myfunc", reg)
+        not_in_("MYFUNC", reg)
+        not_in_("MyFunc", reg)
+        in_("myfunc", cs_reg)
+        eq_(list(cs_reg['myfunc'].keys()), ['MYFUNC', 'MyFunc'])
 
     def test_replace_function_case_sensitive(self):
-        reg = functions._registry
-        cs_reg = functions._case_sensitive_registry
+        reg = functions._registry['_default']
+        cs_reg = functions._case_sensitive_registry['_default']
 
         class replaceable_func(GenericFunction):
             type = Integer
@@ -204,11 +204,11 @@ class DeprecationWarningsTest(fixtures.TestBase):
         assert isinstance(func.RePlAcEaBlE_fUnC().type, Integer)
         assert isinstance(func.replaceable_func().type, Integer)
 
-        in_("replaceable_func", reg['_default'])
-        not_in_("REPLACEABLE_FUNC", reg['_default'])
-        not_in_("Replaceable_Func", reg['_default'])
-        in_("replaceable_func", cs_reg['_default'])
-        eq_(list(cs_reg['_default']['replaceable_func'].keys()),
+        in_("replaceable_func", reg)
+        not_in_("REPLACEABLE_FUNC", reg)
+        not_in_("Replaceable_Func", reg)
+        in_("replaceable_func", cs_reg)
+        eq_(list(cs_reg['replaceable_func'].keys()),
             ['REPLACEABLE_FUNC'])
 
         with testing.expect_deprecated():
@@ -221,11 +221,11 @@ class DeprecationWarningsTest(fixtures.TestBase):
         assert isinstance(func.RePlAcEaBlE_fUnC().type, NullType)
         assert isinstance(func.replaceable_func().type, NullType)
 
-        not_in_("replaceable_func", reg['_default'])
-        in_("REPLACEABLE_FUNC", reg['_default'])
-        in_("Replaceable_Func", reg['_default'])
-        in_("replaceable_func", cs_reg['_default'])
-        eq_(list(cs_reg['_default']['replaceable_func'].keys()),
+        not_in_("replaceable_func", reg)
+        not_in_("REPLACEABLE_FUNC", reg)
+        not_in_("Replaceable_Func", reg)
+        in_("replaceable_func", cs_reg)
+        eq_(list(cs_reg['replaceable_func'].keys()),
             ['REPLACEABLE_FUNC', 'Replaceable_Func'])
 
         with expect_warnings():
@@ -248,11 +248,11 @@ class DeprecationWarningsTest(fixtures.TestBase):
         assert isinstance(func.RePlAcEaBlE_fUnC().type, NullType)
         assert isinstance(func.replaceable_func().type, String)
 
-        in_("replaceable_func", reg['_default'])
-        in_("REPLACEABLE_FUNC", reg['_default'])
-        in_("Replaceable_Func", reg['_default'])
-        in_("replaceable_func", cs_reg['_default'])
-        eq_(list(cs_reg['_default']['replaceable_func'].keys()),
+        not_in_("replaceable_func", reg)
+        not_in_("REPLACEABLE_FUNC", reg)
+        not_in_("Replaceable_Func", reg)
+        in_("replaceable_func", cs_reg)
+        eq_(list(cs_reg['replaceable_func'].keys()),
             ['REPLACEABLE_FUNC', 'Replaceable_Func', 'replaceable_func'])
 
 

--- a/test/sql/test_functions.py
+++ b/test/sql/test_functions.py
@@ -57,11 +57,12 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def setup_method(self):
         self._registry = deepcopy(functions._registry)
-        self._case_sensitive_reg = deepcopy(functions._case_sensitive_reg)
+        self._case_sensitive_registry = deepcopy(
+            functions._case_sensitive_registry)
 
     def teardown_method(self):
         functions._registry = self._registry
-        functions._case_sensitive_reg = self._case_sensitive_reg
+        functions._case_sensitive_registry = self._case_sensitive_registry
 
     def test_compile(self):
         for dialect in all_dialects(exclude=("sybase",)):
@@ -95,7 +96,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             )
 
             functions._registry['_default'].pop('fake_func')
-            functions._case_sensitive_reg['_default'].pop('fake_func')
+            functions._case_sensitive_registry['_default'].pop('fake_func')
 
     def test_use_labels(self):
         self.assert_compile(

--- a/test/sql/test_functions.py
+++ b/test/sql/test_functions.py
@@ -240,7 +240,6 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         assert isinstance(func.myfunc().type, DateTime)
 
     def test_replace_function(self):
-
         class replaceable_func(GenericFunction):
             type = Integer
             identifier = 'replaceable_func'

--- a/test/sql/test_functions.py
+++ b/test/sql/test_functions.py
@@ -33,6 +33,7 @@ from sqlalchemy.sql import table
 from sqlalchemy.sql.compiler import BIND_TEMPLATES
 from sqlalchemy.sql.functions import FunctionElement
 from sqlalchemy.sql.functions import GenericFunction
+from sqlalchemy.sql.sqltypes import NullType
 from sqlalchemy.testing import assert_raises
 from sqlalchemy.testing import assert_raises_message
 from sqlalchemy.testing import AssertsCompiledSQL
@@ -56,7 +57,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def tear_down(self):
         functions._registry.clear()
-        functions._case_insensitive_functions.clear()
+        functions._case_sensitive_functions.clear()
 
     def test_compile(self):
         for dialect in all_dialects(exclude=("sybase",)):
@@ -102,7 +103,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def test_uppercase(self):
         # for now, we need to keep case insensitivity
-        self.assert_compile(func.NOW(), "NOW()")
+        self.assert_compile(func.UNREGISTERED_FN(), "UNREGISTERED_FN()")
 
     def test_uppercase_packages(self):
         # for now, we need to keep case insensitivity
@@ -219,21 +220,50 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         class myfunc(GenericFunction):
             __return_type__ = DateTime
 
-        with pytest.raises(AssertionError):
-            assert isinstance(func.MyFunc().type, DateTime)
-        with pytest.raises(AssertionError):
-            assert isinstance(func.mYfUnC().type, DateTime)
         assert isinstance(func.myfunc().type, DateTime)
 
-    def test_custom_legacy_type_case_insensitive(self):
-        # in case someone was using this system
-        class MyFunc(GenericFunction):
+    def test_replace_function(self):
+
+        class replacable_func(GenericFunction):
+            __return_type__ = Integer
+            identifier = 'replacable_func'
+
+        assert isinstance(func.Replacable_Func().type, Integer)
+        assert isinstance(func.RePlAcaBlE_fUnC().type, Integer)
+        assert isinstance(func.replacable_func().type, Integer)
+
+        with testing.expect_deprecated():
+            class Replacable_Func(GenericFunction):
+                __return_type__ = DateTime
+                identifier = 'Replacable_Func'
+
+        assert isinstance(func.Replacable_Func().type, DateTime)
+        assert isinstance(func.RePlAcaBlE_fUnC().type, NullType)
+        assert isinstance(func.replacable_func().type, Integer)
+
+        class replacable_func_override(GenericFunction):
             __return_type__ = DateTime
-            case_sensitive = False
+            identifier = 'replacable_func'
 
-        assert isinstance(func.MyFunc().type, DateTime)
-        assert isinstance(func.mYfUnC().type, DateTime)
-        assert isinstance(func.myfunc().type, DateTime)
+        class Replacable_Func_override(GenericFunction):
+            __return_type__ = Integer
+            identifier = 'Replacable_Func'
+
+        assert isinstance(func.Replacable_Func().type, Integer)
+        assert isinstance(func.RePlAcaBlE_fUnC().type, NullType)
+        assert isinstance(func.replacable_func().type, DateTime)
+
+    def test_custom_legacy_case_sensitive(self):
+        # in case someone was using this system
+        with testing.expect_deprecated():
+            class MyFunc(GenericFunction):
+                __return_type__ = Integer
+
+        assert isinstance(func.MyFunc().type, Integer)
+        with pytest.raises(AssertionError):
+            assert isinstance(func.mYfUnC().type, Integer)
+        with pytest.raises(AssertionError):
+            assert isinstance(func.myfunc().type, Integer)
 
     def test_custom_w_custom_name(self):
         class myfunc(GenericFunction):
@@ -287,7 +317,6 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             type = Integer
             name = "BufferFour"
             identifier = "Buf4"
-            case_sensitive = False
 
         self.assert_compile(func.geo.buf1(), "BufferOne()")
         self.assert_compile(func.buf2(), "BufferTwo()")
@@ -298,17 +327,21 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         self.assert_compile(func.bUf4_(), "BufferFour()")
         self.assert_compile(func.buf4(), "BufferFour()")
 
-        class geobufferfour(GenericFunction):
-            type = Integer
-            name = "BufferFour"
-            identifier = "Buf4"
-            case_sensitive = True
+        with testing.expect_deprecated():
+            class geobufferfour_lowercase(GenericFunction):
+                type = Integer
+                name = "BufferFour_lowercase"
+                identifier = "buf4"
+
+        with testing.expect_deprecated():
+            class geobufferfour_random_case(GenericFunction):
+                type = Integer
+                name = "BuFferFouR"
+                identifier = "BuF4"
 
         self.assert_compile(func.Buf4(), "BufferFour()")
-        with pytest.raises(AssertionError):
-            self.assert_compile(func.BuF4(), "BufferFour()")
-        with pytest.raises(AssertionError):
-            self.assert_compile(func.buf4(), "BufferFour()")
+        self.assert_compile(func.BuF4(), "BuFferFouR()")
+        self.assert_compile(func.buf4(), "BufferFour_lowercase()")
 
     def test_custom_args(self):
         class myfunc(GenericFunction):

--- a/test/sql/test_functions.py
+++ b/test/sql/test_functions.py
@@ -55,12 +55,12 @@ table1 = table(
 class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
     __dialect__ = "default"
 
-    def setup_method(self):
+    def setup(self):
         self._registry = deepcopy(functions._registry)
         self._case_sensitive_registry = deepcopy(
             functions._case_sensitive_registry)
 
-    def teardown_method(self):
+    def teardown(self):
         functions._registry = self._registry
         functions._case_sensitive_registry = self._case_sensitive_registry
 

--- a/test/sql/test_functions.py
+++ b/test/sql/test_functions.py
@@ -241,22 +241,26 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def test_replace_function(self):
 
-        class replacable_func(GenericFunction):
+        class replaceable_func(GenericFunction):
             type = Integer
-            identifier = 'replacable_func'
+            identifier = 'replaceable_func'
 
-        assert isinstance(func.Replacable_Func().type, Integer)
-        assert isinstance(func.RePlAcaBlE_fUnC().type, Integer)
-        assert isinstance(func.replacable_func().type, Integer)
+        assert isinstance(func.Replaceable_Func().type, Integer)
+        assert isinstance(func.RePlAcEaBlE_fUnC().type, Integer)
+        assert isinstance(func.replaceable_func().type, Integer)
 
-        with expect_warnings():
-            class replacable_func_override(GenericFunction):
+        with expect_warnings(
+            "The GenericFunction 'replaceable_func' is already registered and "
+            "is going to be overriden.",
+            regex=False
+        ):
+            class replaceable_func_override(GenericFunction):
                 type = DateTime
-                identifier = 'replacable_func'
+                identifier = 'replaceable_func'
 
-        assert isinstance(func.Replacable_Func().type, DateTime)
-        assert isinstance(func.RePlAcaBlE_fUnC().type, DateTime)
-        assert isinstance(func.replacable_func().type, DateTime)
+        assert isinstance(func.Replaceable_Func().type, DateTime)
+        assert isinstance(func.RePlAcEaBlE_fUnC().type, DateTime)
+        assert isinstance(func.replaceable_func().type, DateTime)
 
     def test_custom_w_custom_name(self):
         class myfunc(GenericFunction):


### PR DESCRIPTION
### Description
Fixes: #4569

Following this discussion: https://github.com/geoalchemy/geoalchemy2/pull/216
The goal of the PR is to allow the possibility to register case-insensitive `GenericFunction(s)`.
By default, the case-sensitivity is kept in order to keep the current behavior.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
