### PR TITLE
updated doc string to show `NOT (EXISTS` instead of `NOT EXISTS`, as …

### DIFF
--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -1210,8 +1210,8 @@ class RelationshipProperty(StrategizedProperty):
             will produce::
 
                 SELECT * FROM my_table WHERE
-                NOT EXISTS (SELECT 1 FROM related WHERE
-                related.my_id=my_table.id)
+                NOT (EXISTS (SELECT 1 FROM related WHERE
+                related.my_id=my_table.id))
 
             :meth:`~.RelationshipProperty.Comparator.any` is only
             valid for collections, i.e. a :func:`.relationship`


### PR DESCRIPTION
…that is what SqlAlchemy now renders.

SqlAlchemy currently renders `NOT (EXISTS` not `NOT EXISTS`. This fixes the example SQL.

### Description
The change is a docstring only.

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
