### PR TITLE
Do not register the GenericFunction in sql.functions._registry

### DIFF
--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -603,7 +603,17 @@ class _GenericMeta(VisitableType):
             # legacy
             if "__return_type__" in clsdict:
                 cls.type = clsdict["__return_type__"]
-            register_function(identifier, cls, package)
+
+            # Check _register attribute status
+            cls._register = getattr(cls, '_register', True)
+
+            # Register the function if required
+            if cls._register:
+                register_function(identifier, cls, package)
+            else:
+                # Set _register to True to register child classes by default
+                cls._register = True
+
         super(_GenericMeta, cls).__init__(clsname, bases, clsdict)
 
 
@@ -671,6 +681,7 @@ class GenericFunction(util.with_metaclass(_GenericMeta, Function)):
     """
 
     coerce_arguments = True
+    _register = False
 
     def __init__(self, *args, **kwargs):
         parsed_args = kwargs.pop("_parsed_args", None)

--- a/test/sql/test_functions.py
+++ b/test/sql/test_functions.py
@@ -1091,27 +1091,27 @@ class RegisterTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def test_register_function(self):
 
-            # test generic function registering
-            class registered_func(GenericFunction):
-                _register = True
+        # test generic function registering
+        class registered_func(GenericFunction):
+            _register = True
 
-                def __init__(self, *args, **kwargs):
-                    GenericFunction.__init__(self, *args, **kwargs)
+            def __init__(self, *args, **kwargs):
+                GenericFunction.__init__(self, *args, **kwargs)
 
-            class registered_func_child(registered_func):
-                type = sqltypes.Integer
+        class registered_func_child(registered_func):
+            type = sqltypes.Integer
 
-            assert 'registered_func' in functions._registry['_default']
-            assert isinstance(func.registered_func_child().type, Integer)
+        assert 'registered_func' in functions._registry['_default']
+        assert isinstance(func.registered_func_child().type, Integer)
 
-            class not_registered_func(GenericFunction):
-                _register = False
+        class not_registered_func(GenericFunction):
+            _register = False
 
-                def __init__(self, *args, **kwargs):
-                    GenericFunction.__init__(self, *args, **kwargs)
+            def __init__(self, *args, **kwargs):
+                GenericFunction.__init__(self, *args, **kwargs)
 
-            class not_registered_func_child(not_registered_func):
-                type = sqltypes.Integer
+        class not_registered_func_child(not_registered_func):
+            type = sqltypes.Integer
 
-            assert 'not_registered_func' not in functions._registry['_default']
-            assert isinstance(func.not_registered_func_child().type, Integer)
+        assert 'not_registered_func' not in functions._registry['_default']
+        assert isinstance(func.not_registered_func_child().type, Integer)


### PR DESCRIPTION
### Description
Fixes #4653 

Introduce a new attribute in the `GenericFunction` class to mark the parent class that should not be registered in `sql.functions._registry`.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
