### PR TITLE
SyntaxError in on_duplicate_key_update() example.

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/dml.py
+++ b/lib/sqlalchemy/dialects/mysql/dml.py
@@ -72,7 +72,7 @@ class Insert(StandardInsert):
          in :ref:`updates_order_parameters`::
 
             insert().on_duplicate_key_update(
-                [("name": "some name"), ("value", "some value")])
+                [("name", "some name"), ("value", "some value")])
 
          .. versionchanged:: 1.3 parameters can be specified as a dictionary
             or list of 2-tuples; the latter form provides for parameter


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Very small change to fix documented example of passing list of tuples to `insert().on_duplicate_key_update()`.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [Y ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed

**Have a nice day!**
