### PR TITLE
Issue 4680 - recognize message 20047 as disconnect event in MSDialect_pymssql

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/pymssql.py
+++ b/lib/sqlalchemy/dialects/mssql/pymssql.py
@@ -98,6 +98,7 @@ class MSDialect_pymssql(MSDialect):
             "Connection is closed",
             "message 20006",  # Write to the server failed
             "message 20017",  # Unexpected EOF from the server
+            "message 20047",  # DBPROCESS is dead or not enabled
         ):
             if msg in str(e):
                 return True

--- a/test/dialect/mssql/test_engine.py
+++ b/test/dialect/mssql/test_engine.py
@@ -292,6 +292,9 @@ class ParseConnectTest(fixtures.TestBase):
             "Error 10054",
             "Not connected to any MS SQL server",
             "Connection is closed",
+            "message 20006",  # Write to the server failed
+            "message 20017",  # Unexpected EOF from the server
+            "message 20047",  # DBPROCESS is dead or not enabled
         ]:
             eq_(dialect.is_disconnect(error, None, None), True)
 


### PR DESCRIPTION
added message 20047 to MSDialect_pymssql.is_disconnect msg tuple, which is now raised back to the caller when using freeTDS >= 1.1.5.

TODO:
- [x]  update commit message
- [x]  add tests

