### PR TITLE
Add a dedupe_rows method to the Query class

### DIFF
--- a/lib/sqlalchemy/orm/loading.py
+++ b/lib/sqlalchemy/orm/loading.py
@@ -92,8 +92,9 @@ def instances(query, cursor, context):
             for path, post_load in context.post_load_paths.items():
                 post_load.invoke(context, path)
 
-            if filtered:
-                rows = util.unique_list(rows, filter_fn)
+            if filtered and query._dedupe_rows:
+                dedupe_func = util.unique_list if query._dedupe_func is None else query._dedupe_func
+                rows = dedupe_func(rows, filter_fn)
 
             for row in rows:
                 yield row

--- a/lib/sqlalchemy/orm/loading.py
+++ b/lib/sqlalchemy/orm/loading.py
@@ -93,7 +93,11 @@ def instances(query, cursor, context):
                 post_load.invoke(context, path)
 
             if filtered and query._dedupe_rows:
-                dedupe_func = util.unique_list if query._dedupe_func is None else query._dedupe_func
+                dedupe_func = (
+                    util.unique_list
+                    if query._dedupe_func is None
+                    else query._dedupe_func
+                )
                 rows = dedupe_func(rows, filter_fn)
 
             for row in rows:

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -125,6 +125,8 @@ class Query(object):
     _orm_only_from_obj_alias = True
     _current_path = _path_registry
     _has_mapper_entities = False
+    _dedupe_rows = True
+    _dedupe_func = None
 
     lazy_loaded_from = None
     """An :class:`.InstanceState` that is using this :class:`.Query` for a
@@ -3189,6 +3191,21 @@ class Query(object):
             )
 
         self._statement = statement
+
+    @_generative()
+    def dedupe_rows(self, value, dedupe_func=None):
+        """Indicate whether the query execution results should be de-duplicated
+        and return the newly resulting ``Query``.
+
+        :param dedupe_func: optional function applied to the execution results.
+               User-provided functions must take two arguments: the sequence
+               to de-dupe, and the hash function for each row. The default of
+               None will result in :func:`.util._collections.unique_list` being
+               used.
+
+        """
+        self._dedupe_rows = value
+        self._dedupe_func = dedupe_func
 
     def first(self):
         """Return the first result of this ``Query`` or

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -5518,7 +5518,6 @@ class QueryClsTest(QueryTest):
 
 
 class DedupeQueryTest(QueryTest):
-
     def test_dedupe_rows_on(self):
         User = self.classes.User
         s = Session()
@@ -5542,11 +5541,17 @@ class DedupeQueryTest(QueryTest):
         s = Session()
 
         def remove_jacks(seq, hashfunc=None):
-            return [x for x in seq if x.name != 'jack']
+            return [x for x in seq if x.name != "jack"]
 
-        eq_(s.query(User).join("addresses").dedupe_rows(True, remove_jacks).all(),
-            [User(id=8, name='ed'),
-             User(id=8, name='ed'),
-             User(id=8, name='ed'),
-             User(id=9, name='fred')]
-            )
+        eq_(
+            s.query(User)
+            .join("addresses")
+            .dedupe_rows(True, remove_jacks)
+            .all(),
+            [
+                User(id=8, name="ed"),
+                User(id=8, name="ed"),
+                User(id=8, name="ed"),
+                User(id=9, name="fred"),
+            ],
+        )


### PR DESCRIPTION
### Description

The method accepts a boolean indicating whether or not to
deduplicate the execution results (default of True
preserves the existing behavior), and provides an optional parameter
where the user can provide their own deduplication function.
    
Fixes #4602

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
