### PR TITLE
Fixes typo in core/connections.rst

### DIFF
--- a/doc/build/core/connections.rst
+++ b/doc/build/core/connections.rst
@@ -401,7 +401,7 @@ render the schema as ``user_schema_one``::
 The above code will invoke SQL on the database of the form::
 
     SELECT user_schema_one.user.id, user_schema_one.user.name FROM
-    user_schema.user
+    user_schema_one.user
 
 That is, the schema name is substituted with our translated name.  The
 map can specify any number of target->destination schemas::


### PR DESCRIPTION
The generated sql was using the incorrect translated table name `user_schema` instead
of the correct `user_schema_one` .

### Checklist
This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
