### PR TITLE
Enable use of psycopg2.execute_values()

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -596,11 +596,13 @@ class PGCompiler_psycopg2(PGCompiler):
     def generate_values_placeholders_str(
             self, crud_params, returning_clause_exists):
 
-        # Currently not using psycopg2.execute_values() when there's a returning clause; need to add support
+        # Currently not using psycopg2.execute_values() when there's a
+        # returning clause; need to add support
         # for receiving multiple return values from insert query
         # Note: self.inline is true iff there are multiple parameters sets to
         # the query
-        if self.inline and not returning_clause_exists and self.dialect.psycopg2_executemany_mode is EXECUTEMANY_VALUES:
+        if self.inline and not returning_clause_exists and \
+                self.dialect.psycopg2_executemany_mode is EXECUTEMANY_VALUES:
             self.execute_values_insert_template = "(" + \
                 ", ".join([c[1] for c in crud_params]) + ")"
             return " VALUES %s"
@@ -693,24 +695,27 @@ class PGDialect_psycopg2(PGDialect):
                     EXECUTEMANY_BATCH.name,
                     EXECUTEMANY_VALUES.name):
                 raise exc.ArgumentError(
-                    "Unsupported value for 'executemany_mode': %s" % executemany_mode)
+                    "Unsupported value for 'executemany_mode': %s" %
+                    executemany_mode)
             self.psycopg2_executemany_mode = util.symbol(executemany_mode)
         else:
             self.psycopg2_executemany_mode = None
 
         if not isinstance(executemany_page_size, int):
-            raise exc.ArgumentError("Wrong type for 'executemany_page_size': %s" % type(
-                executemany_page_size).__name__)
+            raise exc.ArgumentError(
+                "Wrong type for 'executemany_page_size': %s" %
+                type(executemany_page_size).__name__)
 
         if executemany_page_size <= 0:
             raise exc.ArgumentError(
-                "Wrong value for 'executemany_page_size': %s" % executemany_page_size)
+                "Wrong value for 'executemany_page_size': %s" %
+                executemany_page_size)
 
         self.psycopg2_executemany_page_size = executemany_page_size
         self.psycopg2_batch_mode = use_batch_mode
 
-        # use_batch_mode supported for backward compatibility. To avoid having to check two flags,
-        # set executemany_mode flag here and use it only
+        # use_batch_mode supported for backward compatibility. To avoid having
+        # to check two flags, set executemany_mode flag here and use it only
         if not self.psycopg2_executemany_mode:
             self.psycopg2_executemany_mode = \
                 EXECUTEMANY_BATCH if self.psycopg2_batch_mode else \
@@ -875,7 +880,8 @@ class PGDialect_psycopg2(PGDialect):
                 page_size=self.psycopg2_executemany_page_size)
 
         else:  # EXECUTEMANY_VALUES of non-insert query, or EXECUTEMANY_BATCH
-            self._psycopg2_extras().execute_batch(cursor, statement, parameters)
+            self._psycopg2_extras().execute_batch(cursor, statement,
+                                                  parameters)
 
     @util.memoized_instancemethod
     def _hstore_oids(self, conn):

--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -689,17 +689,18 @@ class PGDialect_psycopg2(PGDialect):
         self.supports_unicode_binds = use_native_unicode
         self.client_encoding = client_encoding
 
-        if executemany_mode:
-            if executemany_mode not in (
-                    EXECUTEMANY_DEFAULT.name,
-                    EXECUTEMANY_BATCH.name,
-                    EXECUTEMANY_VALUES.name):
-                raise exc.ArgumentError(
-                    "Unsupported value for 'executemany_mode': %s" %
-                    executemany_mode)
-            self.psycopg2_executemany_mode = util.symbol(executemany_mode)
-        else:
-            self.psycopg2_executemany_mode = None
+        # Parse executemany_mode argument, allowing it to be only one of the
+        # symbol names
+        self.psycopg2_executemany_mode = util.symbol.parse_user_argument(
+            executemany_mode,
+            {
+                EXECUTEMANY_DEFAULT: [],
+                EXECUTEMANY_BATCH: [],
+                EXECUTEMANY_VALUES: []
+            },
+            "executemany_mode",
+            resolve_symbol_names=True
+        )
 
         if not isinstance(executemany_page_size, int):
             raise exc.ArgumentError(

--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -62,18 +62,16 @@ psycopg2-specific keyword arguments which are accepted by
   * ``None``:
     Flag not used, ``use_batch_mode`` determines behavior.
   * ``'single_statement'``:
-    Every parameters set is a single query that is sent to the database.
-    Uses ``psycopg2.extras.execute`` or ``psycopg2.extras.executemany``.
-    Equivalent to ``use_batch_mode=False``.
+    A single query is created for every parameters set and sent to the database.
+    Uses ``psycopg2.extras.executemany``. Equivalent to ``use_batch_mode=False``.
   * ``'statements_batch'``:
     Multiple queries are sent together to the database. Uses
     ``psycopg2.extras.execute_batch``. Equivalent to ``use_batch_mode=True``.
   * ``'values_batch'``:
     Multiple parameters sets are packed together into a single query
-    that is sent to the database. This flag currently supports only insert queries,
+    that is sent to the database. This flag currently supports only INSERT queries,
     and uses ``psycopg2.extras.execute_values``. For other queries it behaves the
     same as ``'statements_batch'``.
-
 
   .. seealso::
 

--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -562,17 +562,33 @@ class PGCompiler_psycopg2(PGCompiler):
         self.multiple_rows = inline
         self.execute_values_insert_template = None
         self.execute_values_page_size = 2000
-        super(PGCompiler_psycopg2, PGCompiler_psycopg2).__init__(self, dialect, statement, column_keys, inline, **kwargs)
+        super(
+            PGCompiler_psycopg2,
+            PGCompiler_psycopg2).__init__(
+            self,
+            dialect,
+            statement,
+            column_keys,
+            inline,
+            **kwargs)
 
-    # Override SQLCompiler.generate_values_placeholders_str- enable use of psycopg2 execute_values()
-    def generate_values_placeholders_str(self, crud_params, returning_clause_exists):
+    # Override SQLCompiler.generate_values_placeholders_str - enable use of
+    # psycopg2 execute_values()
+    def generate_values_placeholders_str(
+            self, crud_params, returning_clause_exists):
         # Currently not using psycopg2.execute_values() when there's a returning clause; need to add support
         # for receiving multiple return values from insert query
         if self.multiple_rows and not returning_clause_exists and self.dialect.psycopg2_batch_mode == 'execute_values':
-            self.execute_values_insert_template = "(" + ", ".join([c[1] for c in crud_params]) + ")"
+            self.execute_values_insert_template = "(" + \
+                ", ".join([c[1] for c in crud_params]) + ")"
             return " VALUES %s"
         else:
-            return super(PGCompiler_psycopg2, PGCompiler_psycopg2).generate_values_placeholders_str(self, crud_params, returning_clause_exists)
+            return super(
+                PGCompiler_psycopg2,
+                PGCompiler_psycopg2).generate_values_placeholders_str(
+                self,
+                crud_params,
+                returning_clause_exists)
 
 
 class PGIdentifierPreparer_psycopg2(PGIdentifierPreparer):
@@ -789,7 +805,11 @@ class PGDialect_psycopg2(PGDialect):
     def do_executemany(self, cursor, statement, parameters, context=None):
         if self.psycopg2_batch_mode == 'execute_values' and context and context.compiled.execute_values_insert_template:
             self._psycopg2_extras().execute_values(
-                cursor, statement, parameters, template=context.compiled.execute_values_insert_template, page_size=context.compiled.execute_values_page_size)
+                cursor,
+                statement,
+                parameters,
+                template=context.compiled.execute_values_insert_template,
+                page_size=context.compiled.execute_values_page_size)
         # Support True for backward compatibility
         elif self.psycopg2_batch_mode in ('execute_batch', True):
             self._psycopg2_extras().execute_batch(cursor, statement, parameters)

--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -855,13 +855,11 @@ class PGDialect_psycopg2(PGDialect):
 
     def do_executemany(self, cursor, statement, parameters, context=None):
         if self.psycopg2_execution_mode == EnumPsycopg2ExecutionMode.SINGLE_STATEMENT:
-            print('calling executemany()')
             cursor.executemany(statement, parameters)
         elif self.psycopg2_execution_mode == EnumPsycopg2ExecutionMode.VALUES_BATCH and \
                 context and \
                 context.compiled.execute_values_insert_template:
 
-            print('calling execute_values()')
             self._psycopg2_extras().execute_values(
                 cursor,
                 statement,
@@ -870,7 +868,6 @@ class PGDialect_psycopg2(PGDialect):
                 page_size=context.compiled.execute_values_page_size)
 
         else:  # VALUES_BATCH of non-insert query, or STATEMENTS_BATCH
-            print('calling execute_batch()')
             self._psycopg2_extras().execute_batch(cursor, statement, parameters)
 
     @util.memoized_instancemethod

--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -598,7 +598,8 @@ class PGCompiler_psycopg2(PGCompiler):
 
         # Currently not using psycopg2.execute_values() when there's a returning clause; need to add support
         # for receiving multiple return values from insert query
-        # Note: self.inline is true iff there are multiple parameters sets to the query
+        # Note: self.inline is true iff there are multiple parameters sets to
+        # the query
         if self.inline and not returning_clause_exists and self.dialect.psycopg2_executemany_mode is EXECUTEMANY_VALUES:
             self.execute_values_insert_template = "(" + \
                 ", ".join([c[1] for c in crud_params]) + ")"
@@ -619,7 +620,6 @@ class PGIdentifierPreparer_psycopg2(PGIdentifierPreparer):
 EXECUTEMANY_DEFAULT = util.symbol("executemany_default")
 EXECUTEMANY_BATCH = util.symbol("executemany_batch")
 EXECUTEMANY_VALUES = util.symbol("executemany_values")
-
 
 
 class PGDialect_psycopg2(PGDialect):
@@ -688,11 +688,23 @@ class PGDialect_psycopg2(PGDialect):
         self.client_encoding = client_encoding
 
         if executemany_mode:
-            if executemany_mode not in (EXECUTEMANY_DEFAULT.name, EXECUTEMANY_BATCH.name, EXECUTEMANY_VALUES.name):
-                raise exc.ArgumentError("Unsupported value for 'executemany_mode': %s" % executemany_mode)
+            if executemany_mode not in (
+                    EXECUTEMANY_DEFAULT.name,
+                    EXECUTEMANY_BATCH.name,
+                    EXECUTEMANY_VALUES.name):
+                raise exc.ArgumentError(
+                    "Unsupported value for 'executemany_mode': %s" % executemany_mode)
             self.psycopg2_executemany_mode = util.symbol(executemany_mode)
         else:
             self.psycopg2_executemany_mode = None
+
+        if not isinstance(executemany_page_size, int):
+            raise exc.ArgumentError("Wrong type for 'executemany_page_size': %s" % type(
+                executemany_page_size).__name__)
+
+        if executemany_page_size <= 0:
+            raise exc.ArgumentError(
+                "Wrong value for 'executemany_page_size': %s" % executemany_page_size)
 
         self.psycopg2_executemany_page_size = executemany_page_size
         self.psycopg2_batch_mode = use_batch_mode

--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -559,7 +559,7 @@ class PGCompiler_psycopg2(PGCompiler):
         self, dialect, statement, column_keys=None, inline=False, **kwargs
     ):
         self.dialect = dialect
-        self.multi_params = inline
+        self.multiple_rows = inline
         self.execute_values_insert_template = None
         self.execute_values_page_size = 2000
         super(PGCompiler_psycopg2, PGCompiler_psycopg2).__init__(self, dialect, statement, column_keys, inline, **kwargs)
@@ -568,7 +568,7 @@ class PGCompiler_psycopg2(PGCompiler):
     def generate_values_placeholders_str(self, crud_params, returning_clause_exists):
         # Currently not using psycopg2.execute_values() when there's a returning clause; need to add support
         # for receiving multiple return values from insert query
-        if self.multi_params and not returning_clause_exists and self.dialect.psycopg2_batch_mode == 'execute_values':
+        if self.multiple_rows and not returning_clause_exists and self.dialect.psycopg2_batch_mode == 'execute_values':
             self.execute_values_insert_template = "(" + ", ".join([c[1] for c in crud_params]) + ")"
             return " VALUES %s"
         else:

--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -607,7 +607,7 @@ class PGCompiler_psycopg2(PGCompiler):
             self, crud_params, returning_clause_exists):
         # Currently not using psycopg2.execute_values() when there's a returning clause; need to add support
         # for receiving multiple return values from insert query
-        if self.multiple_rows and not returning_clause_exists and self.dialect.psycopg2_batch_mode == 'execute_values':
+        if self.multiple_rows and not returning_clause_exists and self.dialect.psycopg2_execution_mode == 'values_batch':
             self.execute_values_insert_template = "(" + \
                 ", ".join([c[1] for c in crud_params]) + ")"
             return " VALUES %s"
@@ -840,7 +840,7 @@ class PGDialect_psycopg2(PGDialect):
             return None
 
     def do_executemany(self, cursor, statement, parameters, context=None):
-        if self.psycopg2_execution_mode == 'single_insert':
+        if self.psycopg2_execution_mode == 'single_statement':
             cursor.executemany(statement, parameters)
         elif self.psycopg2_execution_mode == 'values_batch' and \
                 context and \

--- a/lib/sqlalchemy/pool/base.py
+++ b/lib/sqlalchemy/pool/base.py
@@ -204,16 +204,16 @@ class Pool(log.Identified):
         self._invalidate_time = 0
         self._use_threadlocal = use_threadlocal
         self._pre_ping = pre_ping
-        if reset_on_return in ("rollback", True, reset_rollback):
-            self._reset_on_return = reset_rollback
-        elif reset_on_return in ("none", None, False, reset_none):
-            self._reset_on_return = reset_none
-        elif reset_on_return in ("commit", reset_commit):
-            self._reset_on_return = reset_commit
-        else:
-            raise exc.ArgumentError(
-                "Invalid value for 'reset_on_return': %r" % reset_on_return
-            )
+        self._reset_on_return = util.symbol.parse_user_argument(
+            reset_on_return,
+            {
+                reset_rollback: ["rollback", True],
+                reset_none: ["none", None, False],
+                reset_commit: ["commit"],
+            },
+            "reset_on_return",
+            resolve_symbol_names=False,
+        )
 
         self.echo = echo
 

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -2499,7 +2499,8 @@ class SQLCompiler(Compiled):
                 )
             )
         else:
-            text += self.generate_values_placeholders_str(crud_params, returning_clause is not None)
+            text += self.generate_values_placeholders_str(
+                crud_params, returning_clause is not None)
 
         if insert_stmt._post_values_clause is not None:
             post_values_clause = self.process(
@@ -2518,7 +2519,8 @@ class SQLCompiler(Compiled):
 
         return text
 
-    def generate_values_placeholders_str(self, crud_params, returning_clause_exists):
+    def generate_values_placeholders_str(
+            self, crud_params, returning_clause_exists):
         """
         Generate the VALUES place holder string
         Should be overridden in classes that need a different implementation than the default

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -2499,7 +2499,7 @@ class SQLCompiler(Compiled):
                 )
             )
         else:
-            text += " VALUES (%s)" % ", ".join([c[1] for c in crud_params])
+            text += self.generate_values_placeholders_str(crud_params, returning_clause is not None)
 
         if insert_stmt._post_values_clause is not None:
             post_values_clause = self.process(
@@ -2517,6 +2517,13 @@ class SQLCompiler(Compiled):
         self.stack.pop(-1)
 
         return text
+
+    def generate_values_placeholders_str(self, crud_params, returning_clause_exists):
+        """
+        Generate the VALUES place holder string
+        Should be overridden in classes that need a different implementation than the default
+        """
+        return " VALUES (%s)" % ", ".join([c[1] for c in crud_params])
 
     def update_limit_clause(self, update_stmt):
         """Provide a hook for MySQL to add LIMIT to the UPDATE"""

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -2523,7 +2523,8 @@ class SQLCompiler(Compiled):
             self, crud_params, returning_clause_exists):
         """
         Generate the VALUES place holder string
-        Should be overridden in classes that need a different implementation than the default
+        Should be overridden in classes that need a different implementation
+        than the default
         """
         return " VALUES (%s)" % ", ".join([c[1] for c in crud_params])
 

--- a/lib/sqlalchemy/util/langhelpers.py
+++ b/lib/sqlalchemy/util/langhelpers.py
@@ -1368,6 +1368,41 @@ class symbol(object):
         finally:
             symbol._lock.release()
 
+    @classmethod
+    def parse_user_argument(
+        cls, arg, choices, name, resolve_symbol_names=False
+    ):
+        """Given a user parameter, parse the parameter into a chosen symbol.
+
+        The user argument can be a string name that matches the name of a
+        symbol, or the symbol object itself, or any number of alternate choices
+        such as True/False/ None etc.
+
+        :param arg: the user argument.
+        :param choices: dictionary of symbol object to list of possible
+         entries.
+        :param name: name of the argument.   Used in an :class:`.ArgumentError`
+         that is raised if the parameter doesn't match any available argument.
+        :param resolve_symbol_names: include the name of each symbol as a valid
+         entry.
+
+        """
+        # note using hash lookup is tricky here because symbol's `__hash__`
+        # is its int value which we don't want included in the lookup
+        # explicitly, so we iterate and compare each.
+        for sym, choice in choices.items():
+            if arg is sym:
+                return sym
+            elif resolve_symbol_names and arg == sym.name:
+                return sym
+            elif arg in choice:
+                return sym
+
+        if arg is None:
+            return None
+
+        raise exc.ArgumentError("Invalid value for '%s': %r" % (name, arg))
+
 
 _creation_order = 1
 

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -2227,6 +2227,69 @@ class SymbolTest(fixtures.TestBase):
         assert not (sym1 | sym2) & (sym3 | sym4)
         assert (sym1 | sym2) & (sym2 | sym4)
 
+    def test_parser(self):
+        sym1 = util.symbol("sym1", canonical=1)
+        sym2 = util.symbol("sym2", canonical=2)
+        sym3 = util.symbol("sym3", canonical=4)
+        sym4 = util.symbol("sym4", canonical=8)
+
+        lookup_one = {sym1: [], sym2: [True], sym3: [False], sym4: [None]}
+        lookup_two = {sym1: [], sym2: [True], sym3: [False]}
+        lookup_three = {sym1: [], sym2: ["symbol2"], sym3: []}
+
+        is_(
+            util.symbol.parse_user_argument(
+                "sym2", lookup_one, "some_name", resolve_symbol_names=True
+            ),
+            sym2,
+        )
+
+        assert_raises_message(
+            exc.ArgumentError,
+            "Invalid value for 'some_name': 'sym2'",
+            util.symbol.parse_user_argument,
+            "sym2",
+            lookup_one,
+            "some_name",
+        )
+        is_(
+            util.symbol.parse_user_argument(
+                True, lookup_one, "some_name", resolve_symbol_names=False
+            ),
+            sym2,
+        )
+
+        is_(
+            util.symbol.parse_user_argument(sym2, lookup_one, "some_name"),
+            sym2,
+        )
+
+        is_(
+            util.symbol.parse_user_argument(None, lookup_one, "some_name"),
+            sym4,
+        )
+
+        is_(
+            util.symbol.parse_user_argument(None, lookup_two, "some_name"),
+            None,
+        )
+
+        is_(
+            util.symbol.parse_user_argument(
+                "symbol2", lookup_three, "some_name"
+            ),
+            sym2,
+        )
+
+        assert_raises_message(
+            exc.ArgumentError,
+            "Invalid value for 'some_name': 'foo'",
+            util.symbol.parse_user_argument,
+            "foo",
+            lookup_three,
+            "some_name",
+        )
+
 
 class _Py3KFixtures(object):
     pass

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -425,7 +425,7 @@ class ExecutemanyFlagOptionsTest(fixtures.TablesTest):
         for opt in [1, True, "batch_insert"]:
             assert_raises_message(
                 exc.ArgumentError,
-                "Unsupported value for 'executemany_mode': %s" % opt,
+                "Invalid value for 'executemany_mode': %r" % opt,
                 engines.testing_engine,
                 options={"executemany_mode": opt}
             )

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -172,7 +172,7 @@ class ExecuteBatchInsertsTest(fixtures.TablesTest):
 
     def setup(self):
         super(ExecuteBatchInsertsTest, self).setup()
-        self.engine = engines.testing_engine(options={"execution_mode": "statements_batch"})
+        self.engine = engines.testing_engine(options={"executemany_mode": "executemany_batch"})
 
     def teardown(self):
         self.engine.dispose()
@@ -243,7 +243,7 @@ class ExecuteValuesInsertsTest(fixtures.TablesTest):
     def setup(self):
         super(ExecuteValuesInsertsTest, self).setup()
         self.engine = engines.testing_engine(
-            options={"execution_mode": "values_batch"})
+            options={"executemany_mode": "executemany_values"})
 
     def teardown(self):
         self.engine.dispose()
@@ -314,7 +314,7 @@ class ExecuteValuesInsertsTest(fixtures.TablesTest):
 
     def test_execute_values_arguments_page_size(self):
         self.engine = engines.testing_engine(
-            options={"execution_mode": "values_batch", "page_size": 5000})
+            options={"executemany_mode": "executemany_values", "execute_values_page_size": 5000})
 
         def execute_values(cur, sql, argslist, template=None, page_size=100):
             assert sql == "INSERT INTO data (x, y) VALUES %s"

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -314,7 +314,7 @@ class ExecuteValuesInsertsTest(fixtures.TablesTest):
 
     def test_execute_values_arguments_page_size(self):
         self.engine = engines.testing_engine(
-            options={"executemany_mode": "executemany_values", "execute_values_page_size": 5000})
+            options={"executemany_mode": "executemany_values", "executemany_page_size": 5000})
 
         def execute_values(cur, sql, argslist, template=None, page_size=100):
             assert sql == "INSERT INTO data (x, y) VALUES %s"

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -172,7 +172,7 @@ class ExecuteBatchInsertsTest(fixtures.TablesTest):
 
     def setup(self):
         super(ExecuteBatchInsertsTest, self).setup()
-        self.engine = engines.testing_engine(options={"use_batch_mode": True})
+        self.engine = engines.testing_engine(options={"execution_mode": "statements_batch"})
 
     def teardown(self):
         self.engine.dispose()
@@ -243,7 +243,7 @@ class ExecuteValuesInsertsTest(fixtures.TablesTest):
     def setup(self):
         super(ExecuteValuesInsertsTest, self).setup()
         self.engine = engines.testing_engine(
-            options={"use_batch_mode": "execute_values"})
+            options={"execution_mode": "values_batch"})
 
     def teardown(self):
         self.engine.dispose()
@@ -299,7 +299,7 @@ class ExecuteValuesInsertsTest(fixtures.TablesTest):
             assert argslist == ({'x': 'x1', 'y': 'y1'}, {
                                 'x': 'x2', 'y': 'y2'}, {'x': 'x3', 'y': 'y3'})
             assert template == "(%(x)s, %(y)s)"
-            assert page_size == 2000
+            assert page_size == 10000
 
         with patch("psycopg2.extras.execute_values", execute_values):
             with self.engine.connect() as conn:

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -242,7 +242,8 @@ class ExecuteValuesInsertsTest(fixtures.TablesTest):
 
     def setup(self):
         super(ExecuteValuesInsertsTest, self).setup()
-        self.engine = engines.testing_engine(options={"use_batch_mode": "execute_values"})
+        self.engine = engines.testing_engine(
+            options={"use_batch_mode": "execute_values"})
 
     def teardown(self):
         self.engine.dispose()
@@ -295,7 +296,8 @@ class ExecuteValuesInsertsTest(fixtures.TablesTest):
     def test_correct_arguments(self):
         def execute_values(cur, sql, argslist, template=None, page_size=100):
             assert sql == "INSERT INTO data (x, y) VALUES %s"
-            assert argslist == ({'x': 'x1', 'y': 'y1'}, {'x': 'x2', 'y': 'y2'}, {'x': 'x3', 'y': 'y3'})
+            assert argslist == ({'x': 'x1', 'y': 'y1'}, {
+                                'x': 'x2', 'y': 'y2'}, {'x': 'x3', 'y': 'y3'})
             assert template == "(%(x)s, %(y)s)"
             assert page_size == 2000
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Fixes: #4623
In SQLCompiler.visit_insert(), put logic to generate the VALUES clause into function (generate_values_placeholders_str) to enable overriding just that logic in derived classes.
In PGCompiler_psycopg2 override generate_values_placeholders_str() to enable use of psycopg2.execute_values() which is faster than execute_batch().
Extend flag use_batch_mode to indicate which psycopg2 method to use.
In PGDialect_psycopg2.do_executemany(), call the correct psycopg2 method based on the use_batch_mode flag and compiler variables.
Add tests for psycopg2.execute_values().

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
