### PR TITLE
Enable use of psycopg2.execute_values() which is faster than psycopg2.execute_batch()

### DIFF
--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -2455,7 +2455,7 @@ class SQLCompiler(Compiled):
                 )
             )
         else:
-            text += " VALUES (%s)" % ", ".join([c[1] for c in crud_params])
+            text += self.generate_values_placeholders_str(crud_params, returning_clause is not None)
 
         if insert_stmt._post_values_clause is not None:
             post_values_clause = self.process(
@@ -2476,6 +2476,13 @@ class SQLCompiler(Compiled):
             return "(" + text + ")"
         else:
             return text
+
+    def generate_values_placeholders_str(self, crud_params, returning_clause_exists):
+        """
+        Generate the VALUES place holder string
+        Should be overridden in classes that need a different implementation than the default
+        """
+        return " VALUES (%s)" % ", ".join([c[1] for c in crud_params])
 
     def update_limit_clause(self, update_stmt):
         """Provide a hook for MySQL to add LIMIT to the UPDATE"""


### PR DESCRIPTION
### Description
In SQLCompiler.visit_insert(), put logic to generate the VALUES clause into function (generate_values_placeholders_str) to enable overriding just that logic in derived classes.
In PGCompiler_psycopg2 override generate_values_placeholders_str() to enable use of psycopg2.execute_values() which is faster than execute_batch().
Extend flag use_batch_mode to indicate which psycopg2 method to use.
Issue number: #4623

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
