### PR TITLE
added fire sequence method for mssql dialect - issue 4627

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -1360,6 +1360,10 @@ class MSExecutionContext(default.DefaultExecutionContext):
     _result_proxy = None
     _lastrowid = None
 
+    def fire_sequence(self, seq, type_):
+        return self._execute_scalar((
+            "select NEXT VALUE FOR %s " %
+            self.dialect.identifier_preparer.format_sequence(seq)), type_)
     def _opt_encode(self, statement):
         if not self.dialect.supports_unicode_statements:
             return self.dialect._encoder(statement)[0]


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
Sequence not getting executed for mssql dialect
### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<4627>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
