### PR TITLE
Add additional rollback to PGDialect feature detection

### DIFF
--- a/doc/build/changelog/unreleased_14/4663.rst
+++ b/doc/build/changelog/unreleased_14/4663.rst
@@ -1,0 +1,7 @@
+.. change::
+   :tags: bug, orm, postgresql
+   :tickets: 4663
+
+   Added additional rollback during engine creation for postgresql
+   engines that prevents the first connection starting having an
+   implicit transaction created earlier than usual.

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -312,8 +312,6 @@ class DefaultDialect(interfaces.Dialect):
         ):
             self._description_decoder = self.description_encoding = None
 
-        self.do_rollback(connection.connection)
-
     def on_connect(self):
         """return a callable which sets up a newly created DBAPI connection.
 

--- a/lib/sqlalchemy/engine/strategies.py
+++ b/lib/sqlalchemy/engine/strategies.py
@@ -197,6 +197,7 @@ class DefaultEngineStrategy(EngineStrategy):
                 )
                 c._execution_options = util.immutabledict()
                 dialect.initialize(c)
+                dialect.do_rollback(c.connection)
 
             event.listen(pool, "first_connect", first_connect, once=True)
 

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -500,6 +500,12 @@ class MiscBackendTest(
                 "c %s NOT NULL" % expected,
             )
 
+    def test_initial_transaction_state(self):
+        from psycopg2.extensions import STATUS_IN_TRANSACTION
+        engine = engines.testing_engine()
+        with engine.connect() as conn:
+            assert conn.connection.status != STATUS_IN_TRANSACTION
+
 
 class AutocommitTextTest(test_execute.AutocommitTextTest):
     __only_on__ = "postgresql"

--- a/test/engine/test_execute.py
+++ b/test/engine/test_execute.py
@@ -660,6 +660,15 @@ class ExecuteTest(fixtures.TestBase):
         eq_(conn._execution_options, {"autocommit": True})
         conn.close()
 
+    def test_initialize_rollback(self):
+        """test a rollback happens during first connect"""
+        eng = create_engine(testing.db.url)
+        with patch.object(eng.dialect, "do_rollback") as do_rollback:
+            assert do_rollback.call_count == 0
+            connection = eng.connect()
+            assert do_rollback.call_count == 1
+        connection.close()
+
     @testing.requires.ad_hoc_engines
     def test_dialect_init_uses_options(self):
         eng = create_engine(testing.db.url)


### PR DESCRIPTION
Address problem reported in bug #4663 that causes minor inconsistency in the underlying postgresql transaction state for the first connection
to a new engine.

### Description
As described in #4663, the first transaction created against a postgres database is responsible for doing engine feature detection. All the feature-detection queries done in `BaseDialect` are guarded by an explicit rollback, however on postgresql > 8.2 there is an additional query done in the `PGDialect` which is not so guarded. This adds an additional rollback at the end of that check.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
