### PR TITLE
Fixes: 4589 - "enhancement: more descriptive error for a particular l…

### DIFF
--- a/lib/sqlalchemy/orm/strategy_options.py
+++ b/lib/sqlalchemy/orm/strategy_options.py
@@ -15,6 +15,7 @@ from .base import _is_aliased_class
 from .base import _is_mapped_class
 from .base import InspectionAttr
 from .interfaces import MapperOption
+from .interfaces import MapperProperty
 from .interfaces import PropComparator
 from .path_registry import _DEFAULT_TOKEN
 from .path_registry import _WILDCARD_TOKEN
@@ -235,11 +236,10 @@ class Load(Generative, MapperOption):
                 try:
                     attr = found_property = attr.property
                 except AttributeError:
-                    if isinstance(attr, property):
+                    if not isinstance(attr, MapperProperty):
                         raise sa_exc.ArgumentError(
-                            'The entity %s in this Query is a '
-                            'Python @property object and not an '
-                            'addressable column.' %  ent
+                            'Expected %s to be a mapped column; '
+                            'instead got %s object.' % (ent, type(attr))
                             )
                     raise
 

--- a/lib/sqlalchemy/orm/strategy_options.py
+++ b/lib/sqlalchemy/orm/strategy_options.py
@@ -232,7 +232,16 @@ class Load(Generative, MapperOption):
                 else:
                     return None
             else:
-                attr = found_property = attr.property
+                try:
+                    attr = found_property = attr.property
+                except AttributeError:
+                    if isinstance(attr, property):
+                        raise sa_exc.ArgumentError(
+                            'The entity %s in this Query is a '
+                            'Python @property object and not an '
+                            'addressable column.' %  ent
+                            )
+                    raise
 
             path = path[attr]
         elif _is_mapped_class(attr):

--- a/test/orm/test_attributes.py
+++ b/test/orm/test_attributes.py
@@ -3693,8 +3693,8 @@ class InvalidLoadOnlyTest(fixtures.MappedTest):
         _option = joinedload('b').load_only('id', 'id_string')
         assert_raises_message(
             sa_exc.ArgumentError,
-            "The entity mapped class B->b in this Query is a Python @property "
-            "object and not an addressable column.",
+            "Expected mapped class B->b to be a mapped column; "
+            "instead got <type 'property'> object.",
             qCore.options,
             _option,
         )


### PR DESCRIPTION
Fixes: #4589 - "enhancement: more descriptive error for a particular loadonly usage"

* Detect when a class attribute passed to `load_only(` is not actually a column, but a Python class's method that is decorated with `@property`; raise a more descriptive error.
* Test case for raising the correct exception and message when a Python @property column is submitted to `load_only()`

### Description

`_generate_path` now catches an exception, looking for a particular situation where the attribute is a Python @property

A new test case `InvalidLoadOnlyTest` was added to `test/orm/test_attributes.py`.  It was modeled after `test/orm/inheritance/test_basic.py` but did not fit in the inheritance section. Because of this, several support functions are newly imported into `test_attributes.py`; instead of integrating them into the list of all imports, they appear as a separate section in case this is best moved to another test suite.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
- [X] A new feature implementation
        - Fixes #4589
        - Tests are included
