### PR TITLE
Fix for: unable to set column to NULL within ON DUPLICATE KEY UPDATE

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1237,10 +1237,12 @@ class MySQLCompiler(compiler.SQLCompiler):
 
         clauses = []
         for column in cols:
-            val = on_duplicate.update.get(column.key)
-            if val is None:
+            try:
+                val = on_duplicate.update[column.key]
+            except KeyError:
                 continue
-            elif coercions._is_literal(val):
+
+            if coercions._is_literal(val):
                 val = elements.BindParameter(None, val, type_=column.type)
                 value_text = self.process(val.self_group(), use_schema=False)
             elif isinstance(val, elements.BindParameter) and val.type._isnull:

--- a/test/dialect/mysql/test_on_duplicate.py
+++ b/test/dialect/mysql/test_on_duplicate.py
@@ -62,6 +62,21 @@ class OnDuplicateTest(fixtures.TablesTest):
                 [(1, "ab", "bz", False)],
             )
 
+    def test_on_duplicate_key_update_null(self):
+        foos = self.tables.foos
+        with testing.db.connect() as conn:
+            conn.execute(insert(foos, dict(id=1, bar="b", baz="bz")))
+            stmt = insert(foos).values(
+                [dict(id=1, bar="ab"), dict(id=2, bar="b")]
+            )
+            stmt = stmt.on_duplicate_key_update(updated_once=None)
+            result = conn.execute(stmt)
+            eq_(result.inserted_primary_key, [2])
+            eq_(
+                conn.execute(foos.select().where(foos.c.id == 1)).fetchall(),
+                [(1, "b", "bz", None)],
+            )
+
     def test_on_duplicate_key_update_preserve_order(self):
         foos = self.tables.foos
         with testing.db.connect() as conn:


### PR DESCRIPTION
### Description

Fixes #4715.  Anyway, I don't quite understand why the `for` loop iterates over all columns in the table, when we care only about those that are present in `on_duplicate.update` dictionary.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.