### PR TITLE
sql.sqltypes.Enum: More efficient copy for python 2.7

### DIFF
--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -1426,12 +1426,14 @@ class Enum(Emulated, String, SchemaType):
             self.enum_class = enums[0]
             if self.values_callable:
                 values = self.values_callable(self.enum_class)
+                objects = [
+                    self.enum_class.__members__[k]
+                    for k in self.enum_class.__members__
+                ]
             else:
-                values = list(self.enum_class.__members__)
-            objects = [
-                self.enum_class.__members__[k]
-                for k in self.enum_class.__members__
-            ]
+                enum_members = self.enum_class.__members__.copy()
+                values = enum_members.keys()
+                objects = enum_members.values()
             return values, objects
         else:
             self.enum_class = None


### PR DESCRIPTION
### Description

Before this commit, an enumeration with a few hundred options (e.g.,
representing 3-letter ISO 4217 currency codes) that appeared on ≈10
tables could take a couple of seconds to import and declare the classes.
After this commit, the same declared schema classes can be imported in
less than a second.

This performance issue is not present when running with Python 3.6.8.

Reproduction script, run using `Python 2.7.12`, `Babel==2.4.0`,
`SQLAlchemy==1.3.5` on a quad core Intel i5 @ 2.20GHz running Ubuntu
16.04.01.

``` python
import enum
import uuid
from datetime import datetime

import babel
from sqlalchemy import Column, Enum, Integer
from sqlalchemy.ext.declarative import declarative_base
from sqlalchemy.ext.declarative.api import DeclarativeMeta

class Currency(enum.Enum):
    """Standard unit of money.

    Instances can be referenced via ISO 4217 currency codes, e.g.,
    `Currency.EUR`.
    """

    locals().update(
        {code: object() for code in list(babel.Locale("en", "US").currencies)}
    )

print(len(Currency.__members__))
 # prints 297 with Babel==2.4.0

class CurrencyClassType(DeclarativeMeta):
    def __init__(cls, *args, **kwargs):
        setattr(cls, "__tablename__", uuid.uuid4().hex)
        setattr(cls, "id", Column(Integer, primary_key=True))
        setattr(cls, "currency", Column(Enum(Currency, native_enum=False)))
        super(CurrencyClassType, cls).__init__(*args, **kwargs)

start = datetime.now()
Base = declarative_base()

 # This loop has the same effect as declaring N(=10) classes with a
 # random class name, a random table name, an `id` primary key column,
 # and a `currency` enumerated column, using the `Currency` enumeration
 # above.
for i in xrange(10):
    # Simulate declaring a class, inheriting from `Base`
    CurrencyClassType(uuid.uuid4().hex, (Base, ), {})

print(datetime.now() - start)
 # prints roughly 2.5 seconds
 # prints less than 200 milliseconds
```

Fixes #4758.

### Checklist

This pull request is:

- [x] A performance improvement
