### PR TITLE
Fixes 4717 - Reflection of indexes in PostgreSQL doesn't include DESC / NULLS ordering

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3193,7 +3193,7 @@ class PGDialect(default.DefaultDialect):
                   i.relname as relname,
                   ix.indisunique, ix.indexprs, ix.indpred,
                   a.attname, a.attnum, NULL, ix.indkey%s,
-                  %s, am.amname
+                  %s, %s, am.amname
               FROM
                   pg_class t
                         join pg_index ix on t.oid = ix.indrelid
@@ -3216,6 +3216,9 @@ class PGDialect(default.DefaultDialect):
                 # cast does not work in PG 8.2.4, does work in 8.3.0.
                 # nothing in PG changelogs regarding this.
                 "::varchar" if self.server_version_info >= (8, 3) else "",
+                "ix.indoption::varchar"
+                if self.server_version_info >= (8, 3)
+                else "NULL",
                 "i.reloptions"
                 if self.server_version_info >= (8, 2)
                 else "NULL",
@@ -3227,7 +3230,7 @@ class PGDialect(default.DefaultDialect):
                   i.relname as relname,
                   ix.indisunique, ix.indexprs, ix.indpred,
                   a.attname, a.attnum, c.conrelid, ix.indkey::varchar,
-                  i.reloptions, am.amname
+                  ix.indoption::varchar, i.reloptions, am.amname
               FROM
                   pg_class t
                         join pg_index ix on t.oid = ix.indrelid
@@ -3270,6 +3273,7 @@ class PGDialect(default.DefaultDialect):
                 col_num,
                 conrelid,
                 idx_key,
+                idx_option,
                 options,
                 amname,
             ) = row
@@ -3296,6 +3300,27 @@ class PGDialect(default.DefaultDialect):
                 index["cols"][col_num] = col
             if not has_idx:
                 index["key"] = [int(k.strip()) for k in idx_key.split()]
+
+                # (new in pg 8.3)
+                # "pg_index.indoption" is list of ints, one per column/expr.
+                # int acts as bitmask: 0x01=DESC, 0x02=NULLSFIRST
+                sorting = {}
+                for col_idx, col_flags in enumerate((idx_option or "").split()):
+                    col_flags = int(col_flags.strip())
+                    col_sorting = {}
+                    # try to set flags only if they differ from PG defaults...
+                    if col_flags & 0x01:
+                        col_sorting["desc"] = True
+                        if not (col_flags & 0x02):
+                            col_sorting["nullslast"] = True
+                    else:
+                        if col_flags & 0x02:
+                            col_sorting["nullsfirst"] = True
+                    if col_sorting:
+                        sorting[col_idx] = col_sorting
+                if sorting:
+                    index["sorting"] = sorting
+
                 index["unique"] = unique
                 if conrelid is not None:
                     index["duplicates_constraint"] = idx_name
@@ -3320,6 +3345,11 @@ class PGDialect(default.DefaultDialect):
             }
             if "duplicates_constraint" in idx:
                 entry["duplicates_constraint"] = idx["duplicates_constraint"]
+            if "sorting" in idx:
+                entry["column_sorting"] = dict(
+                    (idx["cols"][idx["key"][i]], value)
+                    for i, value in idx["sorting"].items()
+                )
             if "options" in idx:
                 entry.setdefault("dialect_options", {})[
                     "postgresql_with"


### PR DESCRIPTION
This fixes #4717, adding support to the postgresql dialect to reflect per-column sort order for indexes.

*I may not have made this commit on top of the appropriate branch, please let me know if I should rebase & resubmit*.

### Description

1) `Dialect.get_indexes()` was expanded to support general reflection
of per-column sort order via "column_sorting" keyword (details added to get_indexes docstring).  This keyword signals `Inspector._reflect_indexes()` to adapt the column objects via .desc(), .nullslast(), etc before adding them to the resulting Index.  

This should be generic enough to work for any database.  Additionally, since the dictionary is keyed off the column name, when/if the framework is expanded in the future to support general expressions, this should still hold up: dialects can either just omit expressions from the "column_sorting" dictionary (and handle appending sort modifiers as part of the returned expression), or just use the sql.text() expressions themselves as "column_sorting" key. 

2) PGDialect.get_indexes() now reflects per-column sort order from "pg_index.indoption" in system schema. (This feature wasn't present before pg 8.3).   I added a new unittest for index sort order reflection; and on my limited system, all index reflection tests are passing.

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #4717` in the commit message
	- please include tests.
