### PR TITLE
Use "parent object" instead of "primary object"

### DIFF
--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -711,8 +711,8 @@ class RelationshipProperty(StrategizedProperty):
 
         :param primaryjoin:
           a SQL expression that will be used as the primary
-          join of this child object against the parent object, or in a
-          many-to-many relationship the join of the primary object to the
+          join of the child object against the parent object, or in a
+          many-to-many relationship the join of the parent object to the
           association table. By default, this value is computed based on the
           foreign key relationships of the parent and child tables (or
           association table).


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
1. Change "primary object" to "parent object" in docstring 
2. Change "this child object" to "the child object" in docstring 

I promise I'm not trying to be annoying. I'm just a noob and these details genuinely confused me... Here's my rationale, if needed:

For thing 1: 
- The [Glossary](https://docs.sqlalchemy.org/en/13/glossary.html) has no entries for any of `parent object`, `child object`, or `primary object`. But the former two are used quite often throughout the docs. 
- From mentions of `parent object` in the glossary, I'm guessing that `parent object` just means the object/class where a relationship is being defined, and `child object` just means the related table. (As opposed to e.g. `child object` is always the referring object with the foreign key, and `parent object` is always the referred-to object with the primary key? When the docs discuss delete cascades e.g. in the `passive_deletes` section, this seems to be the case...) 
- Question: Is `primary object` supposed to be synonymous with `parent object`? Or is it something like the implicit LHS of a JOIN? It has nothing to do with which side of a relationship has the primary key, right? 
- In either case, if I've correctly understood what the `primaryjoin` argument means and what `parent object` means, then I think it makes more sense to say that `primaryjoin` in the M-M case is the join of the _parent_ object to the association table: 
  - If `primary object` == `parent object`, then `parent object` is more consistent since it appears far more often throughout the docs. 
  - If `primary object` means something else, I think the point is still that `primaryjoin` is `object where relationship is defined-->secondary`, and then `secondaryjoin` is `secondary-->target of relationship`.
  - Also, `secondaryjoin` is later described as "the join of an association table to the *child* object".

For thing 2:
"This" object would be the `RelationshipProperty`, right? 

Sorry if I am just hopelessly confused :P



### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
