### PR TITLE
type_ck integration

### DIFF
--- a/.github/workflows/scripts/can_install.py
+++ b/.github/workflows/scripts/can_install.py
@@ -1,4 +1,5 @@
 import sys
+
 from packaging import tags
 
 to_check = "--"

--- a/doc/build/changelog/migration_14.rst
+++ b/doc/build/changelog/migration_14.rst
@@ -550,8 +550,8 @@ base :class:`.AliasedReturnsRows`.
 
 That is, this will now raise::
 
-    stmt1 = select([user.c.id, user.c.name])
-    stmt2 = select([addresses, stmt1]).select_from(addresses.join(stmt1))
+    stmt1 = select(user.c.id, user.c.name)
+    stmt2 = select(addresses, stmt1).select_from(addresses.join(stmt1))
 
 Raising::
 
@@ -630,7 +630,7 @@ people hope that ``.c`` does (but does not), which is to reference the columns
 that are in the columns clause of the SELECT statement.   A common beginner mistake
 is code such as the following::
 
-    stmt = select([users])
+    stmt = select(users)
     stmt = stmt.where(stmt.c.name == 'foo')
 
 The above code appears intuitive and that it would generate
@@ -642,7 +642,7 @@ The new :attr:`_expression.SelectBase.selected_columns` attribute however **does
 the use case above, as in a case like the above it links directly to the columns
 present in the ``users.c`` collection::
 
-    stmt = select([users])
+    stmt = select(users)
     stmt = stmt.where(stmt.selected_columns.name == 'foo')
 
 
@@ -993,7 +993,7 @@ feature represents a simpler approach to building expressions in any case,
 it's now invoked automatically whenever a list of values is passed to
 an IN expression::
 
-    stmt = select([A.id, A.data]).where(A.id.in_([1, 2, 3]))
+    stmt = select(A.id, A.data).where(A.id.in_([1, 2, 3]))
 
 The pre-execution string representation is::
 
@@ -1374,7 +1374,7 @@ the 2.0 transition::
 
     >>> from sqlalchemy import column, select
     >>> c1, c2, c3, c4 = column('c1'), column('c2'), column('c3'), column('c4')
-    >>> stmt = select([c1, c2, c3.label('c2'), c2, c4])
+    >>> stmt = select(c1, c2, c3.label('c2'), c2, c4)
     >>> print(stmt)
     SELECT c1, c2, c3 AS c2, c2, c4
 
@@ -1418,7 +1418,7 @@ deduplication of implicitly generated labels::
 
     >>> from sqlalchemy import table
     >>> user = table('user', column('id'), column('name'))
-    >>> stmt = select([user.c.id, user.c.name, user.c.id]).apply_labels()
+    >>> stmt = select(user.c.id, user.c.name, user.c.id).apply_labels()
     >>> print(stmt)
     SELECT "user".id AS user_id, "user".name AS user_name, "user".id AS id_1
     FROM "user"
@@ -1428,8 +1428,8 @@ Finally, the change makes it easier to create UNION and other
 of columns in a SELECT statement mirrors what was given, in a use case such
 as::
 
-    >>> s1 = select([user, user.c.id])
-    >>> s2 = select([c1, c2, c3])
+    >>> s1 = select(user, user.c.id)
+    >>> s2 = select(c1, c2, c3)
     >>> from sqlalchemy import union
     >>> u = union(s1, s2)
     >>> print(u)
@@ -1476,7 +1476,7 @@ In SQLAlchemy Core expressions, we never deal with a raw generated name like
 the above, as SQLAlchemy applies auto-labeling to expressions like these, which
 are up until now always a so-called "anonymous" expression::
 
-    >>> print(select([cast(foo.c.data, String)]))
+    >>> print(select(cast(foo.c.data, String)))
     SELECT CAST(foo.data AS VARCHAR) AS anon_1     # old behavior
     FROM foo
 
@@ -1494,14 +1494,14 @@ or label names such as in :ref:`change_4753`.  So we now emulate PostgreSQL's
 reasonable behavior for simple modifications to a single column, most
 prominently with CAST::
 
-    >>> print(select([cast(foo.c.data, String)]))
+    >>> print(select(cast(foo.c.data, String)))
     SELECT CAST(foo.data AS VARCHAR) AS data
     FROM foo
 
 For CAST against expressions that don't have a name, the previous logic is used
 to generate the usual "anonymous" labels::
 
-    >>> print(select([cast('hi there,' + foo.c.data, String)]))
+    >>> print(select(cast('hi there,' + foo.c.data, String)))
     SELECT CAST(:data_1 + foo.data AS VARCHAR) AS anon_1
     FROM foo
 
@@ -1509,14 +1509,14 @@ A :func:`.cast` against a :class:`.Label`, despite having to omit the label
 expression as these don't render inside of a CAST, will nonetheless make use of
 the given name::
 
-    >>> print(select([cast(('hi there,' + foo.c.data).label('hello_data'), String)]))
+    >>> print(select(cast(('hi there,' + foo.c.data).label('hello_data'), String)))
     SELECT CAST(:data_1 + foo.data AS VARCHAR) AS hello_data
     FROM foo
 
 And of course as was always the case, :class:`.Label` can be applied to the
 expression on the outside to apply an "AS <name>" label directly::
 
-    >>> print(select([cast(('hi there,' + foo.c.data), String).label('hello_data')]))
+    >>> print(select(cast(('hi there,' + foo.c.data), String).label('hello_data')))
     SELECT CAST(:data_1 + foo.data AS VARCHAR) AS hello_data
     FROM foo
 

--- a/doc/build/changelog/unreleased_13/5539.rst
+++ b/doc/build/changelog/unreleased_13/5539.rst
@@ -2,9 +2,9 @@
     :tags: change, mysql
     :tickets: 5539
 
-	Add new MySQL reserved words: `cube`, `lateral`.
+    Add new MySQL reserved words: `cube`, `lateral`.
 
-	Reference https://dev.mysql.com/doc/refman/8.0/en/keywords.html :
+    Reference https://dev.mysql.com/doc/refman/8.0/en/keywords.html :
 
-	* CUBE (R); became reserved in 8.0.1
-	* LATERAL (R); added in 8.0.14 (reserved)
+    * CUBE (R); became reserved in 8.0.1
+    * LATERAL (R); added in 8.0.14 (reserved)

--- a/doc/build/core/custom_types.rst
+++ b/doc/build/core/custom_types.rst
@@ -290,7 +290,7 @@ get at this with a type like ``JSONEncodedDict``, we need to
 
     from sqlalchemy import type_coerce, String
 
-    stmt = select([my_table]).where(
+    stmt = select(my_table).where(
         type_coerce(my_table.c.json_data, String).like('%foo%'))
 
 :class:`.TypeDecorator` provides a built-in system for working up type
@@ -378,7 +378,7 @@ and use it in a :func:`_expression.select` construct::
                   Column('geom_data', Geometry)
                 )
 
-    print(select([geometry]).where(
+    print(select(geometry).where(
       geometry.c.geom_data == 'LINESTRING(189412 252431,189631 259122)'))
 
 The resulting SQL embeds both functions as appropriate.   ``ST_AsText``
@@ -396,7 +396,7 @@ with the labeling of the wrapped expression.   Such as, if we rendered
 a :func:`_expression.select` against a :func:`.label` of our expression, the string
 label is moved to the outside of the wrapped expression::
 
-    print(select([geometry.c.geom_data.label('my_data')]))
+    print(select(geometry.c.geom_data.label('my_data')))
 
 Output::
 
@@ -445,7 +445,7 @@ transparently::
                                     message="this is my message")
 
         print(conn.scalar(
-                select([message.c.message]).\
+                select(message.c.message).\
                     where(message.c.username == "some user")
             ))
 

--- a/doc/build/core/defaults.rst
+++ b/doc/build/core/defaults.rst
@@ -189,7 +189,7 @@ INSERT or UPDATE statement::
         Column('create_date', DateTime, default=func.now()),
 
         # define 'key' to pull its default from the 'keyvalues' table
-        Column('key', String(20), default=select([keyvalues.c.key]).where(keyvalues.c.type='type1')),
+        Column('key', String(20), default=select(keyvalues.c.key).where(keyvalues.c.type='type1')),
 
         # define 'last_modified' to use the current_timestamp SQL function on update
         Column('last_modified', DateTime, onupdate=func.utc_timestamp())
@@ -404,7 +404,7 @@ method, which will render at statement compilation time a SQL function that is
 appropriate for the target backend::
 
     >>> my_seq = Sequence('some_sequence')
-    >>> stmt = select([my_seq.next_value()])
+    >>> stmt = select(my_seq.next_value())
     >>> print(stmt.compile(dialect=postgresql.dialect()))
     SELECT nextval('some_sequence') AS next_value_1
 

--- a/doc/build/core/functions.rst
+++ b/doc/build/core/functions.rst
@@ -11,7 +11,7 @@ SQL functions which are known to SQLAlchemy with regards to database-specific
 rendering, return types and argument behavior. Generic functions are invoked
 like all SQL functions, using the :attr:`func` attribute::
 
-    select([func.count()]).select_from(sometable)
+    select(func.count()).select_from(sometable)
 
 Note that any name not known to :attr:`func` generates the function name as is
 - there is no restriction on what SQL functions can be called, known or

--- a/doc/build/core/pooling.rst
+++ b/doc/build/core/pooling.rst
@@ -244,7 +244,7 @@ behaviors are needed::
             # run a SELECT 1.   use a core select() so that
             # the SELECT of a scalar value without a table is
             # appropriately formatted for the backend
-            connection.scalar(select([1]))
+            connection.scalar(select(1))
         except exc.DBAPIError as err:
             # catch SQLAlchemy's DBAPIError, which is a wrapper
             # for the DBAPI's exception.  It includes a .connection_invalidated
@@ -256,7 +256,7 @@ behaviors are needed::
                 # itself and establish a new connection.  The disconnect detection
                 # here also causes the whole connection pool to be invalidated
                 # so that all stale connections are discarded.
-                connection.scalar(select([1]))
+                connection.scalar(select(1))
             else:
                 raise
         finally:

--- a/doc/build/errors.rst
+++ b/doc/build/errors.rst
@@ -741,6 +741,58 @@ Since "b" is required, pass it as ``None`` so that the INSERT may proceed::
 
  :ref:`execute_multiple`
 
+
+.. _error_f0f1:
+
+Naming convention "ck_%(table_name)s_%(constraint_name)s" failed to apply to CHECK constraint...
+------------------------------------------------------------------------------------------------
+
+This error typically occurs when SqlAlchemy must automatically generate a check
+constraint for a "type bound" column such as :class:`.Boolean` or :class:`.Enum`,
+and the naming convention references a `constraint_name`, but a constraint
+name was not explicitly provided.  SqlAlchemy only generates type-bound constraints
+on certain database backends which do not have native enforcement of data types.
+
+The simplest way to address this issue is to update your MetaData's naming convention
+to include a ``type_ck`` prefix and corresponding template which uses the
+``column_0_name`` token. This naming convention will only be used when automatically
+generating contraints for "type bound" columns. The "type_ck"``" prefix was added
+in SqlAlchemy 1.4 .
+
+This following example adds a "type_ck" prefix and template which use the
+``column_0_name`` token instead of ``constraint_name`` ::
+
+    metadata = MetaData(
+        naming_convention={"ck": "ck_%(table_name)s_%(constraint_name)s",
+                           "type_ck": "ck_%(table_name)s_%(column_0_name)s",
+                           }
+    )
+    Table('foo', metadata,
+        Column('flag', Boolean())
+    )
+    
+If you prefer more control over your constraint naming, SqlAlchemy allows you
+to supply the contraint name in the column definition itself, using the `name`
+argument ::
+
+    metadata = MetaData(
+        naming_convention={"ck": "ck_%(table_name)s_%(constraint_name)s",
+                           }
+    )
+    Table('foo', metadata,
+        Column('flag', Boolean(name='flag_bool'))
+    )
+
+In the example above, because there is a contraint name explicitly supplied to the
+:class:`.Boolean` column, the "ck_" prefix can utilize the "%(constraint_name)s"
+token and a "type_ck" template is not needed.
+
+
+.. seealso::
+
+ :ref:`_naming_schematypes`
+
+
 .. _error_89ve:
 
 Expected FROM clause, got Select.  To create a FROM clause, use the .subquery() method

--- a/doc/build/errors.rst
+++ b/doc/build/errors.rst
@@ -643,7 +643,7 @@ that is not associated with any :class:`_engine.Engine`::
  metadata = MetaData()
  table = Table('t', metadata, Column('q', Integer))
 
- stmt = select([table])
+ stmt = select(table)
  result = stmt.execute()   # <--- raises
 
 What the logic is expecting is that the :class:`_schema.MetaData` object has
@@ -681,7 +681,7 @@ This error occurs when a statement makes use of :func:`.bindparam` either
 implicitly or explicitly and does not provide a value when the statement
 is executed::
 
- stmt = select([table.c.column]).where(table.c.id == bindparam('my_param'))
+ stmt = select(table.c.column).where(table.c.id == bindparam('my_param'))
 
  result = conn.execute(stmt)
 
@@ -762,17 +762,17 @@ Given an example as::
        Column('b', Integer),
        Column('c', Integer)
     )
-    stmt = select([t])
+    stmt = select(t)
 
 Above, ``stmt`` represents a SELECT statement.  The error is produced when we want
 to use ``stmt`` directly as a FROM clause in another SELECT, such as if we
 attempted to select from it::
 
-    new_stmt_1 = select([stmt])
+    new_stmt_1 = select(stmt)
 
 Or if we wanted to use it in a FROM clause such as in a JOIN::
 
-    new_stmt_2 = select([some_table]).select_from(some_table.join(stmt))
+    new_stmt_2 = select(some_table).select_from(some_table.join(stmt))
 
 In previous versions of SQLAlchemy, using a SELECT inside of another SELECT
 would produce a parenthesized, unnamed subquery.   In most cases, this form of
@@ -789,9 +789,9 @@ therefore requires that :meth:`_expression.SelectBase.subquery` is used::
 
     subq = stmt.subquery()
 
-    new_stmt_1 = select([subq])
+    new_stmt_1 = select(subq)
 
-    new_stmt_2 = select([some_table]).select_from(some_table.join(subq))
+    new_stmt_2 = select(some_table).select_from(some_table.join(subq))
 
 .. seealso::
 

--- a/doc/build/faq/sessions.rst
+++ b/doc/build/faq/sessions.rst
@@ -6,6 +6,7 @@ Sessions / Queries
     :class: faq
     :backlinks: none
 
+.. _faq_session_identity:
 
 I'm re-loading data with my Session but it isn't seeing changes that I committed elsewhere
 ------------------------------------------------------------------------------------------

--- a/doc/build/faq/sqlexpressions.rst
+++ b/doc/build/faq/sqlexpressions.rst
@@ -20,7 +20,7 @@ if we don't use it explicitly)::
 
     >>> from sqlalchemy import table, column, select
     >>> t = table('my_table', column('x'))
-    >>> statement = select([t])
+    >>> statement = select(t)
     >>> print(str(statement))
     SELECT my_table.x
     FROM my_table
@@ -93,7 +93,7 @@ flag, passed to ``compile_kwargs``::
 
     t = table('t', column('x'))
 
-    s = select([t]).where(t.c.x == 5)
+    s = select(t).where(t.c.x == 5)
 
     # **do not use** with untrusted input!!!
     print(s.compile(compile_kwargs={"literal_binds": True}))

--- a/doc/build/glossary.rst
+++ b/doc/build/glossary.rst
@@ -453,7 +453,7 @@ Glossary
         as an ORDER BY clause by calling upon the :meth:`_expression.Select.where`
         and :meth:`_expression.Select.order_by` methods::
 
-            stmt = select([user.c.name]).\
+            stmt = select(user.c.name).\
                         where(user.c.id > 5).\
                         where(user.c.name.like('e%').\
                         order_by(user.c.name)

--- a/doc/build/orm/join_conditions.rst
+++ b/doc/build/orm/join_conditions.rst
@@ -807,12 +807,12 @@ ten items for each collection::
         id = Column(Integer, primary_key=True)
         a_id = Column(ForeignKey("a.id"))
 
-    partition = select([
+    partition = select(
         B,
         func.row_number().over(
             order_by=B.id, partition_by=B.a_id
         ).label('index')
-    ]).alias()
+    ).alias()
 
     partitioned_b = aliased(B, partition)
 

--- a/doc/build/orm/loading_relationships.rst
+++ b/doc/build/orm/loading_relationships.rst
@@ -1185,11 +1185,11 @@ Below it is linked to a :func:`_expression.select` which links a set of column o
 to a string SQL statement::
 
     # label the columns of the addresses table
-    eager_columns = select([
+    eager_columns = select(
         addresses.c.address_id.label('a1'),
         addresses.c.email_address.label('a2'),
         addresses.c.user_id.label('a3')
-    ])
+    )
 
     # select from a raw SQL statement which uses those label names for the
     # addresses table.  contains_eager() matches them up.

--- a/doc/build/orm/mapped_sql_expr.rst
+++ b/doc/build/orm/mapped_sql_expr.rst
@@ -123,14 +123,14 @@ objects available for a particular ``User``::
         __tablename__ = 'user'
         id = Column(Integer, primary_key=True)
         address_count = column_property(
-            select([func.count(Address.id)]).\
+            select(func.count(Address.id)).\
                 where(Address.user_id==id).\
                 correlate_except(Address)
         )
 
 In the above example, we define a :func:`_expression.select` construct like the following::
 
-    select([func.count(Address.id)]).\
+    select(func.count(Address.id)).\
         where(Address.user_id==id).\
         correlate_except(Address)
 
@@ -154,7 +154,7 @@ are configured.   In Declarative this has the effect of calling :meth:`_orm.Mapp
 to add an additional property after the fact::
 
     User.address_count = column_property(
-            select([func.count(Address.id)]).\
+            select(func.count(Address.id)).\
                 where(Address.user_id==User.id)
         )
 
@@ -168,8 +168,7 @@ association table to both tables in a relationship::
         # ...
 
         book_count = column_property(
-            select(
-                [func.count(books.c.id)]
+            select(func.count(books.c.id)
             ).where(
                 and_(
                     book_authors.c.author_id==authors.c.id,
@@ -239,7 +238,7 @@ which is then used to emit a query::
         def address_count(self):
             return object_session(self).\
                 scalar(
-                    select([func.count(Address.id)]).\
+                    select(func.count(Address.id)).\
                         where(Address.user_id==self.id)
                 )
 

--- a/doc/build/orm/nonstandard_mappings.rst
+++ b/doc/build/orm/nonstandard_mappings.rst
@@ -125,17 +125,15 @@ subquery::
 
     from sqlalchemy import select, func
 
-    subq = select([
+    subq = select(
                 func.count(orders.c.id).label('order_count'),
                 func.max(orders.c.price).label('highest_order'),
                 orders.c.customer_id
-                ]).group_by(orders.c.customer_id).alias()
+                ).group_by(orders.c.customer_id).alias()
 
-    customer_select = select([customers, subq]).\
-                select_from(
-                    join(customers, subq,
-                            customers.c.id == subq.c.customer_id)
-                ).alias()
+    customer_select = select(customers, subq).select_from(
+        join(customers, subq, customers.c.id == subq.c.customer_id)
+    ).alias()
 
     class Customer(Base):
         __table__ = customer_select

--- a/doc/build/orm/persistence_techniques.rst
+++ b/doc/build/orm/persistence_techniques.rst
@@ -153,7 +153,7 @@ part of the object's primary key::
 
     session = Session(e)
 
-    foo = Foo(pk=sql.select([sql.func.coalesce(sql.func.max(Foo.pk) + 1, 1)])
+    foo = Foo(pk=sql.select(sql.func.coalesce(sql.func.max(Foo.pk) + 1, 1))
     session.add(foo)
     session.commit()
 
@@ -191,7 +191,7 @@ This is most easily accomplished using the
     result = session.execute("select * from table where id=:id", {'id':7})
 
     # execute a SQL expression construct
-    result = session.execute(select([mytable]).where(mytable.c.id==7))
+    result = session.execute(select(mytable).where(mytable.c.id==7))
 
 The current :class:`~sqlalchemy.engine.Connection` held by the
 :class:`~sqlalchemy.orm.session.Session` is accessible using the
@@ -222,7 +222,7 @@ proper context for the desired engine::
     )
 
     result = session.execute(
-        select([mytable], mytable.c.id==7),
+        select(mytable).where(mytable.c.id==7),
         bind_arguments={'mapper': MyMappedClass}
     )
 

--- a/doc/build/orm/session_basics.rst
+++ b/doc/build/orm/session_basics.rst
@@ -298,6 +298,8 @@ via standard methods such as :meth:`_engine.Result.all`,
 
     :ref:`migration_20_toplevel`
 
+
+
 Adding New or Existing Items
 ----------------------------
 
@@ -451,6 +453,76 @@ mode, an explicit call to :meth:`~.Session.rollback` is
 required after a flush fails, even though the underlying transaction will have
 been rolled back already - this is so that the overall nesting pattern of
 so-called "subtransactions" is consistently maintained.
+
+
+Expiring / Refreshing
+---------------------
+
+An important consideration that will often come up when using the
+:class:`_orm.Session` is that of dealing with the state that is present on
+objects that have been loaded from the database, in terms of keeping them
+synchronized with the current state of the transaction.   The SQLAlchemy
+ORM is based around the concept of an :term:`identity map` such that when
+an object is "loaded" from a SQL query, there will be a unique Python
+object instance maintained corresponding to a particular database identity.
+This means if we emit two separate queries, each for the same row, and get
+a mapped object back, the two queries will have returned the same Python
+object::
+
+  >>> u1 = session.query(User).filter(id=5).first()
+  >>> u2 = session.query(User).filter(id=5).first()
+  >>> u1 is u2
+  True
+
+Following from this, when the ORM gets rows back from a query, it will
+**skip the population of attributes** for an object that's already loaded.
+The design assumption here is to assume a transaction that's perfectly
+isolated, and then to the degree that the transaction isn't isolated, the
+application can take steps on an as-needed basis to refresh objects
+from the database transaction.  The FAQ entry at :ref:`faq_session_identity`
+discusses this concept in more detail.
+
+When an ORM mapped object is loaded into memory, there are three general
+ways to refresh its contents with new data from the current transaction:
+
+* **the expire() method** - the :meth:`_orm.Session.expire` method will
+  erase the contents of selected or all attributes of an object, such that they
+  will be loaded from the database when they are next accessed, e.g. using
+  a :term:`lazy loading` pattern::
+
+    session.expire(u1)
+    u1.some_attribute  # <-- lazy loads from the transaction
+  ..
+
+* **the refresh() method** - closely related is the :meth:`_orm.Session.refresh`
+  method, which does everything the :meth:`_orm.Session.expire` method does
+  but also emits one or more SQL queries immediately to actually refresh
+  the contents of the object::
+
+    session.refresh(u1)  # <-- emits a SQL query
+    u1.some_attribute  # <-- is refreshed from the transaction
+
+  ..
+
+* **the populate_existing() method** - this method is actually on the
+  :class:`_orm.Query` object as :meth:`_orm.Query.populate_existing`
+  and indicates that it should return objects that are unconditionally
+  re-populated from their contents in the database::
+
+    u2 = session.query(User).populate_existing().filter(id=5).first()
+
+  ..
+
+Further discussion on the refresh / expire concept can be found at
+:ref:`session_expire`.
+
+.. seealso::
+
+  :ref:`session_expire`
+
+  :ref:`faq_session_identity`
+
+
 
 .. _bulk_update_delete:
 

--- a/doc/build/orm/session_state_management.rst
+++ b/doc/build/orm/session_state_management.rst
@@ -506,6 +506,12 @@ attributes to be marked as expired::
     # expire only attributes obj1.attr1, obj1.attr2
     session.expire(obj1, ['attr1', 'attr2'])
 
+The :meth:`.Session.expire_all` method allows us to essentially call
+:meth:`.Session.expire` on all objects contained within the :class:`.Session`
+at once::
+
+    session.expire_all()
+
 The :meth:`~.Session.refresh` method has a similar interface, but instead
 of expiring, it emits an immediate SELECT for the object's row immediately::
 
@@ -519,11 +525,14 @@ be that of a column-mapped attribute::
     # reload obj1.attr1, obj1.attr2
     session.refresh(obj1, ['attr1', 'attr2'])
 
-The :meth:`.Session.expire_all` method allows us to essentially call
-:meth:`.Session.expire` on all objects contained within the :class:`.Session`
-at once::
+An alternative method of refreshing which is often more flexible is to
+use the :meth:`_orm.Query.populate_existing` method of :class:`_orm.Query`.
+With this option, all of the ORM objects returned by the :class:`_orm.Query`
+will be refreshed with the contents of what was loaded in the SELECT::
 
-    session.expire_all()
+    for user in session.query(User).populate_existing().filter(User.name.in_(['a', 'b', 'c'])):
+        print(user)  # will be refreshed for those columns that came back from the query
+
 
 What Actually Loads
 ~~~~~~~~~~~~~~~~~~~
@@ -630,6 +639,10 @@ transactions, an understanding of the isolation behavior in effect is essential.
     :meth:`.Session.expire_all`
 
     :meth:`.Session.refresh`
+
+    :meth:`_orm.Query.populate_existing` - :class:`_orm.Query` method that refreshes
+    all matching objects in the identity map against the results of a
+    SELECT statement.
 
     :term:`isolation` - glossary explanation of isolation which includes links
     to Wikipedia.

--- a/doc/build/orm/session_transaction.rst
+++ b/doc/build/orm/session_transaction.rst
@@ -653,7 +653,7 @@ entire database interaction is rolled back.
 
 .. versionchanged:: 1.4  This section introduces a new version of the
    "join into an external transaction" recipe that will work equally well
-   for both :term:`2.0 style` and :term:`1.x style`engines and sessions.
+   for both :term:`2.0 style` and :term:`1.x style` engines and sessions.
    The recipe here from previous versions such as 1.3 will also continue to
    work for 1.x engines and sessions.
 

--- a/examples/materialized_paths/materialized_paths.py
+++ b/examples/materialized_paths/materialized_paths.py
@@ -62,17 +62,15 @@ class Node(Base):
     # Finding the ancestors is a little bit trickier. We need to create a fake
     # secondary table since this behaves like a many-to-many join.
     secondary = select(
-        [
-            id.label("id"),
-            func.unnest(
-                cast(
-                    func.string_to_array(
-                        func.regexp_replace(path, r"\.?\d+$", ""), "."
-                    ),
-                    ARRAY(Integer),
-                )
-            ).label("ancestor_id"),
-        ]
+        id.label("id"),
+        func.unnest(
+            cast(
+                func.string_to_array(
+                    func.regexp_replace(path, r"\.?\d+$", ""), "."
+                ),
+                ARRAY(Integer),
+            )
+        ).label("ancestor_id"),
     ).alias()
     ancestors = relationship(
         "Node",

--- a/examples/nested_sets/nested_sets.py
+++ b/examples/nested_sets/nested_sets.py
@@ -46,7 +46,7 @@ def before_insert(mapper, connection, instance):
     else:
         personnel = mapper.mapped_table
         right_most_sibling = connection.scalar(
-            select([personnel.c.rgt]).where(
+            select(personnel.c.rgt).where(
                 personnel.c.emp == instance.parent.emp
             )
         )

--- a/examples/performance/short_selects.py
+++ b/examples/performance/short_selects.py
@@ -159,7 +159,7 @@ def test_core_new_stmt_each_time(n):
 
     with engine.connect() as conn:
         for id_ in random.sample(ids, n):
-            stmt = select([Customer.__table__]).where(Customer.id == id_)
+            stmt = select(Customer.__table__).where(Customer.id == id_)
             row = conn.execute(stmt).first()
             tuple(row)
 
@@ -173,7 +173,7 @@ def test_core_new_stmt_each_time_compiled_cache(n):
         compiled_cache=compiled_cache
     ) as conn:
         for id_ in random.sample(ids, n):
-            stmt = select([Customer.__table__]).where(Customer.id == id_)
+            stmt = select(Customer.__table__).where(Customer.id == id_)
             row = conn.execute(stmt).first()
             tuple(row)
 
@@ -182,7 +182,7 @@ def test_core_new_stmt_each_time_compiled_cache(n):
 def test_core_reuse_stmt(n):
     """test core, reusing the same statement (but recompiling each time)."""
 
-    stmt = select([Customer.__table__]).where(Customer.id == bindparam("id"))
+    stmt = select(Customer.__table__).where(Customer.id == bindparam("id"))
     with engine.connect() as conn:
         for id_ in random.sample(ids, n):
 
@@ -194,7 +194,7 @@ def test_core_reuse_stmt(n):
 def test_core_reuse_stmt_compiled_cache(n):
     """test core, reusing the same statement + compiled cache."""
 
-    stmt = select([Customer.__table__]).where(Customer.id == bindparam("id"))
+    stmt = select(Customer.__table__).where(Customer.id == bindparam("id"))
     compiled_cache = {}
     with engine.connect().execution_options(
         compiled_cache=compiled_cache

--- a/examples/postgis/postgis.py
+++ b/examples/postgis/postgis.py
@@ -190,13 +190,10 @@ def setup_ddl_events():
                 for c in gis_cols:
                     bind.execute(
                         select(
-                            [
-                                func.DropGeometryColumn(
-                                    "public", table.name, c.name
-                                )
-                            ],
-                            autocommit=True,
-                        )
+                            func.DropGeometryColumn(
+                                "public", table.name, c.name
+                            )
+                        ).execution_options(autocommit=True)
                     )
 
         elif event == "after-create":
@@ -205,17 +202,14 @@ def setup_ddl_events():
                 if isinstance(c.type, Geometry):
                     bind.execute(
                         select(
-                            [
-                                func.AddGeometryColumn(
-                                    table.name,
-                                    c.name,
-                                    c.type.srid,
-                                    c.type.name,
-                                    c.type.dimension,
-                                )
-                            ],
-                            autocommit=True,
-                        )
+                            func.AddGeometryColumn(
+                                table.name,
+                                c.name,
+                                c.type.srid,
+                                c.type.name,
+                                c.type.dimension,
+                            )
+                        ).execution_options(autocommit=True)
                     )
         elif event == "after-drop":
             table.columns = table.info.pop("_saved_columns")
@@ -319,7 +313,7 @@ if __name__ == "__main__":
     # core usage just fine:
 
     road_table = Road.__table__
-    stmt = select([road_table]).where(
+    stmt = select(road_table).where(
         road_table.c.road_geom.intersects(r1.road_geom)
     )
     print(session.execute(stmt).fetchall())
@@ -329,7 +323,7 @@ if __name__ == "__main__":
 
     # look up the hex binary version, using SQLAlchemy casts
     as_binary = session.scalar(
-        select([type_coerce(r.road_geom, Geometry(coerce_="binary"))])
+        select(type_coerce(r.road_geom, Geometry(coerce_="binary")))
     )
     assert as_binary.as_hex == (
         "01020000000200000000000000b832084100000000"
@@ -338,7 +332,7 @@ if __name__ == "__main__":
 
     # back again, same method !
     as_text = session.scalar(
-        select([type_coerce(as_binary, Geometry(coerce_="text"))])
+        select(type_coerce(as_binary, Geometry(coerce_="text")))
     )
     assert as_text.desc == "LINESTRING(198231 263418,198213 268322)"
 

--- a/examples/versioned_history/test_versioning.py
+++ b/examples/versioned_history/test_versioning.py
@@ -460,10 +460,10 @@ class TestVersioning(TestCase, AssertsCompiledSQL):
         sess.commit()
 
         actual_changed_base = sess.scalar(
-            select([BaseClass.__history_mapper__.local_table.c.changed])
+            select(BaseClass.__history_mapper__.local_table.c.changed)
         )
         actual_changed_sub = sess.scalar(
-            select([SubClass.__history_mapper__.local_table.c.changed])
+            select(SubClass.__history_mapper__.local_table.c.changed)
         )
         h1 = sess.query(BaseClassHistory).first()
         eq_(h1.changed, actual_changed_base)

--- a/examples/versioned_rows/versioned_rows_w_versionid.py
+++ b/examples/versioned_rows/versioned_rows_w_versionid.py
@@ -39,7 +39,7 @@ class Versioned(object):
     def __declare_last__(cls):
         alias = cls.__table__.alias()
         cls.calc_is_current_version = column_property(
-            select([func.max(alias.c.version_id) == cls.version_id]).where(
+            select(func.max(alias.c.version_id) == cls.version_id).where(
                 alias.c.id == cls.id
             )
         )

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -296,7 +296,7 @@ For statements that specify only LIMIT and no OFFSET, all versions of SQL
 Server support the TOP keyword.   This syntax is used for all SQL Server
 versions when no OFFSET clause is present.  A statement such as::
 
-    select([some_table]).limit(5)
+    select(some_table).limit(5)
 
 will render similarly to::
 
@@ -306,7 +306,7 @@ For versions of SQL Server prior to SQL Server 2012, a statement that uses
 LIMIT and OFFSET, or just OFFSET alone, will be rendered using the
 ``ROW_NUMBER()`` window function.   A statement such as::
 
-    select([some_table]).order_by(some_table.c.col3).limit(5).offset(10)
+    select(some_table).order_by(some_table.c.col3).limit(5).offset(10)
 
 will render similarly to::
 
@@ -1277,9 +1277,9 @@ class TryCast(sql.elements.Cast):
             from sqlalchemy import Numeric
             from sqlalchemy.dialects.mssql import try_cast
 
-            stmt = select([
+            stmt = select(
                 try_cast(product_table.c.unit_price, Numeric(10, 4))
-            ])
+            )
 
         The above would render::
 
@@ -1816,7 +1816,7 @@ class MSSQLCompiler(compiler.SQLCompiler):
 
             mssql_rn = sql.column("mssql_rn")
             limitselect = sql.select(
-                [c for c in select.c if c.key != "mssql_rn"]
+                *[c for c in select.c if c.key != "mssql_rn"]
             )
             if offset_clause is not None:
                 limitselect = limitselect.where(mssql_rn > offset_clause)
@@ -2793,9 +2793,8 @@ class MSDialect(default.DefaultDialect):
 
     @reflection.cache
     def get_schema_names(self, connection, **kw):
-        s = sql.select(
-            [ischema.schemata.c.schema_name],
-            order_by=[ischema.schemata.c.schema_name],
+        s = sql.select(ischema.schemata.c.schema_name).order_by(
+            ischema.schemata.c.schema_name
         )
         schema_names = [r[0] for r in connection.execute(s)]
         return schema_names

--- a/lib/sqlalchemy/dialects/oracle/base.py
+++ b/lib/sqlalchemy/dialects/oracle/base.py
@@ -1057,7 +1057,7 @@ class OracleCompiler(compiler.SQLCompiler):
                 # Wrap the middle select and add the hint
                 inner_subquery = select.alias()
                 limitselect = sql.select(
-                    [
+                    *[
                         c
                         for c in inner_subquery.c
                         if orig_select.selected_columns.corresponding_column(c)
@@ -1140,7 +1140,7 @@ class OracleCompiler(compiler.SQLCompiler):
                     limit_subquery = limitselect.alias()
                     origselect_cols = orig_select.selected_columns
                     offsetselect = sql.select(
-                        [
+                        *[
                             c
                             for c in limit_subquery.c
                             if origselect_cols.corresponding_column(c)

--- a/lib/sqlalchemy/dialects/postgresql/array.py
+++ b/lib/sqlalchemy/dialects/postgresql/array.py
@@ -53,9 +53,7 @@ class array(expression.ClauseList, expression.ColumnElement):
         from sqlalchemy.dialects import postgresql
         from sqlalchemy import select, func
 
-        stmt = select([
-                        array([1,2]) + array([3,4,5])
-                    ])
+        stmt = select(array([1,2]) + array([3,4,5]))
 
         print(stmt.compile(dialect=postgresql.dialect()))
 
@@ -76,11 +74,11 @@ class array(expression.ClauseList, expression.ColumnElement):
     recursively adding the dimensions of the inner :class:`_types.ARRAY`
     type::
 
-        stmt = select([
+        stmt = select(
             array([
                 array([1, 2]), array([3, 4]), array([column('q'), column('x')])
             ])
-        ])
+        )
         print(stmt.compile(dialect=postgresql.dialect()))
 
     Produces::

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -572,7 +572,7 @@ SQLAlchemy makes available the PostgreSQL ``@@`` operator via the
 method on any textual column expression.
 On a PostgreSQL dialect, an expression like the following::
 
-    select([sometable.c.text.match("search string")])
+    select(sometable.c.text.match("search string"))
 
 will emit to the database::
 
@@ -582,9 +582,7 @@ The PostgreSQL text search functions such as ``to_tsquery()``
 and ``to_tsvector()`` are available
 explicitly using the standard :data:`.func` construct.  For example::
 
-    select([
-        func.to_tsvector('fat cats ate rats').match('cat & rat')
-    ])
+    select(func.to_tsvector('fat cats ate rats').match('cat & rat'))
 
 Emits the equivalent of::
 
@@ -594,7 +592,7 @@ The :class:`_postgresql.TSVECTOR` type can provide for explicit CAST::
 
     from sqlalchemy.dialects.postgresql import TSVECTOR
     from sqlalchemy import select, cast
-    select([cast("some text", TSVECTOR)])
+    select(cast("some text", TSVECTOR))
 
 produces a statement equivalent to::
 
@@ -615,7 +613,7 @@ In order to provide for this explicit query planning, or to use different
 search strategies, the ``match`` method accepts a ``postgresql_regconfig``
 keyword argument::
 
-    select([mytable.c.id]).where(
+    select(mytable.c.id).where(
         mytable.c.title.match('somestring', postgresql_regconfig='english')
     )
 
@@ -627,7 +625,7 @@ Emits the equivalent of::
 One can also specifically pass in a `'regconfig'` value to the
 ``to_tsvector()`` command as the initial argument::
 
-    select([mytable.c.id]).where(
+    select(mytable.c.id).where(
             func.to_tsvector('english', mytable.c.title )\
             .match('somestring', postgresql_regconfig='english')
         )
@@ -927,7 +925,7 @@ is not available yet in sqlalchemy, however the
 :func:`_expression.literal_column` function with the name of the table may be
 used in its place::
 
-    select(['*']).select_from(func.my_function(literal_column('my_table')))
+    select('*').select_from(func.my_function(literal_column('my_table')))
 
 Will generate the SQL::
 

--- a/lib/sqlalchemy/dialects/postgresql/ext.py
+++ b/lib/sqlalchemy/dialects/postgresql/ext.py
@@ -22,7 +22,7 @@ class aggregate_order_by(expression.ColumnElement):
 
         from sqlalchemy.dialects.postgresql import aggregate_order_by
         expr = func.array_agg(aggregate_order_by(table.c.a, table.c.b.desc()))
-        stmt = select([expr])
+        stmt = select(expr)
 
     would represent the expression::
 
@@ -34,7 +34,7 @@ class aggregate_order_by(expression.ColumnElement):
             table.c.a,
             aggregate_order_by(literal_column("','"), table.c.a)
         )
-        stmt = select([expr])
+        stmt = select(expr)
 
     Would represent::
 

--- a/lib/sqlalchemy/dialects/postgresql/hstore.py
+++ b/lib/sqlalchemy/dialects/postgresql/hstore.py
@@ -278,14 +278,14 @@ class hstore(sqlfunc.GenericFunction):
 
         from sqlalchemy.dialects.postgresql import array, hstore
 
-        select([hstore('key1', 'value1')])
+        select(hstore('key1', 'value1'))
 
-        select([
-                hstore(
-                    array(['key1', 'key2', 'key3']),
-                    array(['value1', 'value2', 'value3'])
-                )
-            ])
+        select(
+            hstore(
+                array(['key1', 'key2', 'key3']),
+                array(['value1', 'value2', 'value3'])
+            )
+        )
 
     .. seealso::
 

--- a/lib/sqlalchemy/dialects/postgresql/json.py
+++ b/lib/sqlalchemy/dialects/postgresql/json.py
@@ -219,7 +219,7 @@ class JSON(sqltypes.JSON):
 
             E.g.::
 
-                select([data_table.c.data['some key'].astext])
+                select(data_table.c.data['some key'].astext)
 
             .. seealso::
 

--- a/lib/sqlalchemy/engine/create.py
+++ b/lib/sqlalchemy/engine/create.py
@@ -254,8 +254,8 @@ def create_engine(url, **kwargs):
     :param isolation_level: this string parameter is interpreted by various
         dialects in order to affect the transaction isolation level of the
         database connection.   The parameter essentially accepts some subset of
-        these string arguments: ``"SERIALIZABLE"``, ``"REPEATABLE_READ"``,
-        ``"READ_COMMITTED"``, ``"READ_UNCOMMITTED"`` and ``"AUTOCOMMIT"``.
+        these string arguments: ``"SERIALIZABLE"``, ``"REPEATABLE READ"``,
+        ``"READ COMMITTED"``, ``"READ UNCOMMITTED"`` and ``"AUTOCOMMIT"``.
         Behavior here varies per backend, and
         individual dialects should be consulted directly.
 

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -603,7 +603,7 @@ class DefaultDialect(interfaces.Dialect):
 
     @util.memoized_property
     def _dialect_specific_select_one(self):
-        return str(expression.select([1]).compile(dialect=self))
+        return str(expression.select(1).compile(dialect=self))
 
     def do_ping(self, dbapi_connection):
         cursor = None
@@ -1586,9 +1586,7 @@ class DefaultExecutionContext(interfaces.ExecutionContext):
             default_arg = expression.type_coerce(default.arg, type_)
         else:
             default_arg = default.arg
-        compiled = expression.select([default_arg]).compile(
-            dialect=self.dialect
-        )
+        compiled = expression.select(default_arg).compile(dialect=self.dialect)
         compiled_params = compiled.construct_params()
         processors = compiled._bind_processors
         if compiled.positional:

--- a/lib/sqlalchemy/ext/compiler.py
+++ b/lib/sqlalchemy/ext/compiler.py
@@ -31,7 +31,7 @@ when the object is compiled to a string::
 
     from sqlalchemy import select
 
-    s = select([MyColumn('x'), MyColumn('y')])
+    s = select(MyColumn('x'), MyColumn('y'))
     print(str(s))
 
 Produces::
@@ -89,7 +89,7 @@ method which can be used for compilation of embedded attributes::
             compiler.process(element.select, **kw)
         )
 
-    insert = InsertFromSelect(t1, select([t1]).where(t1.c.x>5))
+    insert = InsertFromSelect(t1, select(t1).where(t1.c.x>5))
     print(insert)
 
 Produces::
@@ -393,8 +393,8 @@ Example usage::
     from sqlalchemy import select, union_all
 
     exp = union_all(
-        select([users.c.name, sql_false().label("enrolled")]),
-        select([customers.c.name, customers.c.enrolled])
+        select(users.c.name, sql_false().label("enrolled")),
+        select(customers.c.name, customers.c.enrolled)
     )
 
 """

--- a/lib/sqlalchemy/ext/hybrid.py
+++ b/lib/sqlalchemy/ext/hybrid.py
@@ -384,7 +384,7 @@ we can adjust our ``SavingsAccount`` example to aggregate the balances for
 
         @balance.expression
         def balance(cls):
-            return select([func.sum(SavingsAccount.balance)]).\
+            return select(func.sum(SavingsAccount.balance)).\
                     where(SavingsAccount.user_id==cls.id).\
                     label('total_balance')
 

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -993,6 +993,10 @@ class Query(
             ``populate_existing=True`` option to the
             :meth:`_orm.Query.execution_options` method.
 
+        .. seealso::
+
+            :ref:`session_expire` - in the ORM :class:`_orm.Session`
+            documentation
 
         """
         self.load_options += {"_populate_existing": True}
@@ -1552,11 +1556,18 @@ class Query(
 
         E.g.::
 
-            q = sess.query(User).with_for_update(nowait=True, of=User)
+            q = sess.query(User).populate_existing().with_for_update(nowait=True, of=User)
 
         The above query on a PostgreSQL backend will render like::
 
             SELECT users.id AS users_id FROM users FOR UPDATE OF users NOWAIT
+
+        .. note::  It is generally a good idea to combine the use of the
+           :meth:`_orm.Query.populate_existing` method when using the
+           :meth:`_orm.Query.with_for_update` method.   The purpose of
+           :meth:`_orm.Query.populate_existing` is to force all the data read
+           from the SELECT to be populated into the ORM objects returned,
+           even if these objects are already in the :term:`identity map`.
 
         .. seealso::
 
@@ -1564,7 +1575,11 @@ class Query(
             - Core level method with
             full argument and behavioral description.
 
-        """
+            :meth:`_orm.Query.populate_existing` - overwrites attributes of
+            objects already loaded in the identity map.
+
+        """  # noqa: E501
+
         self._for_update_arg = ForUpdateArg(
             read=read,
             nowait=nowait,

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -956,7 +956,7 @@ class Query(
         """
 
         self._auto_correlate = False
-        if fromclauses and fromclauses[0] is None:
+        if fromclauses and fromclauses[0] in {None, False}:
             self._correlate = ()
         else:
             self._correlate = set(self._correlate).union(
@@ -2374,7 +2374,7 @@ class Query(
         Given a case for :func:`.aliased` such as selecting ``User``
         objects from a SELECT statement::
 
-            select_stmt = select([User]).where(User.id == 7)
+            select_stmt = select(User).where(User.id == 7)
             user_alias = aliased(User, select_stmt)
 
             q = session.query(user_alias).\

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -2137,6 +2137,8 @@ class Session(_SessionClassMethods):
 
             :meth:`.Session.expire_all`
 
+            :meth:`_orm.Query.populate_existing`
+
         """
         try:
             state = attributes.instance_state(instance)
@@ -2201,6 +2203,8 @@ class Session(_SessionClassMethods):
 
             :meth:`.Session.refresh`
 
+            :meth:`_orm.Query.populate_existing`
+
         """
         for state in self.identity_map.all_states():
             state._expire(state.dict, self.identity_map._modified)
@@ -2238,6 +2242,8 @@ class Session(_SessionClassMethods):
             :meth:`.Session.expire`
 
             :meth:`.Session.refresh`
+
+            :meth:`_orm.Query.populate_existing`
 
         """
         try:

--- a/lib/sqlalchemy/orm/util.py
+++ b/lib/sqlalchemy/orm/util.py
@@ -245,22 +245,18 @@ def polymorphic_union(
     result = []
     for type_, table in table_map.items():
         if typecolname is not None:
-            result.append(
-                sql.select(
-                    [col(name, table) for name in colnames]
-                    + [
-                        sql.literal_column(
-                            sql_util._quote_ddl_expr(type_)
-                        ).label(typecolname)
-                    ],
-                    from_obj=[table],
-                )
+            cols = [col(name, table) for name in colnames]
+            cols.append(
+                sql.literal_column(sql_util._quote_ddl_expr(type_)).label(
+                    typecolname
+                ),
             )
+            result.append(sql.select(*cols).select_from(table))
         else:
             result.append(
                 sql.select(
-                    [col(name, table) for name in colnames], from_obj=[table]
-                )
+                    *[col(name, table) for name in colnames]
+                ).select_from(table)
             )
     return sql.union_all(*result).alias(aliasname)
 

--- a/lib/sqlalchemy/sql/base.py
+++ b/lib/sqlalchemy/sql/base.py
@@ -825,7 +825,7 @@ class Executable(Generative):
         The :meth:`execution_options` method is generative.  A new
         instance of this statement is returned that contains the options::
 
-            statement = select([table.c.x, table.c.y])
+            statement = select(table.c.x, table.c.y)
             statement = statement.execution_options(autocommit=True)
 
         Note that only a subset of possible execution options can be applied

--- a/lib/sqlalchemy/sql/ddl.py
+++ b/lib/sqlalchemy/sql/ddl.py
@@ -94,9 +94,11 @@ class DDLElement(roles.DDLRole, Executable, _DDLCompiles):
 
         :param target:
           Optional, defaults to None.  The target :class:`_schema.SchemaItem`
-          for the execute call.  Will be passed to the ``on`` callable if any,
-          and may also provide string expansion data for the statement.
-          See ``execute_at`` for more information.
+          for the execute call.   This is equivalent to passing the
+          :class:`_schema.SchemaItem` to the :meth:`.DDLElement.against`
+          method and then invoking :meth:`_schema.DDLElement.execute`
+          upon the resulting :class:`_schema.DDLElement` object.  See
+          :meth:`.DDLElement.against` for further detail.
 
         """
 
@@ -110,7 +112,37 @@ class DDLElement(roles.DDLRole, Executable, _DDLCompiles):
 
     @_generative
     def against(self, target):
-        """Return a copy of this DDL against a specific schema item."""
+        """Return a copy of this :class:`_schema.DDLElement` which will include
+        the given target.
+
+        This essentially applies the given item to the ``.target`` attribute
+        of the returned :class:`_schema.DDLElement` object.  This target
+        is then usable by event handlers and compilation routines in order to
+        provide services such as tokenization of a DDL string in terms of a
+        particular :class:`_schema.Table`.
+
+        When a :class:`_schema.DDLElement` object is established as an event
+        handler for the :meth:`_events.DDLEvents.before_create` or
+        :meth:`_events.DDLEvents.after_create` events, and the event
+        then occurs for a given target such as a :class:`_schema.Constraint`
+        or :class:`_schema.Table`, that target is established with a copy
+        of the :class:`_schema.DDLElement` object using this method, which
+        then proceeds to the :meth:`_schema.DDLElement.execute` method
+        in order to invoke the actual DDL instruction.
+
+        :param target: a :class:`_schema.SchemaItem` that will be the subject
+         of a DDL operation.
+
+        :return: a copy of this :class:`_schema.DDLElement` with the
+         ``.target`` attribute assigned to the given
+         :class:`_schema.SchemaItem`.
+
+        .. seealso::
+
+            :class:`_schema.DDL` - uses tokenization against the "target" when
+            processing the DDL string.
+
+        """
 
         self.target = target
 

--- a/lib/sqlalchemy/sql/dml.py
+++ b/lib/sqlalchemy/sql/dml.py
@@ -914,7 +914,7 @@ class Insert(ValuesBase):
 
         e.g.::
 
-            sel = select([table1.c.a, table1.c.b]).where(table1.c.c > 5)
+            sel = select(table1.c.a, table1.c.b).where(table1.c.c > 5)
             ins = table2.insert().from_select(['a', 'b'], sel)
 
         :param names: a sequence of string column names or
@@ -1116,7 +1116,7 @@ class Update(DMLWhereBase, ValuesBase):
          subquery::
 
             users.update().values(name='ed').where(
-                    users.c.name==select([addresses.c.email_address]).\
+                    users.c.name==select(addresses.c.email_address).\
                                 where(addresses.c.user_id==users.c.id).\
                                 scalar_subquery()
                     )
@@ -1183,7 +1183,7 @@ class Update(DMLWhereBase, ValuesBase):
         the subquery to the outer table being updated::
 
             users.update().values(
-                    name=select([addresses.c.email_address]).\
+                    name=select(addresses.c.email_address).\
                             where(addresses.c.user_id==users.c.id).\
                             scalar_subquery()
                 )
@@ -1334,7 +1334,7 @@ class Delete(DMLWhereBase, UpdateBase):
          subquery::
 
             users.delete().where(
-                    users.c.name==select([addresses.c.email_address]).\
+                    users.c.name==select(addresses.c.email_address).\
                                 where(addresses.c.user_id==users.c.id).\
                                 scalar_subquery()
                     )

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -81,7 +81,7 @@ def between(expr, lower_bound, upper_bound, symmetric=False):
     E.g.::
 
         from sqlalchemy import between
-        stmt = select([users_table]).where(between(users_table.c.id, 5, 7))
+        stmt = select(users_table).where(between(users_table.c.id, 5, 7))
 
     Would produce SQL resembling::
 
@@ -91,7 +91,7 @@ def between(expr, lower_bound, upper_bound, symmetric=False):
     :meth:`_expression.ColumnElement.between` method available on all
     SQL expressions, as in::
 
-        stmt = select([users_table]).where(users_table.c.id.between(5, 7))
+        stmt = select(users_table).where(users_table.c.id.between(5, 7))
 
     All arguments passed to :func:`.between`, including the left side
     column expression, are coerced from Python scalar values if a
@@ -470,7 +470,7 @@ class ClauseElement(
 
                 t = table('t', column('x'))
 
-                s = select([t]).where(t.c.x == 5)
+                s = select(t).where(t.c.x == 5)
 
                 print(s.compile(compile_kwargs={"literal_binds": True}))
 
@@ -1037,7 +1037,7 @@ class BindParameter(roles.InElementRole, ColumnElement):
 
         from sqlalchemy import bindparam
 
-        stmt = select([users_table]).\
+        stmt = select(users_table).\
                     where(users_table.c.name == bindparam('username'))
 
     Detailed discussion of how :class:`.BindParameter` is used is
@@ -1107,7 +1107,7 @@ class BindParameter(roles.InElementRole, ColumnElement):
 
             from sqlalchemy import bindparam
 
-            stmt = select([users_table]).\
+            stmt = select(users_table).\
                         where(users_table.c.name == bindparam('username'))
 
         The above statement, when rendered, will produce SQL similar to::
@@ -1161,7 +1161,7 @@ class BindParameter(roles.InElementRole, ColumnElement):
         along where it is later used within statement execution.  If we
         invoke a statement like the following::
 
-            stmt = select([users_table]).where(users_table.c.name == 'Wendy')
+            stmt = select(users_table).where(users_table.c.name == 'Wendy')
             result = connection.execute(stmt)
 
         We would see SQL logging output as::
@@ -1625,7 +1625,7 @@ class TextClause(
         a literal string SQL fragment is specified as part of a larger query,
         such as for the WHERE clause of a SELECT statement::
 
-            s = select([users.c.id, users.c.name]).where(text("id=:user_id"))
+            s = select(users.c.id, users.c.name).where(text("id=:user_id"))
             result = connection.execute(s, user_id=12)
 
         :func:`_expression.text` is also used for the construction
@@ -1821,7 +1821,7 @@ class TextClause(
             stmt = text("SELECT id, name FROM some_table")
             stmt = stmt.columns(column('id'), column('name')).subquery('st')
 
-            stmt = select([mytable]).\
+            stmt = select(mytable).\
                     select_from(
                         mytable.join(stmt, mytable.c.name == stmt.c.name)
                     ).where(stmt.c.id > 5)
@@ -1901,7 +1901,7 @@ class TextClause(
 
             stmt = stmt.columns(id=Integer, name=String).cte('st')
 
-            stmt = select([sometable]).where(sometable.c.id == stmt.c.id)
+            stmt = select(sometable).where(sometable.c.id == stmt.c.id)
 
         :param \*cols: A series of :class:`_expression.ColumnElement` objects,
          typically
@@ -2000,23 +2000,23 @@ class False_(SingletonConstant, roles.ConstExprRole, ColumnElement):
         E.g.::
 
             >>> from sqlalchemy import false
-            >>> print(select([t.c.x]).where(false()))
+            >>> print(select(t.c.x).where(false()))
             SELECT x FROM t WHERE false
 
         A backend which does not support true/false constants will render as
         an expression against 1 or 0::
 
-            >>> print(select([t.c.x]).where(false()))
+            >>> print(select(t.c.x).where(false()))
             SELECT x FROM t WHERE 0 = 1
 
         The :func:`.true` and :func:`.false` constants also feature
         "short circuit" operation within an :func:`.and_` or :func:`.or_`
         conjunction::
 
-            >>> print(select([t.c.x]).where(or_(t.c.x > 5, true())))
+            >>> print(select(t.c.x).where(or_(t.c.x > 5, true())))
             SELECT x FROM t WHERE true
 
-            >>> print(select([t.c.x]).where(and_(t.c.x > 5, false())))
+            >>> print(select(t.c.x).where(and_(t.c.x > 5, false())))
             SELECT x FROM t WHERE false
 
         .. versionchanged:: 0.9 :func:`.true` and :func:`.false` feature
@@ -2068,23 +2068,23 @@ class True_(SingletonConstant, roles.ConstExprRole, ColumnElement):
         E.g.::
 
             >>> from sqlalchemy import true
-            >>> print(select([t.c.x]).where(true()))
+            >>> print(select(t.c.x).where(true()))
             SELECT x FROM t WHERE true
 
         A backend which does not support true/false constants will render as
         an expression against 1 or 0::
 
-            >>> print(select([t.c.x]).where(true()))
+            >>> print(select(t.c.x).where(true()))
             SELECT x FROM t WHERE 1 = 1
 
         The :func:`.true` and :func:`.false` constants also feature
         "short circuit" operation within an :func:`.and_` or :func:`.or_`
         conjunction::
 
-            >>> print(select([t.c.x]).where(or_(t.c.x > 5, true())))
+            >>> print(select(t.c.x).where(or_(t.c.x > 5, true())))
             SELECT x FROM t WHERE true
 
-            >>> print(select([t.c.x]).where(and_(t.c.x > 5, false())))
+            >>> print(select(t.c.x).where(and_(t.c.x > 5, false())))
             SELECT x FROM t WHERE false
 
         .. versionchanged:: 0.9 :func:`.true` and :func:`.false` feature
@@ -2327,7 +2327,7 @@ class BooleanClauseList(ClauseList, ColumnElement):
 
             from sqlalchemy import and_
 
-            stmt = select([users_table]).where(
+            stmt = select(users_table).where(
                             and_(
                                 users_table.c.name == 'wendy',
                                 users_table.c.enrolled == True
@@ -2339,7 +2339,7 @@ class BooleanClauseList(ClauseList, ColumnElement):
         need to be parenthesized in order to function with Python
         operator precedence behavior)::
 
-            stmt = select([users_table]).where(
+            stmt = select(users_table).where(
                             (users_table.c.name == 'wendy') &
                             (users_table.c.enrolled == True)
                         )
@@ -2350,7 +2350,7 @@ class BooleanClauseList(ClauseList, ColumnElement):
         times against a statement, which will have the effect of each
         clause being combined using :func:`.and_`::
 
-            stmt = select([users_table]).\
+            stmt = select(users_table).\
                     where(users_table.c.name == 'wendy').\
                     where(users_table.c.enrolled == True)
 
@@ -2390,7 +2390,7 @@ class BooleanClauseList(ClauseList, ColumnElement):
 
             from sqlalchemy import or_
 
-            stmt = select([users_table]).where(
+            stmt = select(users_table).where(
                             or_(
                                 users_table.c.name == 'wendy',
                                 users_table.c.name == 'jack'
@@ -2402,7 +2402,7 @@ class BooleanClauseList(ClauseList, ColumnElement):
         need to be parenthesized in order to function with Python
         operator precedence behavior)::
 
-            stmt = select([users_table]).where(
+            stmt = select(users_table).where(
                             (users_table.c.name == 'wendy') |
                             (users_table.c.name == 'jack')
                         )
@@ -2536,7 +2536,7 @@ class Case(ColumnElement):
 
         from sqlalchemy import case
 
-        stmt = select([users_table]).\
+        stmt = select(users_table).\
                     where(
                         case(
                             (users_table.c.name == 'wendy', 'W'),
@@ -2576,7 +2576,7 @@ class Case(ColumnElement):
 
             from sqlalchemy import case
 
-            stmt = select([users_table]).\
+            stmt = select(users_table).\
                         where(
                             case(
                                 (users_table.c.name == 'wendy', 'W'),
@@ -2603,7 +2603,7 @@ class Case(ColumnElement):
         compared against keyed to result expressions.  The statement below is
         equivalent to the preceding statement::
 
-            stmt = select([users_table]).\
+            stmt = select(users_table).\
                         where(
                             case(
                                 {"wendy": "W", "jack": "J"},
@@ -2800,9 +2800,7 @@ class Cast(WrapsColumnExpression, ColumnElement):
 
         from sqlalchemy import cast, Numeric
 
-        stmt = select([
-                    cast(product_table.c.unit_price, Numeric(10, 4))
-                ])
+        stmt = select(cast(product_table.c.unit_price, Numeric(10, 4)))
 
     Details on :class:`.Cast` usage is at :func:`.cast`.
 
@@ -2834,9 +2832,7 @@ class Cast(WrapsColumnExpression, ColumnElement):
 
             from sqlalchemy import cast, Numeric
 
-            stmt = select([
-                        cast(product_table.c.unit_price, Numeric(10, 4))
-                    ])
+            stmt = select(cast(product_table.c.unit_price, Numeric(10, 4)))
 
         The above statement will produce SQL resembling::
 
@@ -2930,7 +2926,7 @@ class TypeCoerce(WrapsColumnExpression, ColumnElement):
 
             from sqlalchemy import type_coerce
 
-            stmt = select([type_coerce(log_table.date_string, StringDateTime())])
+            stmt = select(type_coerce(log_table.date_string, StringDateTime()))
 
         The above construct will produce a :class:`.TypeCoerce` object, which
         does not modify the rendering in any way on the SQL side, with the
@@ -2950,9 +2946,9 @@ class TypeCoerce(WrapsColumnExpression, ColumnElement):
         In order to provide a named label for the expression, use
         :meth:`_expression.ColumnElement.label`::
 
-            stmt = select([
+            stmt = select(
                 type_coerce(log_table.date_string, StringDateTime()).label('date')
-            ])
+            )
 
 
         A type that features bound-value handling will also have that behavior
@@ -2966,7 +2962,7 @@ class TypeCoerce(WrapsColumnExpression, ColumnElement):
 
             # bound-value handling of MyStringType will be applied to the
             # literal value "some string"
-            stmt = select([type_coerce("some string", MyStringType)])
+            stmt = select(type_coerce("some string", MyStringType))
 
         When using :func:`.type_coerce` with composed expressions, note that
         **parenthesis are not applied**.   If :func:`.type_coerce` is being
@@ -3145,7 +3141,7 @@ class UnaryExpression(ColumnElement):
 
             from sqlalchemy import desc, nullsfirst
 
-            stmt = select([users_table]).order_by(
+            stmt = select(users_table).order_by(
                 nullsfirst(desc(users_table.c.name)))
 
         The SQL expression from the above would resemble::
@@ -3158,7 +3154,7 @@ class UnaryExpression(ColumnElement):
         rather than as its standalone
         function version, as in::
 
-            stmt = select([users_table]).order_by(
+            stmt = select(users_table).order_by(
                 users_table.c.name.desc().nullsfirst())
 
         .. seealso::
@@ -3189,7 +3185,7 @@ class UnaryExpression(ColumnElement):
 
             from sqlalchemy import desc, nullslast
 
-            stmt = select([users_table]).order_by(
+            stmt = select(users_table).order_by(
                 nullslast(desc(users_table.c.name)))
 
         The SQL expression from the above would resemble::
@@ -3202,7 +3198,7 @@ class UnaryExpression(ColumnElement):
         rather than as its standalone
         function version, as in::
 
-            stmt = select([users_table]).order_by(
+            stmt = select(users_table).order_by(
                 users_table.c.name.desc().nullslast())
 
         .. seealso::
@@ -3230,7 +3226,7 @@ class UnaryExpression(ColumnElement):
 
             from sqlalchemy import desc
 
-            stmt = select([users_table]).order_by(desc(users_table.c.name))
+            stmt = select(users_table).order_by(desc(users_table.c.name))
 
         will produce SQL as::
 
@@ -3242,7 +3238,7 @@ class UnaryExpression(ColumnElement):
         e.g.::
 
 
-            stmt = select([users_table]).order_by(users_table.c.name.desc())
+            stmt = select(users_table).order_by(users_table.c.name.desc())
 
         :param column: A :class:`_expression.ColumnElement` (e.g.
          scalar SQL expression)
@@ -3272,7 +3268,7 @@ class UnaryExpression(ColumnElement):
         e.g.::
 
             from sqlalchemy import asc
-            stmt = select([users_table]).order_by(asc(users_table.c.name))
+            stmt = select(users_table).order_by(asc(users_table.c.name))
 
         will produce SQL as::
 
@@ -3284,7 +3280,7 @@ class UnaryExpression(ColumnElement):
         e.g.::
 
 
-            stmt = select([users_table]).order_by(users_table.c.name.asc())
+            stmt = select(users_table).order_by(users_table.c.name.asc())
 
         :param column: A :class:`_expression.ColumnElement` (e.g.
          scalar SQL expression)
@@ -3316,7 +3312,7 @@ class UnaryExpression(ColumnElement):
         as in::
 
             from sqlalchemy import distinct, func
-            stmt = select([func.count(distinct(users_table.c.name))])
+            stmt = select(func.count(distinct(users_table.c.name)))
 
         The above would produce an expression resembling::
 
@@ -3325,7 +3321,7 @@ class UnaryExpression(ColumnElement):
         The :func:`.distinct` function is also available as a column-level
         method, e.g. :meth:`_expression.ColumnElement.distinct`, as in::
 
-            stmt = select([func.count(users_table.c.name.distinct())])
+            stmt = select(func.count(users_table.c.name.distinct()))
 
         The :func:`.distinct` operator is different from the
         :meth:`_expression.Select.distinct` method of
@@ -3403,7 +3399,7 @@ class CollectionAggregate(UnaryExpression):
             expr = 5 == any_(mytable.c.somearray)
 
             # mysql '5 = ANY (SELECT value FROM table)'
-            expr = 5 == any_(select([table.c.value]))
+            expr = 5 == any_(select(table.c.value))
 
         .. versionadded:: 1.1
 
@@ -3434,7 +3430,7 @@ class CollectionAggregate(UnaryExpression):
             expr = 5 == all_(mytable.c.somearray)
 
             # mysql '5 = ALL (SELECT value FROM table)'
-            expr = 5 == all_(select([table.c.value]))
+            expr = 5 == all_(select(table.c.value))
 
         .. versionadded:: 1.1
 
@@ -3933,12 +3929,12 @@ class WithinGroup(ColumnElement):
         the :meth:`.FunctionElement.within_group` method, e.g.::
 
             from sqlalchemy import within_group
-            stmt = select([
+            stmt = select(
                 department.c.id,
                 func.percentile_cont(0.5).within_group(
                     department.c.salary.desc()
                 )
-            ])
+            )
 
         The above statement would produce SQL similar to
         ``SELECT department.id, percentile_cont(0.5)
@@ -4279,7 +4275,7 @@ class ColumnClause(
         from sqlalchemy import column
 
         id, name = column("id"), column("name")
-        stmt = select([id, name]).select_from("user")
+        stmt = select(id, name).select_from("user")
 
     The above statement would produce SQL like::
 
@@ -4331,7 +4327,7 @@ class ColumnClause(
             from sqlalchemy import column
 
             id, name = column("id"), column("name")
-            stmt = select([id, name]).select_from("user")
+            stmt = select(id, name).select_from("user")
 
         The above statement would produce SQL like::
 
@@ -4345,7 +4341,7 @@ class ColumnClause(
             from sqlalchemy.sql import column
 
             id, name = column("id"), column("name")
-            stmt = select([id, name]).select_from("user")
+            stmt = select(id, name).select_from("user")
 
         The text handled by :func:`_expression.column`
         is assumed to be handled
@@ -4375,7 +4371,7 @@ class ColumnClause(
                     column("description"),
             )
 
-            stmt = select([user.c.description]).where(user.c.name == 'wendy')
+            stmt = select(user.c.description).where(user.c.name == 'wendy')
 
         A :func:`_expression.column` / :func:`.table`
         construct like that illustrated

--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -137,7 +137,7 @@ class FunctionElement(Executable, ColumnElement, FromClause):
 
             from sqlalchemy.sql import column
 
-            stmt = select([column('x'), column('y')]).\
+            stmt = select(column('x'), column('y')).\
                 select_from(func.myfunction())
 
 
@@ -317,7 +317,7 @@ class FunctionElement(Executable, ColumnElement, FromClause):
 
             from sqlalchemy.sql import column
 
-            stmt = select([column('data_view')]).\
+            stmt = select(column('data_view')).\
                 select_from(SomeTable).\
                 select_from(func.unnest(SomeTable.data).alias('data_view')
             )
@@ -343,7 +343,7 @@ class FunctionElement(Executable, ColumnElement, FromClause):
 
         This is shorthand for::
 
-            s = select([function_element])
+            s = select(function_element)
 
         """
         s = Select._create_select(self)
@@ -453,7 +453,7 @@ class _FunctionGenerator(object):
     The returned object is an instance of :class:`.Function`, and  is a
     column-oriented SQL element like any other, and is used in that way::
 
-        >>> print(select([func.count(table.c.id)]))
+        >>> print(select(func.count(table.c.id)))
         SELECT count(sometable.id) FROM sometable
 
     Any name can be given to :data:`.func`. If the function name is unknown to
@@ -680,7 +680,7 @@ class GenericFunction(util.with_metaclass(_GenericMeta, Function)):
         class as_utc(GenericFunction):
             type = DateTime
 
-        print(select([func.as_utc()]))
+        print(select(func.as_utc()))
 
     User-defined generic functions can be organized into
     packages by specifying the "package" attribute when defining
@@ -697,7 +697,7 @@ class GenericFunction(util.with_metaclass(_GenericMeta, Function)):
     The above function would be available from :data:`.func`
     using the package name ``time``::
 
-        print(select([func.time.as_utc()]))
+        print(select(func.time.as_utc()))
 
     A final option is to allow the function to be accessed
     from one name in :data:`.func` but to render as a different name.
@@ -887,7 +887,7 @@ class count(GenericFunction):
 
         my_table = table('some_table', column('id'))
 
-        stmt = select([func.count()]).select_from(my_table)
+        stmt = select(func.count()).select_from(my_table)
 
     Executing ``stmt`` would emit::
 
@@ -958,7 +958,7 @@ class array_agg(GenericFunction):
 
     e.g.::
 
-        stmt = select([func.array_agg(table.c.values)[2:5]])
+        stmt = select(func.array_agg(table.c.values)[2:5])
 
     .. versionadded:: 1.1
 
@@ -1132,8 +1132,8 @@ class cube(GenericFunction):
     e.g. :meth:`_expression.Select.group_by`::
 
         stmt = select(
-            [func.sum(table.c.value), table.c.col_1, table.c.col_2]
-            ).group_by(func.cube(table.c.col_1, table.c.col_2))
+            func.sum(table.c.value), table.c.col_1, table.c.col_2
+        ).group_by(func.cube(table.c.col_1, table.c.col_2))
 
     .. versionadded:: 1.2
 
@@ -1149,7 +1149,7 @@ class rollup(GenericFunction):
     e.g. :meth:`_expression.Select.group_by`::
 
         stmt = select(
-            [func.sum(table.c.value), table.c.col_1, table.c.col_2]
+            func.sum(table.c.value), table.c.col_1, table.c.col_2
         ).group_by(func.rollup(table.c.col_1, table.c.col_2))
 
     .. versionadded:: 1.2
@@ -1166,7 +1166,7 @@ class grouping_sets(GenericFunction):
     e.g. :meth:`_expression.Select.group_by`::
 
         stmt = select(
-            [func.sum(table.c.value), table.c.col_1, table.c.col_2]
+            func.sum(table.c.value), table.c.col_1, table.c.col_2
         ).group_by(func.grouping_sets(table.c.col_1, table.c.col_2))
 
     In order to group by multiple sets, use the :func:`.tuple_` construct::
@@ -1174,10 +1174,9 @@ class grouping_sets(GenericFunction):
         from sqlalchemy import tuple_
 
         stmt = select(
-            [
-                func.sum(table.c.value),
-                table.c.col_1, table.c.col_2,
-                table.c.col_3]
+            func.sum(table.c.value),
+            table.c.col_1, table.c.col_2,
+            table.c.col_3
         ).group_by(
             func.grouping_sets(
                 tuple_(table.c.col_1, table.c.col_2),

--- a/lib/sqlalchemy/sql/operators.py
+++ b/lib/sqlalchemy/sql/operators.py
@@ -462,7 +462,7 @@ class ColumnOperators(Operators):
 
         E.g.::
 
-            stmt = select([sometable]).\
+            stmt = select(sometable).\
                 where(sometable.c.column.like("%foobar%"))
 
         :param other: expression to be compared
@@ -491,7 +491,7 @@ class ColumnOperators(Operators):
 
         E.g.::
 
-            stmt = select([sometable]).\
+            stmt = select(sometable).\
                 where(sometable.c.column.ilike("%foobar%"))
 
         :param other: expression to be compared
@@ -579,7 +579,7 @@ class ColumnOperators(Operators):
 
             stmt.where(
                 column.in_(
-                    select([othertable.c.y]).
+                    select(othertable.c.y).
                     where(table.c.x == othertable.c.x)
                 )
             )
@@ -682,7 +682,7 @@ class ColumnOperators(Operators):
 
         E.g.::
 
-            stmt = select([sometable]).\
+            stmt = select(sometable).\
                 where(sometable.c.column.startswith("foobar"))
 
         Since the operator uses ``LIKE``, wildcard characters
@@ -761,7 +761,7 @@ class ColumnOperators(Operators):
 
         E.g.::
 
-            stmt = select([sometable]).\
+            stmt = select(sometable).\
                 where(sometable.c.column.endswith("foobar"))
 
         Since the operator uses ``LIKE``, wildcard characters
@@ -840,7 +840,7 @@ class ColumnOperators(Operators):
 
         E.g.::
 
-            stmt = select([sometable]).\
+            stmt = select(sometable).\
                 where(sometable.c.column.contains("foobar"))
 
         Since the operator uses ``LIKE``, wildcard characters
@@ -1115,7 +1115,7 @@ class ColumnOperators(Operators):
             expr = 5 == mytable.c.somearray.any_()
 
             # mysql '5 = ANY (SELECT value FROM table)'
-            expr = 5 == select([table.c.value]).scalar_subquery().any_()
+            expr = 5 == select(table.c.value).scalar_subquery().any_()
 
         .. seealso::
 
@@ -1140,7 +1140,7 @@ class ColumnOperators(Operators):
             expr = 5 == mytable.c.somearray.all_()
 
             # mysql '5 = ALL (SELECT value FROM table)'
-            expr = 5 == select([table.c.value]).scalar_subquery().all_()
+            expr = 5 == select(table.c.value).scalar_subquery().all_()
 
         .. seealso::
 

--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -3995,8 +3995,9 @@ class MetaData(SchemaItem):
             class
 
           * a string mnemonic for one of the known constraint classes;
-            ``"fk"``, ``"pk"``, ``"ix"``, ``"ck"``, ``"uq"`` for foreign key,
-            primary key, index, check, and unique constraint, respectively.
+            ``"fk"``, ``"pk"``, ``"ix"``, ``"ck"``, ``"type_ck"``, ``"uq"`` for
+            foreign key, primary key, index, check, type_check, and unique
+            constraint, respectively.
 
           * the string name of a user-defined "token" that can be used
             to define new naming tokens.

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -4108,9 +4108,11 @@ class Select(
           column with its parent table's (or aliases) name so that name
           conflicts between columns in different tables don't occur.
           The format of the label is ``<tablename>_<column>``.  The "c"
-          collection of the resulting :class:`_expression.Select`
-          object will use these
-          names as well for targeting column members.
+          collection of a :class:`_expression.Subquery` created
+          against this :class:`_expression.Select`
+          object, as well as the :attr:`_expression.Select.selected_columns`
+          collection of the :class:`_expression.Select` itself, will use these
+          names for targeting column members.
 
           This parameter can also be specified on an existing
           :class:`_expression.Select` object using the

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -239,7 +239,7 @@ class String(Concatenable, TypeEngine):
           E.g.::
 
             >>> from sqlalchemy import cast, select, String
-            >>> print(select([cast('some string', String(collation='utf8'))]))
+            >>> print(select(cast('some string', String(collation='utf8'))))
             SELECT CAST(:param_1 AS VARCHAR COLLATE utf8) AS anon_1
 
         :param convert_unicode: When set to ``True``, the
@@ -2394,9 +2394,9 @@ class JSON(Indexable, TypeEngine):
 
             e.g.::
 
-                stmt = select([
+                stmt = select(
                     mytable.c.json_column['some_data'].as_boolean()
-                ]).where(
+                ).where(
                     mytable.c.json_column['some_data'].as_boolean() == True
                 )
 
@@ -2410,9 +2410,9 @@ class JSON(Indexable, TypeEngine):
 
             e.g.::
 
-                stmt = select([
+                stmt = select(
                     mytable.c.json_column['some_data'].as_string()
-                ]).where(
+                ).where(
                     mytable.c.json_column['some_data'].as_string() ==
                     'some string'
                 )
@@ -2427,9 +2427,9 @@ class JSON(Indexable, TypeEngine):
 
             e.g.::
 
-                stmt = select([
+                stmt = select(
                     mytable.c.json_column['some_data'].as_integer()
-                ]).where(
+                ).where(
                     mytable.c.json_column['some_data'].as_integer() == 5
                 )
 
@@ -2443,9 +2443,9 @@ class JSON(Indexable, TypeEngine):
 
             e.g.::
 
-                stmt = select([
+                stmt = select(
                     mytable.c.json_column['some_data'].as_float()
-                ]).where(
+                ).where(
                     mytable.c.json_column['some_data'].as_float() == 29.75
                 )
 
@@ -2460,9 +2460,7 @@ class JSON(Indexable, TypeEngine):
 
             e.g.::
 
-                stmt = select([
-                    mytable.c.json_column['some_data'].as_json()
-                ])
+                stmt = select(mytable.c.json_column['some_data'].as_json())
 
             This is typically the default behavior of indexed elements in any
             case.
@@ -2614,7 +2612,7 @@ class ARRAY(SchemaEventTarget, Indexable, Concatenable, TypeEngine):
     constructs which will produce the appropriate SQL, both for
     SELECT statements::
 
-        select([mytable.c.data[5], mytable.c.data[2:7]])
+        select(mytable.c.data[5], mytable.c.data[2:7])
 
     as well as UPDATE statements when the :meth:`_expression.Update.values`
     method
@@ -2693,7 +2691,7 @@ class ARRAY(SchemaEventTarget, Indexable, Concatenable, TypeEngine):
                 from sqlalchemy.sql import operators
 
                 conn.execute(
-                    select([table.c.data]).where(
+                    select(table.c.data).where(
                             table.c.data.any(7, operator=operators.lt)
                         )
                 )
@@ -2733,7 +2731,7 @@ class ARRAY(SchemaEventTarget, Indexable, Concatenable, TypeEngine):
                 from sqlalchemy.sql import operators
 
                 conn.execute(
-                    select([table.c.data]).where(
+                    select(table.c.data).where(
                             table.c.data.all(7, operator=operators.lt)
                         )
                 )

--- a/lib/sqlalchemy/sql/visitors.py
+++ b/lib/sqlalchemy/sql/visitors.py
@@ -664,7 +664,7 @@ def traverse(obj, opts, visitors):
 
         from sqlalchemy.sql import visitors
 
-        stmt = select([some_table]).where(some_table.c.foo == 'bar')
+        stmt = select(some_table).where(some_table.c.foo == 'bar')
 
         def visit_bindparam(bind_param):
             print("found bound value: %s" % bind_param.value)

--- a/lib/sqlalchemy/testing/requirements.py
+++ b/lib/sqlalchemy/testing/requirements.py
@@ -851,7 +851,7 @@ class SuiteRequirements(Requirements):
             expr = decimal.Decimal("15.7563")
 
             value = e.scalar(
-                select([literal(expr)])
+                select(literal(expr))
             )
 
             assert value == expr

--- a/lib/sqlalchemy/testing/suite/test_cte.py
+++ b/lib/sqlalchemy/testing/suite/test_cte.py
@@ -53,12 +53,12 @@ class CTETest(fixtures.TablesTest):
 
         with config.db.connect() as conn:
             cte = (
-                select([some_table])
+                select(some_table)
                 .where(some_table.c.data.in_(["d2", "d3", "d4"]))
                 .cte("some_cte")
             )
             result = conn.execute(
-                select([cte.c.data]).where(cte.c.data.in_(["d4", "d5"]))
+                select(cte.c.data).where(cte.c.data.in_(["d4", "d5"]))
             )
             eq_(result.fetchall(), [("d4",)])
 
@@ -67,7 +67,7 @@ class CTETest(fixtures.TablesTest):
 
         with config.db.connect() as conn:
             cte = (
-                select([some_table])
+                select(some_table)
                 .where(some_table.c.data.in_(["d2", "d3", "d4"]))
                 .cte("some_cte", recursive=True)
             )
@@ -77,10 +77,10 @@ class CTETest(fixtures.TablesTest):
             # note that SQL Server requires this to be UNION ALL,
             # can't be UNION
             cte = cte.union_all(
-                select([st1]).where(st1.c.id == cte_alias.c.parent_id)
+                select(st1).where(st1.c.id == cte_alias.c.parent_id)
             )
             result = conn.execute(
-                select([cte.c.data])
+                select(cte.c.data)
                 .where(cte.c.data != "d2")
                 .order_by(cte.c.data.desc())
             )
@@ -95,18 +95,18 @@ class CTETest(fixtures.TablesTest):
 
         with config.db.connect() as conn:
             cte = (
-                select([some_table])
+                select(some_table)
                 .where(some_table.c.data.in_(["d2", "d3", "d4"]))
                 .cte("some_cte")
             )
             conn.execute(
                 some_other_table.insert().from_select(
-                    ["id", "data", "parent_id"], select([cte])
+                    ["id", "data", "parent_id"], select(cte)
                 )
             )
             eq_(
                 conn.execute(
-                    select([some_other_table]).order_by(some_other_table.c.id)
+                    select(some_other_table).order_by(some_other_table.c.id)
                 ).fetchall(),
                 [(2, "d2", 1), (3, "d3", 1), (4, "d4", 3)],
             )
@@ -120,12 +120,12 @@ class CTETest(fixtures.TablesTest):
         with config.db.connect() as conn:
             conn.execute(
                 some_other_table.insert().from_select(
-                    ["id", "data", "parent_id"], select([some_table])
+                    ["id", "data", "parent_id"], select(some_table)
                 )
             )
 
             cte = (
-                select([some_table])
+                select(some_table)
                 .where(some_table.c.data.in_(["d2", "d3", "d4"]))
                 .cte("some_cte")
             )
@@ -136,7 +136,7 @@ class CTETest(fixtures.TablesTest):
             )
             eq_(
                 conn.execute(
-                    select([some_other_table]).order_by(some_other_table.c.id)
+                    select(some_other_table).order_by(some_other_table.c.id)
                 ).fetchall(),
                 [
                     (1, "d1", None),
@@ -156,12 +156,12 @@ class CTETest(fixtures.TablesTest):
         with config.db.connect() as conn:
             conn.execute(
                 some_other_table.insert().from_select(
-                    ["id", "data", "parent_id"], select([some_table])
+                    ["id", "data", "parent_id"], select(some_table)
                 )
             )
 
             cte = (
-                select([some_table])
+                select(some_table)
                 .where(some_table.c.data.in_(["d2", "d3", "d4"]))
                 .cte("some_cte")
             )
@@ -172,7 +172,7 @@ class CTETest(fixtures.TablesTest):
             )
             eq_(
                 conn.execute(
-                    select([some_other_table]).order_by(some_other_table.c.id)
+                    select(some_other_table).order_by(some_other_table.c.id)
                 ).fetchall(),
                 [(1, "d1", None), (5, "d5", 3)],
             )
@@ -186,26 +186,26 @@ class CTETest(fixtures.TablesTest):
         with config.db.connect() as conn:
             conn.execute(
                 some_other_table.insert().from_select(
-                    ["id", "data", "parent_id"], select([some_table])
+                    ["id", "data", "parent_id"], select(some_table)
                 )
             )
 
             cte = (
-                select([some_table])
+                select(some_table)
                 .where(some_table.c.data.in_(["d2", "d3", "d4"]))
                 .cte("some_cte")
             )
             conn.execute(
                 some_other_table.delete().where(
                     some_other_table.c.data
-                    == select([cte.c.data])
+                    == select(cte.c.data)
                     .where(cte.c.id == some_other_table.c.id)
                     .scalar_subquery()
                 )
             )
             eq_(
                 conn.execute(
-                    select([some_other_table]).order_by(some_other_table.c.id)
+                    select(some_other_table).order_by(some_other_table.c.id)
                 ).fetchall(),
                 [(1, "d1", None), (5, "d5", 3)],
             )

--- a/lib/sqlalchemy/testing/suite/test_deprecations.py
+++ b/lib/sqlalchemy/testing/suite/test_deprecations.py
@@ -38,8 +38,8 @@ class DeprecatedCompoundSelectTest(fixtures.TablesTest):
 
     def test_plain_union(self, connection):
         table = self.tables.some_table
-        s1 = select([table]).where(table.c.id == 2)
-        s2 = select([table]).where(table.c.id == 3)
+        s1 = select(table).where(table.c.id == 2)
+        s2 = select(table).where(table.c.id == 3)
 
         u1 = union(s1, s2)
         with testing.expect_deprecated(
@@ -59,8 +59,8 @@ class DeprecatedCompoundSelectTest(fixtures.TablesTest):
     # it before.
     def _dont_test_select_from_plain_union(self, connection):
         table = self.tables.some_table
-        s1 = select([table]).where(table.c.id == 2)
-        s2 = select([table]).where(table.c.id == 3)
+        s1 = select(table).where(table.c.id == 2)
+        s2 = select(table).where(table.c.id == 3)
 
         u1 = union(s1, s2).alias().select()
         with testing.expect_deprecated(
@@ -75,18 +75,8 @@ class DeprecatedCompoundSelectTest(fixtures.TablesTest):
     @testing.requires.parens_in_union_contained_select_w_limit_offset
     def test_limit_offset_selectable_in_unions(self, connection):
         table = self.tables.some_table
-        s1 = (
-            select([table])
-            .where(table.c.id == 2)
-            .limit(1)
-            .order_by(table.c.id)
-        )
-        s2 = (
-            select([table])
-            .where(table.c.id == 3)
-            .limit(1)
-            .order_by(table.c.id)
-        )
+        s1 = select(table).where(table.c.id == 2).limit(1).order_by(table.c.id)
+        s2 = select(table).where(table.c.id == 3).limit(1).order_by(table.c.id)
 
         u1 = union(s1, s2).limit(2)
         with testing.expect_deprecated(
@@ -100,8 +90,8 @@ class DeprecatedCompoundSelectTest(fixtures.TablesTest):
     @testing.requires.parens_in_union_contained_select_wo_limit_offset
     def test_order_by_selectable_in_unions(self, connection):
         table = self.tables.some_table
-        s1 = select([table]).where(table.c.id == 2).order_by(table.c.id)
-        s2 = select([table]).where(table.c.id == 3).order_by(table.c.id)
+        s1 = select(table).where(table.c.id == 2).order_by(table.c.id)
+        s2 = select(table).where(table.c.id == 3).order_by(table.c.id)
 
         u1 = union(s1, s2).limit(2)
         with testing.expect_deprecated(
@@ -114,8 +104,8 @@ class DeprecatedCompoundSelectTest(fixtures.TablesTest):
 
     def test_distinct_selectable_in_unions(self, connection):
         table = self.tables.some_table
-        s1 = select([table]).where(table.c.id == 2).distinct()
-        s2 = select([table]).where(table.c.id == 3).distinct()
+        s1 = select(table).where(table.c.id == 2).distinct()
+        s2 = select(table).where(table.c.id == 3).distinct()
 
         u1 = union(s1, s2).limit(2)
         with testing.expect_deprecated(
@@ -129,7 +119,7 @@ class DeprecatedCompoundSelectTest(fixtures.TablesTest):
     def test_limit_offset_aliased_selectable_in_unions(self, connection):
         table = self.tables.some_table
         s1 = (
-            select([table])
+            select(table)
             .where(table.c.id == 2)
             .limit(1)
             .order_by(table.c.id)
@@ -137,7 +127,7 @@ class DeprecatedCompoundSelectTest(fixtures.TablesTest):
             .select()
         )
         s2 = (
-            select([table])
+            select(table)
             .where(table.c.id == 3)
             .limit(1)
             .order_by(table.c.id)

--- a/lib/sqlalchemy/testing/suite/test_dialect.py
+++ b/lib/sqlalchemy/testing/suite/test_dialect.py
@@ -65,7 +65,7 @@ class ExceptionTest(fixtures.TablesTest):
                 # there's no way to make this happen with some drivers like
                 # mysqlclient, pymysql.  this at least does produce a non-
                 # ascii error message for cx_oracle, psycopg2
-                conn.execute(select([literal_column(u"méil")]))
+                conn.execute(select(literal_column(u"méil")))
                 assert False
             except exc.DBAPIError as err:
                 err_str = str(err)
@@ -146,7 +146,7 @@ class AutocommitTest(fixtures.TablesTest):
         trans.rollback()
 
         eq_(
-            conn.scalar(select([self.tables.some_table.c.id])),
+            conn.scalar(select(self.tables.some_table.c.id)),
             1 if autocommit else None,
         )
 
@@ -194,7 +194,7 @@ class EscapingTest(fixtures.TestBase):
 
             eq_(
                 conn.scalar(
-                    select([t.c.data]).where(
+                    select(t.c.data).where(
                         t.c.data == literal_column("'some % value'")
                     )
                 ),
@@ -203,7 +203,7 @@ class EscapingTest(fixtures.TestBase):
 
             eq_(
                 conn.scalar(
-                    select([t.c.data]).where(
+                    select(t.c.data).where(
                         t.c.data == literal_column("'some %% other value'")
                     )
                 ),

--- a/lib/sqlalchemy/testing/suite/test_insert.py
+++ b/lib/sqlalchemy/testing/suite/test_insert.py
@@ -55,7 +55,7 @@ class LastrowidTest(fixtures.TablesTest):
         r = connection.execute(
             self.tables.autoinc_pk.insert(), data="some data"
         )
-        pk = connection.scalar(select([self.tables.autoinc_pk.c.id]))
+        pk = connection.scalar(select(self.tables.autoinc_pk.c.id))
         eq_(r.inserted_primary_key, (pk,))
 
     @requirements.dbapi_lastrowid
@@ -64,7 +64,7 @@ class LastrowidTest(fixtures.TablesTest):
             self.tables.autoinc_pk.insert(), data="some data"
         )
         lastrowid = r.lastrowid
-        pk = connection.scalar(select([self.tables.autoinc_pk.c.id]))
+        pk = connection.scalar(select(self.tables.autoinc_pk.c.id))
         eq_(lastrowid, pk)
 
 
@@ -178,7 +178,7 @@ class InsertBehaviorTest(fixtures.TablesTest):
         result = connection.execute(
             dest_table.insert().from_select(
                 ("data",),
-                select([src_table.c.data]).where(
+                select(src_table.c.data).where(
                     src_table.c.data.in_(["data2", "data3"])
                 ),
             )
@@ -187,7 +187,7 @@ class InsertBehaviorTest(fixtures.TablesTest):
         eq_(result.inserted_primary_key, (None,))
 
         result = connection.execute(
-            select([dest_table.c.data]).order_by(dest_table.c.data)
+            select(dest_table.c.data).order_by(dest_table.c.data)
         )
         eq_(result.fetchall(), [("data2",), ("data3",)])
 
@@ -199,7 +199,7 @@ class InsertBehaviorTest(fixtures.TablesTest):
         result = connection.execute(
             dest_table.insert().from_select(
                 ("data",),
-                select([src_table.c.data]).where(
+                select(src_table.c.data).where(
                     src_table.c.data.in_(["data2", "data3"])
                 ),
             )
@@ -207,7 +207,7 @@ class InsertBehaviorTest(fixtures.TablesTest):
         eq_(result.inserted_primary_key, (None,))
 
         result = connection.execute(
-            select([dest_table.c.data]).order_by(dest_table.c.data)
+            select(dest_table.c.data).order_by(dest_table.c.data)
         )
 
         eq_(result.fetchall(), [])
@@ -227,7 +227,7 @@ class InsertBehaviorTest(fixtures.TablesTest):
         connection.execute(
             table.insert(inline=True).from_select(
                 ("id", "data"),
-                select([table.c.id + 5, table.c.data]).where(
+                select(table.c.id + 5, table.c.data).where(
                     table.c.data.in_(["data2", "data3"])
                 ),
             )
@@ -235,7 +235,7 @@ class InsertBehaviorTest(fixtures.TablesTest):
 
         eq_(
             connection.execute(
-                select([table.c.data]).order_by(table.c.data)
+                select(table.c.data).order_by(table.c.data)
             ).fetchall(),
             [("data1",), ("data2",), ("data2",), ("data3",), ("data3",)],
         )
@@ -255,7 +255,7 @@ class InsertBehaviorTest(fixtures.TablesTest):
         connection.execute(
             table.insert(inline=True).from_select(
                 ("id", "data"),
-                select([table.c.id + 5, table.c.data]).where(
+                select(table.c.id + 5, table.c.data).where(
                     table.c.data.in_(["data2", "data3"])
                 ),
             )
@@ -263,7 +263,7 @@ class InsertBehaviorTest(fixtures.TablesTest):
 
         eq_(
             connection.execute(
-                select([table]).order_by(table.c.data, table.c.id)
+                select(table).order_by(table.c.data, table.c.id)
             ).fetchall(),
             [
                 (1, "data1", 5, 4),
@@ -306,7 +306,7 @@ class ReturningTest(fixtures.TablesTest):
             table.insert().returning(table.c.id), data="some data"
         )
         pk = r.first()[0]
-        fetched_pk = connection.scalar(select([table.c.id]))
+        fetched_pk = connection.scalar(select(table.c.id))
         eq_(fetched_pk, pk)
 
     def test_explicit_returning_pk_no_autocommit(self, connection):
@@ -315,7 +315,7 @@ class ReturningTest(fixtures.TablesTest):
             table.insert().returning(table.c.id), data="some data"
         )
         pk = r.first()[0]
-        fetched_pk = connection.scalar(select([table.c.id]))
+        fetched_pk = connection.scalar(select(table.c.id))
         eq_(fetched_pk, pk)
 
     def test_autoincrement_on_insert_implicit_returning(self, connection):
@@ -328,7 +328,7 @@ class ReturningTest(fixtures.TablesTest):
         r = connection.execute(
             self.tables.autoinc_pk.insert(), data="some data"
         )
-        pk = connection.scalar(select([self.tables.autoinc_pk.c.id]))
+        pk = connection.scalar(select(self.tables.autoinc_pk.c.id))
         eq_(r.inserted_primary_key, (pk,))
 
 

--- a/test/aaa_profiling/test_compiler.py
+++ b/test/aaa_profiling/test_compiler.py
@@ -74,12 +74,12 @@ class CompileTest(fixtures.TestBase, AssertsExecutionResults):
     def test_select(self):
         # give some of the cached type values
         # a chance to warm up
-        s = select([t1], t1.c.c2 == t2.c.c1)
+        s = select(t1).where(t1.c.c2 == t2.c.c1)
         s.compile(dialect=self.dialect)
 
         @profiling.function_call_count(variance=0.15, warmup=1)
         def go():
-            s = select([t1], t1.c.c2 == t2.c.c1)
+            s = select(t1).where(t1.c.c2 == t2.c.c1)
             s.compile(dialect=self.dialect)
 
         go()
@@ -87,12 +87,12 @@ class CompileTest(fixtures.TestBase, AssertsExecutionResults):
     def test_select_labels(self):
         # give some of the cached type values
         # a chance to warm up
-        s = select([t1], t1.c.c2 == t2.c.c1).apply_labels()
+        s = select(t1).where(t1.c.c2 == t2.c.c1).apply_labels()
         s.compile(dialect=self.dialect)
 
         @profiling.function_call_count(variance=0.15, warmup=1)
         def go():
-            s = select([t1], t1.c.c2 == t2.c.c1).apply_labels()
+            s = select(t1).where(t1.c.c2 == t2.c.c1).apply_labels()
             s.compile(dialect=self.dialect)
 
         go()

--- a/test/aaa_profiling/test_misc.py
+++ b/test/aaa_profiling/test_misc.py
@@ -99,7 +99,7 @@ class CacheKeyTest(fixtures.TestBase):
 
         return [
             (
-                select([Parent.id, Child.id])
+                select(Parent.id, Child.id)
                 .select_from(ormjoin(Parent, Child, Parent.children))
                 .where(Child.id == 5)
             )

--- a/test/dialect/mssql/test_deprecations.py
+++ b/test/dialect/mssql/test_deprecations.py
@@ -144,7 +144,7 @@ class LegacySchemaAliasingTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def test_column_subquery_to_alias(self):
         a1 = self.t2.alias("a1")
-        s = select([self.t2, select(a1.c.a).scalar_subquery()])
+        s = select(self.t2, select(a1.c.a).scalar_subquery())
         self._assert_sql(
             s,
             "SELECT t2_1.a, t2_1.b, t2_1.c, "

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -425,12 +425,13 @@ class SQLTest(fixtures.TestBase, AssertsCompiledSQL):
         dialect = self.__dialect__
 
         def gen(distinct=None, prefixes=None):
-            kw = {}
-            if distinct is not None:
-                kw["distinct"] = distinct
+            stmt = select(column("q"))
+            if distinct:
+                stmt = stmt.distinct()
             if prefixes is not None:
-                kw["prefixes"] = prefixes
-            return str(select([column("q")], **kw).compile(dialect=dialect))
+                stmt = stmt.prefix_with(*prefixes)
+
+            return str(stmt.compile(dialect=dialect))
 
         eq_(gen(None), "SELECT q")
         eq_(gen(True), "SELECT DISTINCT q")

--- a/test/dialect/mysql/test_query.py
+++ b/test/dialect/mysql/test_query.py
@@ -262,6 +262,6 @@ class AnyAllTest(fixtures.TablesTest):
 
     def test_any_literal(self, connection):
         stuff = self.tables.stuff
-        stmt = select([4 == any_(select(stuff.c.value).scalar_subquery())])
+        stmt = select(4 == any_(select(stuff.c.value).scalar_subquery()))
 
         is_(connection.execute(stmt).scalar(), True)

--- a/test/dialect/oracle/test_compiler.py
+++ b/test/dialect/oracle/test_compiler.py
@@ -745,17 +745,19 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
     def test_outer_join_one(self):
         table1, table2, table3 = self._test_outer_join_fixture()
 
-        query = select(
-            [table1, table2],
-            or_(
-                table1.c.name == "fred",
-                table1.c.myid == 10,
-                table2.c.othername != "jack",
-                text("EXISTS (select yay from foo where boo = lar)"),
-            ),
-            from_obj=[
+        query = (
+            select(table1, table2)
+            .where(
+                or_(
+                    table1.c.name == "fred",
+                    table1.c.myid == 10,
+                    table2.c.othername != "jack",
+                    text("EXISTS (select yay from foo where boo = lar)"),
+                )
+            )
+            .select_from(
                 outerjoin(table1, table2, table1.c.myid == table2.c.otherid)
-            ],
+            )
         )
         self.assert_compile(
             query,

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -1646,7 +1646,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         series = func.generate_series(1, 100).alias("series")
         series_col = column("series")
         query = select(
-            [func.array_agg(series_col).filter(series_col % 2 == 0)[3]]
+            func.array_agg(series_col).filter(series_col % 2 == 0)[3]
         ).select_from(series)
         self.assert_compile(
             query,
@@ -2143,22 +2143,22 @@ class DistinctOnTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def test_plain_inline(self):
         self.assert_compile(
-            select([self.table], distinct=True),
+            select(self.table).distinct(),
             "SELECT DISTINCT t.id, t.a, t.b FROM t",
         )
 
     def test_on_columns_inline_list(self):
         self.assert_compile(
-            select(
-                [self.table], distinct=[self.table.c.a, self.table.c.b]
-            ).order_by(self.table.c.a, self.table.c.b),
+            select(self.table)
+            .distinct(self.table.c.a, self.table.c.b)
+            .order_by(self.table.c.a, self.table.c.b),
             "SELECT DISTINCT ON (t.a, t.b) t.id, "
             "t.a, t.b FROM t ORDER BY t.a, t.b",
         )
 
     def test_on_columns_inline_scalar(self):
         self.assert_compile(
-            select([self.table], distinct=self.table.c.a),
+            select(self.table).distinct(self.table.c.a),
             "SELECT DISTINCT ON (t.a) t.id, t.a, t.b FROM t",
         )
 

--- a/test/dialect/postgresql/test_query.py
+++ b/test/dialect/postgresql/test_query.py
@@ -863,21 +863,19 @@ class TupleTest(fixtures.TestBase):
             eq_(
                 connection.execute(
                     select(
-                        [
-                            tuple_(
-                                literal_column("'a'"), literal_column("'b'")
-                            ).in_(
-                                [
-                                    tuple_(
-                                        *[
-                                            literal_column("'%s'" % letter)
-                                            for letter in elem
-                                        ]
-                                    )
-                                    for elem in test
-                                ]
-                            )
-                        ]
+                        tuple_(
+                            literal_column("'a'"), literal_column("'b'")
+                        ).in_(
+                            [
+                                tuple_(
+                                    *[
+                                        literal_column("'%s'" % letter)
+                                        for letter in elem
+                                    ]
+                                )
+                                for elem in test
+                            ]
+                        )
                     )
                 ).scalar(),
                 exp,

--- a/test/dialect/test_firebird.py
+++ b/test/dialect/test_firebird.py
@@ -515,8 +515,8 @@ class MiscTest(fixtures.TestBase):
         metadata.create_all()
         t.insert(values=dict(name="dante")).execute()
         t.insert(values=dict(name="alighieri")).execute()
-        select(
-            [func.count(t.c.id)], func.length(t.c.name) == 5
+        select(func.count(t.c.id)).where(
+            func.length(t.c.name) == 5
         ).execute().first()[0] == 1
 
     def test_version_parsing(self):

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -332,9 +332,7 @@ class JSONTest(fixtures.TestBase):
         with testing.db.connect() as conn:
             conn.execute(sqlite_json.insert(), foo=value)
 
-            eq_(
-                conn.scalar(select([sqlite_json.c.foo["json"]])), value["json"]
-            )
+            eq_(conn.scalar(select(sqlite_json.c.foo["json"])), value["json"])
 
     @testing.provide_metadata
     def test_deprecated_serializer_args(self):

--- a/test/engine/test_deprecations.py
+++ b/test/engine/test_deprecations.py
@@ -112,7 +112,7 @@ class ConnectionlessDeprecationTest(fixtures.TestBase):
         ):
             testing.db.execute(stmt)
 
-        stmt = select([table])
+        stmt = select(table)
         with testing.expect_deprecated_20(
             r"The Engine.execute\(\) function/method is considered legacy",
         ):
@@ -129,7 +129,7 @@ class ConnectionlessDeprecationTest(fixtures.TestBase):
         ):
             stmt.execute()
 
-        stmt = select([table])
+        stmt = select(table)
         with testing.expect_deprecated_20(
             r"The Executable.execute\(\) function/method is considered legacy",
         ):
@@ -342,7 +342,7 @@ class PoolTestBase(fixtures.TestBase):
 
 
 def select1(db):
-    return str(select([1]).compile(dialect=db.dialect))
+    return str(select(1).compile(dialect=db.dialect))
 
 
 class DeprecatedEngineFeatureTest(fixtures.TablesTest):
@@ -947,7 +947,7 @@ class EngineEventsTest(fixtures.TestBase):
             r"The argument signature for the "
             r"\"ConnectionEvents.before_execute\" event listener",
         ):
-            engine.execute(select([1]))
+            engine.execute(select(1))
         eq_(canary, ["execute", "cursor_execute"])
 
     def test_argument_format_execute(self):
@@ -969,4 +969,4 @@ class EngineEventsTest(fixtures.TestBase):
             r"The argument signature for the "
             r"\"ConnectionEvents.after_execute\" event listener",
         ):
-            e1.execute(select([1]))
+            e1.execute(select(1))

--- a/test/engine/test_execute.py
+++ b/test/engine/test_execute.py
@@ -1425,7 +1425,7 @@ class EngineEventsTest(fixtures.TestBase):
         m1 = Mock()
 
         def select1(db):
-            return str(select([1]).compile(dialect=db.dialect))
+            return str(select(1).compile(dialect=db.dialect))
 
         with testing.db.connect() as conn:
             event.listen(conn, "before_execute", m1.before_execute)

--- a/test/engine/test_logging.py
+++ b/test/engine/test_logging.py
@@ -308,7 +308,7 @@ class LogParamsTest(fixtures.TestBase):
                 r"foo.data = \? OR foo.data = \?\]\n"
                 r"\[SQL parameters hidden due to hide_parameters=True\]",
                 conn.execute,
-                select([foo]).where(
+                select(foo).where(
                     or_(
                         foo.c.data == bindparam("the_data_1"),
                         foo.c.data == bindparam("the_data_2"),
@@ -492,7 +492,7 @@ class LoggingNameTest(fixtures.TestBase):
     __requires__ = ("ad_hoc_engines",)
 
     def _assert_names_in_execute(self, eng, eng_name, pool_name):
-        eng.execute(select([1]))
+        eng.execute(select(1))
         assert self.buf.buffer
         for name in [b.name for b in self.buf.buffer]:
             assert name in (
@@ -502,7 +502,7 @@ class LoggingNameTest(fixtures.TestBase):
             )
 
     def _assert_no_name_in_execute(self, eng):
-        eng.execute(select([1]))
+        eng.execute(select(1))
         assert self.buf.buffer
         for name in [b.name for b in self.buf.buffer]:
             assert name in (
@@ -545,7 +545,7 @@ class LoggingNameTest(fixtures.TestBase):
 
     def test_named_logger_names_after_dispose(self):
         eng = self._named_engine()
-        eng.execute(select([1]))
+        eng.execute(select(1))
         eng.dispose()
         eq_(eng.logging_name, "myenginename")
         eq_(eng.pool.logging_name, "mypoolname")
@@ -565,7 +565,7 @@ class LoggingNameTest(fixtures.TestBase):
 
     def test_named_logger_execute_after_dispose(self):
         eng = self._named_engine()
-        eng.execute(select([1]))
+        eng.execute(select(1))
         eng.dispose()
         self._assert_names_in_execute(eng, "myenginename", "mypoolname")
 
@@ -596,7 +596,7 @@ class EchoTest(fixtures.TestBase):
 
         # do an initial execute to clear out 'first connect'
         # messages
-        e.execute(select([10])).close()
+        e.execute(select(10)).close()
         self.buf.flush()
 
         return e
@@ -634,16 +634,16 @@ class EchoTest(fixtures.TestBase):
         e2 = self._testing_engine()
 
         e1.echo = True
-        e1.execute(select([1])).close()
-        e2.execute(select([2])).close()
+        e1.execute(select(1)).close()
+        e2.execute(select(2)).close()
 
         e1.echo = False
-        e1.execute(select([3])).close()
-        e2.execute(select([4])).close()
+        e1.execute(select(3)).close()
+        e2.execute(select(4)).close()
 
         e2.echo = True
-        e1.execute(select([5])).close()
-        e2.execute(select([6])).close()
+        e1.execute(select(5)).close()
+        e2.execute(select(6)).close()
 
         assert self.buf.buffer[0].getMessage().startswith("SELECT 1")
         assert self.buf.buffer[2].getMessage().startswith("SELECT 6")

--- a/test/engine/test_pool.py
+++ b/test/engine/test_pool.py
@@ -598,7 +598,7 @@ class PoolEventsTest(PoolTestBase):
         event.listen(engine, "connect", listen_three)
         event.listen(engine.__class__, "connect", listen_four)
 
-        engine.execute(select([1])).close()
+        engine.execute(select(1)).close()
         eq_(
             canary, ["listen_one", "listen_four", "listen_two", "listen_three"]
         )

--- a/test/engine/test_reflection.py
+++ b/test/engine/test_reflection.py
@@ -913,7 +913,7 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
             autoload_with=testing.db,
         )
         u2 = Table("users", meta2, autoload_with=testing.db)
-        s = sa.select([a2]).subquery()
+        s = sa.select(a2).subquery()
 
         assert s.c.user_id is not None
         assert len(a2.foreign_keys) == 1
@@ -938,7 +938,7 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
             Column("user_id", sa.Integer, sa.ForeignKey("users.id")),
             autoload_with=testing.db,
         )
-        s = sa.select([a2]).subquery()
+        s = sa.select(a2).subquery()
 
         assert s.c.user_id is not None
         assert len(a2.foreign_keys) == 1

--- a/test/engine/test_transaction.py
+++ b/test/engine/test_transaction.py
@@ -590,7 +590,7 @@ class TransactionTest(fixtures.TestBase):
         transaction.commit()
         eq_(
             connection.execute(
-                select([users.c.user_id]).order_by(users.c.user_id)
+                select(users.c.user_id).order_by(users.c.user_id)
             ).fetchall(),
             [(1,), (3,)],
         )
@@ -607,7 +607,7 @@ class TransactionTest(fixtures.TestBase):
         transaction.commit()
         eq_(
             connection.execute(
-                select([users.c.user_id]).order_by(users.c.user_id)
+                select(users.c.user_id).order_by(users.c.user_id)
             ).fetchall(),
             [(1,), (2,), (3,)],
         )
@@ -637,7 +637,7 @@ class TransactionTest(fixtures.TestBase):
         transaction.commit()
         eq_(
             connection.execute(
-                select([users.c.user_id]).order_by(users.c.user_id)
+                select(users.c.user_id).order_by(users.c.user_id)
             ).fetchall(),
             [(1,), (4,)],
         )
@@ -663,7 +663,7 @@ class TransactionTest(fixtures.TestBase):
         transaction.close()
         eq_(
             connection.execute(
-                select([users.c.user_id]).order_by(users.c.user_id)
+                select(users.c.user_id).order_by(users.c.user_id)
             ).fetchall(),
             [(1,), (2,)],
         )
@@ -695,7 +695,7 @@ class TransactionTest(fixtures.TestBase):
         transaction.commit()
         eq_(
             connection.execute(
-                select([users.c.user_id]).order_by(users.c.user_id)
+                select(users.c.user_id).order_by(users.c.user_id)
             ).fetchall(),
             [(1,), (2,), (5,)],
         )
@@ -722,7 +722,7 @@ class TransactionTest(fixtures.TestBase):
         with testing.db.connect() as connection2:
             eq_(
                 connection2.execution_options(autocommit=True)
-                .execute(select([users.c.user_id]).order_by(users.c.user_id))
+                .execute(select(users.c.user_id).order_by(users.c.user_id))
                 .fetchall(),
                 [],
             )
@@ -731,7 +731,7 @@ class TransactionTest(fixtures.TestBase):
             connection2.commit_prepared(transaction.xid, recover=True)
             eq_(
                 connection2.execute(
-                    select([users.c.user_id]).order_by(users.c.user_id)
+                    select(users.c.user_id).order_by(users.c.user_id)
                 ).fetchall(),
                 [(1,)],
             )
@@ -755,7 +755,7 @@ class TransactionTest(fixtures.TestBase):
         xa.prepare()
         xa.commit()
         result = conn.execute(
-            select([users.c.user_name]).order_by(users.c.user_id)
+            select(users.c.user_name).order_by(users.c.user_id)
         )
         eq_(result.fetchall(), [("user1",), ("user4",)])
 
@@ -786,7 +786,7 @@ class TransactionTest(fixtures.TestBase):
 
         with eng.connect() as conn:
             result = conn.execute(
-                select([users.c.user_name]).order_by(users.c.user_id)
+                select(users.c.user_name).order_by(users.c.user_id)
             )
             eq_(result.fetchall(), [])
 
@@ -1060,13 +1060,13 @@ class ExplicitAutoCommitTest(fixtures.TestBase):
 
         conn1 = testing.db.connect()
         conn2 = testing.db.connect()
-        conn1.execute(select([func.insert_foo("data1")]))
-        assert conn2.execute(select([foo.c.data])).fetchall() == []
+        conn1.execute(select(func.insert_foo("data1")))
+        assert conn2.execute(select(foo.c.data)).fetchall() == []
         conn1.execute(text("select insert_foo('moredata')"))
-        assert conn2.execute(select([foo.c.data])).fetchall() == []
+        assert conn2.execute(select(foo.c.data)).fetchall() == []
         trans = conn1.begin()
         trans.commit()
-        assert conn2.execute(select([foo.c.data])).fetchall() == [
+        assert conn2.execute(select(foo.c.data)).fetchall() == [
             ("data1",),
             ("moredata",),
         ]
@@ -1077,11 +1077,9 @@ class ExplicitAutoCommitTest(fixtures.TestBase):
         conn1 = testing.db.connect()
         conn2 = testing.db.connect()
         conn1.execute(
-            select([func.insert_foo("data1")]).execution_options(
-                autocommit=True
-            )
+            select(func.insert_foo("data1")).execution_options(autocommit=True)
         )
-        assert conn2.execute(select([foo.c.data])).fetchall() == [("data1",)]
+        assert conn2.execute(select(foo.c.data)).fetchall() == [("data1",)]
         conn1.close()
         conn2.close()
 
@@ -1089,28 +1087,26 @@ class ExplicitAutoCommitTest(fixtures.TestBase):
         conn1 = testing.db.connect()
         conn2 = testing.db.connect()
         conn1.execution_options(autocommit=True).execute(
-            select([func.insert_foo("data1")])
+            select(func.insert_foo("data1"))
         )
-        eq_(conn2.execute(select([foo.c.data])).fetchall(), [("data1",)])
+        eq_(conn2.execute(select(foo.c.data)).fetchall(), [("data1",)])
 
         # connection supersedes statement
 
         conn1.execution_options(autocommit=False).execute(
-            select([func.insert_foo("data2")]).execution_options(
-                autocommit=True
-            )
+            select(func.insert_foo("data2")).execution_options(autocommit=True)
         )
-        eq_(conn2.execute(select([foo.c.data])).fetchall(), [("data1",)])
+        eq_(conn2.execute(select(foo.c.data)).fetchall(), [("data1",)])
 
         # ditto
 
         conn1.execution_options(autocommit=True).execute(
-            select([func.insert_foo("data3")]).execution_options(
+            select(func.insert_foo("data3")).execution_options(
                 autocommit=False
             )
         )
         eq_(
-            conn2.execute(select([foo.c.data])).fetchall(),
+            conn2.execute(select(foo.c.data)).fetchall(),
             [("data1",), ("data2",), ("data3",)],
         )
         conn1.close()
@@ -1124,9 +1120,7 @@ class ExplicitAutoCommitTest(fixtures.TestBase):
                 autocommit=True
             )
         )
-        assert conn2.execute(select([foo.c.data])).fetchall() == [
-            ("moredata",)
-        ]
+        assert conn2.execute(select(foo.c.data)).fetchall() == [("moredata",)]
         conn1.close()
         conn2.close()
 
@@ -1134,7 +1128,7 @@ class ExplicitAutoCommitTest(fixtures.TestBase):
         conn1 = testing.db.connect()
         conn2 = testing.db.connect()
         conn1.execute(text("insert into foo (data) values ('implicitdata')"))
-        assert conn2.execute(select([foo.c.data])).fetchall() == [
+        assert conn2.execute(select(foo.c.data)).fetchall() == [
             ("implicitdata",)
         ]
         conn1.close()
@@ -1330,7 +1324,7 @@ class IsolationLevelTest(fixtures.TestBase):
             r"on Connection.execution_options\(\), or "
             r"per-engine using the isolation_level "
             r"argument to create_engine\(\).",
-            select([1]).execution_options,
+            select(1).execution_options,
             isolation_level=self._non_default_isolation_level(),
         )
 
@@ -1793,7 +1787,7 @@ class FutureTransactionTest(fixtures.FutureEngineMixin, fixtures.TablesTest):
         canary = mock.Mock()
         with testing.db.connect() as conn:
             event.listen(conn, "rollback", canary)
-            conn.execute(select([1]))
+            conn.execute(select(1))
             assert conn.in_transaction()
 
         eq_(canary.mock_calls, [mock.call(conn)])
@@ -1802,7 +1796,7 @@ class FutureTransactionTest(fixtures.FutureEngineMixin, fixtures.TablesTest):
         canary = mock.Mock()
         with testing.db.connect() as conn:
             event.listen(conn, "rollback", canary)
-            conn.execute(select([1]))
+            conn.execute(select(1))
             conn.rollback()
             assert not conn.in_transaction()
 
@@ -1813,7 +1807,7 @@ class FutureTransactionTest(fixtures.FutureEngineMixin, fixtures.TablesTest):
         try:
             with testing.db.connect() as conn:
                 event.listen(conn, "rollback", canary)
-                conn.execute(select([1]))
+                conn.execute(select(1))
                 assert conn.in_transaction()
                 raise Exception("some error")
             assert False
@@ -1866,7 +1860,7 @@ class FutureTransactionTest(fixtures.FutureEngineMixin, fixtures.TablesTest):
                 exc.PendingRollbackError,
                 "Can't reconnect",
                 conn.execute,
-                select([1]),
+                select(1),
             )
 
             conn.rollback()

--- a/test/ext/declarative/test_basic.py
+++ b/test/ext/declarative/test_basic.py
@@ -1481,7 +1481,7 @@ class DeclarativeTest(DeclarativeTestBase):
             user_id = Column("user_id", Integer, ForeignKey("users.id"))
 
         User.address_count = sa.orm.column_property(
-            sa.select([sa.func.count(Address.id)])
+            sa.select(sa.func.count(Address.id))
             .where(Address.user_id == User.id)
             .scalar_subquery()
         )
@@ -1528,7 +1528,7 @@ class DeclarativeTest(DeclarativeTestBase):
                 # this doesn't really gain us anything.  but if
                 # one is used, lets have it function as expected...
                 return sa.orm.column_property(
-                    sa.select([sa.func.count(Address.id)])
+                    sa.select(sa.func.count(Address.id))
                     .where(Address.user_id == cls.id)
                     .scalar_subquery()
                 )
@@ -1628,9 +1628,9 @@ class DeclarativeTest(DeclarativeTestBase):
             name = Column("name", String(50))
 
             adr_count = sa.orm.column_property(
-                sa.select(
-                    [sa.func.count(Address.id)], Address.user_id == id
-                ).scalar_subquery()
+                sa.select(sa.func.count(Address.id))
+                .where(Address.user_id == id)
+                .scalar_subquery()
             )
             addresses = relationship(Address)
 
@@ -1932,7 +1932,7 @@ class DeclarativeTest(DeclarativeTestBase):
             )
 
         User.address_count = sa.orm.column_property(
-            sa.select([sa.func.count(Address.id)])
+            sa.select(sa.func.count(Address.id))
             .where(Address.user_id == User.id)
             .scalar_subquery()
         )

--- a/test/ext/declarative/test_mixin.py
+++ b/test/ext/declarative/test_mixin.py
@@ -1849,7 +1849,7 @@ class DeclaredAttrTest(DeclarativeTestBase, testing.AssertsCompiledSQL):
             def address_count(cls):
                 counter(cls.id)
                 return column_property(
-                    select([func.count(Address.id)])
+                    select(func.count(Address.id))
                     .where(Address.user_id == cls.id)
                     .scalar_subquery()
                 )

--- a/test/ext/test_compiler.py
+++ b/test/ext/test_compiler.py
@@ -41,11 +41,11 @@ class UserDefinedTest(fixtures.TestBase, AssertsCompiledSQL):
             return ">>%s<<" % thingy.name
 
         self.assert_compile(
-            select([column("foo"), MyThingy()]), "SELECT foo, >>MYTHINGY!<<"
+            select(column("foo"), MyThingy()), "SELECT foo, >>MYTHINGY!<<"
         )
 
         self.assert_compile(
-            select([MyThingy("x"), MyThingy("y")]).where(MyThingy() == 5),
+            select(MyThingy("x"), MyThingy("y")).where(MyThingy() == 5),
             "SELECT >>x<<, >>y<< WHERE >>MYTHINGY!<< = :MYTHINGY!_1",
         )
 
@@ -103,12 +103,12 @@ class UserDefinedTest(fixtures.TestBase, AssertsCompiledSQL):
             return str(compiler.counter)
 
         self.assert_compile(
-            select([column("foo"), MyThingy()]).order_by(desc(MyThingy())),
+            select(column("foo"), MyThingy()).order_by(desc(MyThingy())),
             "SELECT foo, 1 ORDER BY 2 DESC",
         )
 
         self.assert_compile(
-            select([MyThingy(), MyThingy()]).where(MyThingy() == 5),
+            select(MyThingy(), MyThingy()).where(MyThingy() == 5),
             "SELECT 1, 2 WHERE 3 = :MYTHINGY!_1",
         )
 
@@ -127,7 +127,7 @@ class UserDefinedTest(fixtures.TestBase, AssertsCompiledSQL):
 
         t1 = table("mytable", column("x"), column("y"), column("z"))
         self.assert_compile(
-            InsertFromSelect(t1, select([t1]).where(t1.c.x > 5)),
+            InsertFromSelect(t1, select(t1).where(t1.c.x > 5)),
             "INSERT INTO mytable (SELECT mytable.x, mytable.y, mytable.z "
             "FROM mytable WHERE mytable.x > :x_1)",
         )
@@ -203,7 +203,7 @@ class UserDefinedTest(fixtures.TestBase, AssertsCompiledSQL):
             def compile_(element, compiler, **kw):
                 return "OVERRIDE"
 
-            s1 = select([t1])
+            s1 = select(t1)
             self.assert_compile(s1, "OVERRIDE")
             self.assert_compile(s1._annotate({}), "OVERRIDE")
         finally:
@@ -341,7 +341,7 @@ class UserDefinedTest(fixtures.TestBase, AssertsCompiledSQL):
             return "FOO" + element.name
 
         self.assert_compile(
-            select([Sub1(), Sub2()]),
+            select(Sub1(), Sub2()),
             "SELECT FOOsub1 AS sub1_1, sub2 AS sub2_1",
             use_default_dialect=True,
         )
@@ -364,7 +364,7 @@ class UserDefinedTest(fixtures.TestBase, AssertsCompiledSQL):
             name = "subsub1"
 
         self.assert_compile(
-            select([Sub1(), Sub2(), SubSub1()]),
+            select(Sub1(), Sub2(), SubSub1()),
             "SELECT sub1 AS sub1_1, sub2 AS sub2_1, subsub1 AS subsub1_1",
             use_default_dialect=True,
         )
@@ -374,7 +374,7 @@ class UserDefinedTest(fixtures.TestBase, AssertsCompiledSQL):
             return "FOO" + element.name
 
         self.assert_compile(
-            select([Sub1(), Sub2(), SubSub1()]),
+            select(Sub1(), Sub2(), SubSub1()),
             "SELECT FOOsub1 AS sub1_1, sub2 AS sub2_1, "
             "FOOsubsub1 AS subsub1_1",
             use_default_dialect=True,
@@ -383,7 +383,7 @@ class UserDefinedTest(fixtures.TestBase, AssertsCompiledSQL):
     def _test_result_map_population(self, expression):
         lc1 = literal_column("1")
         lc2 = literal_column("2")
-        stmt = select([lc1, expression, lc2])
+        stmt = select(lc1, expression, lc2)
 
         compiled = stmt.compile()
         eq_(
@@ -437,7 +437,7 @@ class DefaultOnExistingTest(fixtures.TestBase, AssertsCompiledSQL):
         def compile_(element, compiler, **kw):
             return "OVERRIDE"
 
-        s1 = select([t1])
+        s1 = select(t1)
         self.assert_compile(s1, "SELECT t1.c1, t1.c2 FROM t1")
 
         from sqlalchemy.dialects.sqlite import base as sqlite

--- a/test/ext/test_serializer.py
+++ b/test/ext/test_serializer.py
@@ -136,7 +136,7 @@ class SerializeTest(AssertsCompiledSQL, fixtures.MappedTest):
         )
 
     def test_expression(self):
-        expr = select([users]).select_from(users.join(addresses)).limit(5)
+        expr = select(users).select_from(users.join(addresses)).limit(5)
         re_expr = serializer.loads(
             serializer.dumps(expr, -1), users.metadata, None
         )
@@ -228,7 +228,7 @@ class SerializeTest(AssertsCompiledSQL, fixtures.MappedTest):
 
     def test_annotated_one(self):
         j = join(users, addresses)._annotate({"foo": "bar"})
-        query = select([addresses]).select_from(j)
+        query = select(addresses).select_from(j)
 
         str(query)
         for prot in pickle_protocols():
@@ -279,7 +279,7 @@ class SerializeTest(AssertsCompiledSQL, fixtures.MappedTest):
             ue("\u6e2c\u8a66"), m, Column(ue("\u6e2c\u8a66_id"), Integer)
         )
 
-        expr = select([t]).where(t.c[ue("\u6e2c\u8a66_id")] == 5)
+        expr = select(t).where(t.c[ue("\u6e2c\u8a66_id")] == 5)
 
         expr2 = serializer.loads(serializer.dumps(expr, -1), m)
 

--- a/test/orm/inheritance/test_assorted_poly.py
+++ b/test/orm/inheritance/test_assorted_poly.py
@@ -1420,11 +1420,10 @@ class MultiLevelTest(fixtures.MappedTest):
                 "Manager": table_Employee.join(table_Engineer).join(
                     table_Manager
                 ),
-                "Engineer": select(
-                    [table_Employee, table_Engineer.c.machine],
-                    table_Employee.c.atype == "Engineer",
-                    from_obj=[table_Employee.join(table_Engineer)],
-                ).subquery(),
+                "Engineer": select(table_Employee, table_Engineer.c.machine)
+                .where(table_Employee.c.atype == "Engineer")
+                .select_from(table_Employee.join(table_Engineer))
+                .subquery(),
                 "Employee": table_Employee.select(
                     table_Employee.c.atype == "Employee"
                 ).subquery(),
@@ -1446,11 +1445,10 @@ class MultiLevelTest(fixtures.MappedTest):
                 "Manager": table_Employee.join(table_Engineer).join(
                     table_Manager
                 ),
-                "Engineer": select(
-                    [table_Employee, table_Engineer.c.machine],
-                    table_Employee.c.atype == "Engineer",
-                    from_obj=[table_Employee.join(table_Engineer)],
-                ).subquery(),
+                "Engineer": select(table_Employee, table_Engineer.c.machine)
+                .where(table_Employee.c.atype == "Engineer")
+                .select_from(table_Employee.join(table_Engineer))
+                .subquery(),
             },
             None,
             "pu_engineer",
@@ -1839,10 +1837,11 @@ class MissingPolymorphicOnTest(fixtures.MappedTest):
             self.classes.C,
             self.classes.D,
         )
-        poly_select = select(
-            [tablea, tableb.c.data.label("discriminator")],
-            from_obj=tablea.join(tableb),
-        ).alias("poly")
+        poly_select = (
+            select(tablea, tableb.c.data.label("discriminator"))
+            .select_from(tablea.join(tableb))
+            .alias("poly")
+        )
 
         mapper(B, tableb)
         mapper(

--- a/test/orm/inheritance/test_basic.py
+++ b/test/orm/inheritance/test_basic.py
@@ -395,10 +395,10 @@ class PolymorphicOnNotLocalTest(fixtures.MappedTest):
     def test_polymorphic_on_not_present_col(self):
         t2, t1 = self.tables.t2, self.tables.t1
         Parent = self.classes.Parent
-        t1t2_join = select([t1.c.x], from_obj=[t1.join(t2)]).alias()
+        t1t2_join = select(t1.c.x).select_from(t1.join(t2)).alias()
 
         def go():
-            t1t2_join_2 = select([t1.c.q], from_obj=[t1.join(t2)]).alias()
+            t1t2_join_2 = select(t1.c.q).select_from(t1.join(t2)).alias()
             mapper(
                 Parent,
                 t2,
@@ -417,7 +417,7 @@ class PolymorphicOnNotLocalTest(fixtures.MappedTest):
     def test_polymorphic_on_only_in_with_poly(self):
         t2, t1 = self.tables.t2, self.tables.t1
         Parent = self.classes.Parent
-        t1t2_join = select([t1.c.x], from_obj=[t1.join(t2)]).alias()
+        t1t2_join = select(t1.c.x).select_from(t1.join(t2)).alias()
         # if its in the with_polymorphic, then its OK
         mapper(
             Parent,
@@ -431,11 +431,11 @@ class PolymorphicOnNotLocalTest(fixtures.MappedTest):
         t2, t1 = self.tables.t2, self.tables.t1
         Parent = self.classes.Parent
 
-        t1t2_join = select([t1.c.x], from_obj=[t1.join(t2)]).alias()
+        t1t2_join = select(t1.c.x).select_from(t1.join(t2)).alias()
 
         # if with_polymorphic, but its not present, not OK
         def go():
-            t1t2_join_2 = select([t1.c.q], from_obj=[t1.join(t2)]).alias()
+            t1t2_join_2 = select(t1.c.q).select_from(t1.join(t2)).alias()
             mapper(
                 Parent,
                 t2,

--- a/test/orm/test_composites.py
+++ b/test/orm/test_composites.py
@@ -745,10 +745,11 @@ class MappedSelectTest(fixtures.MappedTest):
             def __composite_values__(self):
                 return self
 
-        desc_values = select(
-            [values, descriptions.c.d1, descriptions.c.d2],
-            descriptions.c.id == values.c.description_id,
-        ).alias("descriptions_values")
+        desc_values = (
+            select(values, descriptions.c.d1, descriptions.c.d2)
+            .where(descriptions.c.id == values.c.description_id,)
+            .alias("descriptions_values")
+        )
 
         mapper(
             Descriptions,

--- a/test/orm/test_eager_relations.py
+++ b/test/orm/test_eager_relations.py
@@ -1294,10 +1294,11 @@ class EagerTest(_fixtures.FixtureTest, testing.AssertsCompiledSQL):
 
         # tests the LIMIT/OFFSET aliasing on a mapper
         # against a select.   original issue from ticket #904
-        sel = sa.select(
-            [users, addresses.c.email_address],
-            users.c.id == addresses.c.user_id,
-        ).alias("useralias")
+        sel = (
+            sa.select(users, addresses.c.email_address)
+            .where(users.c.id == addresses.c.user_id,)
+            .alias("useralias")
+        )
         mapper(
             User,
             sel,
@@ -1810,10 +1811,11 @@ class EagerTest(_fixtures.FixtureTest, testing.AssertsCompiledSQL):
             self.classes.Order,
         )
 
-        max_orders_by_user = sa.select(
-            [sa.func.max(orders.c.id).label("order_id")],
-            group_by=[orders.c.user_id],
-        ).alias("max_orders_by_user")
+        max_orders_by_user = (
+            sa.select(sa.func.max(orders.c.id).label("order_id"))
+            .group_by(orders.c.user_id)
+            .alias("max_orders_by_user")
+        )
 
         max_orders = orders.select(
             orders.c.id == max_orders_by_user.c.order_id
@@ -1946,7 +1948,7 @@ class EagerTest(_fixtures.FixtureTest, testing.AssertsCompiledSQL):
             self.classes.Order,
         )
 
-        s = sa.select([orders], orders.c.isopen == 1).alias("openorders")
+        s = sa.select(orders).where(orders.c.isopen == 1).alias("openorders")
 
         mapper(
             Order, s, properties={"user": relationship(User, lazy="joined")}
@@ -4762,9 +4764,8 @@ class SubqueryTest(fixtures.MappedTest):
 
             tag_score = tags_table.c.score1 * tags_table.c.score2
             user_score = sa.select(
-                [sa.func.sum(tags_table.c.score1 * tags_table.c.score2)],
-                tags_table.c.user_id == users_table.c.id,
-            )
+                sa.func.sum(tags_table.c.score1 * tags_table.c.score2)
+            ).where(tags_table.c.user_id == users_table.c.id,)
 
             if labeled:
                 tag_score = tag_score.label(labelname)

--- a/test/orm/test_mapper.py
+++ b/test/orm/test_mapper.py
@@ -1316,15 +1316,16 @@ class MapperTest(_fixtures.FixtureTest, AssertsCompiledSQL):
             self.classes.User,
         )
 
-        s = sa.select(
-            [
+        s = (
+            sa.select(
                 users,
                 (users.c.id * 2).label("concat"),
                 sa.func.count(addresses.c.id).label("count"),
-            ],
-            users.c.id == addresses.c.user_id,
-            group_by=[c for c in users.c],
-        ).alias("myselect")
+            )
+            .where(users.c.id == addresses.c.user_id)
+            .group_by(*[c for c in users.c])
+            .alias("myselect")
+        )
 
         mapper(User, s)
         sess = create_session()

--- a/test/orm/test_relationships.py
+++ b/test/orm/test_relationships.py
@@ -1894,10 +1894,11 @@ class RelationshipToSelectableTest(fixtures.MappedTest):
         class LineItem(fixtures.BasicEntity):
             pass
 
-        container_select = sa.select(
-            [items.c.policyNum, items.c.policyEffDate, items.c.type],
-            distinct=True,
-        ).alias("container_select")
+        container_select = (
+            sa.select(items.c.policyNum, items.c.policyEffDate, items.c.type)
+            .distinct()
+            .alias("container_select")
+        )
 
         mapper(LineItem, items)
 

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -1269,10 +1269,11 @@ class EagerTest(_fixtures.FixtureTest, testing.AssertsCompiledSQL):
             self.classes.Order,
         )
 
-        max_orders_by_user = sa.select(
-            [sa.func.max(orders.c.id).label("order_id")],
-            group_by=[orders.c.user_id],
-        ).alias("max_orders_by_user")
+        max_orders_by_user = (
+            sa.select(sa.func.max(orders.c.id).label("order_id"))
+            .group_by(orders.c.user_id)
+            .alias("max_orders_by_user")
+        )
 
         max_orders = orders.select(
             orders.c.id == max_orders_by_user.c.order_id

--- a/test/orm/test_subquery_relations.py
+++ b/test/orm/test_subquery_relations.py
@@ -1250,10 +1250,11 @@ class EagerTest(_fixtures.FixtureTest, testing.AssertsCompiledSQL):
             self.classes.Order,
         )
 
-        max_orders_by_user = sa.select(
-            [sa.func.max(orders.c.id).label("order_id")],
-            group_by=[orders.c.user_id],
-        ).alias("max_orders_by_user")
+        max_orders_by_user = (
+            sa.select(sa.func.max(orders.c.id).label("order_id"))
+            .group_by(orders.c.user_id)
+            .alias("max_orders_by_user")
+        )
 
         max_orders = orders.select(
             orders.c.id == max_orders_by_user.c.order_id

--- a/test/orm/test_unitofwork.py
+++ b/test/orm/test_unitofwork.py
@@ -2253,10 +2253,15 @@ class ManyToOneTest(_fixtures.FixtureTest):
             ),
         )
 
-        result = sa.select(
-            [users, addresses],
-            sa.and_(users.c.id == addresses.c.user_id, addresses.c.id == a.id),
-        ).execute()
+        result = (
+            sa.select(users, addresses)
+            .where(
+                sa.and_(
+                    users.c.id == addresses.c.user_id, addresses.c.id == a.id
+                ),
+            )
+            .execute()
+        )
         eq_(
             list(result.first()),
             [a.user.id, "asdf8d", a.id, a.user_id, "theater@foo.com"],

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -1234,7 +1234,7 @@ class DefaultRequirements(SuiteRequirements):
             expr = decimal.Decimal("15.7563")
 
             value = e.scalar(
-                select([literal(expr)])
+                select(literal(expr))
             )
 
             assert value == expr

--- a/test/sql/test_compare.py
+++ b/test/sql/test_compare.py
@@ -213,13 +213,13 @@ class CoreFixtures(object):
                 {"orm": True, "parententity": MyEntity("b", table_a)}
             ),
             table_a.c.a._annotate(
-                {"orm": True, "parententity": MyEntity("b", select([table_a]))}
+                {"orm": True, "parententity": MyEntity("b", select(table_a))}
             ),
             table_a.c.a._annotate(
                 {
                     "orm": True,
                     "parententity": MyEntity(
-                        "b", select([table_a]).where(table_a.c.a == 5)
+                        "b", select(table_a).where(table_a.c.a == 5)
                     ),
                 }
             ),
@@ -235,7 +235,7 @@ class CoreFixtures(object):
                 {"orm": True, "parententity": MyEntity("b", table_a)}
             ),
             table_a._annotate(
-                {"orm": True, "parententity": MyEntity("b", select([table_a]))}
+                {"orm": True, "parententity": MyEntity("b", select(table_a))}
             ),
         ),
         lambda: (
@@ -350,25 +350,25 @@ class CoreFixtures(object):
             Slice(2, 10, 15),
         ),
         lambda: (
-            select([table_a.c.a]),
-            select([table_a.c.a, table_a.c.b]),
-            select([table_a.c.b, table_a.c.a]),
-            select([table_a.c.b, table_a.c.a]).limit(5),
-            select([table_a.c.b, table_a.c.a]).limit(5).offset(10),
-            select([table_a.c.b, table_a.c.a])
+            select(table_a.c.a),
+            select(table_a.c.a, table_a.c.b),
+            select(table_a.c.b, table_a.c.a),
+            select(table_a.c.b, table_a.c.a).limit(5),
+            select(table_a.c.b, table_a.c.a).limit(5).offset(10),
+            select(table_a.c.b, table_a.c.a)
             .limit(literal_column("foobar"))
             .offset(10),
-            select([table_a.c.b, table_a.c.a]).apply_labels(),
-            select([table_a.c.a]).where(table_a.c.b == 5),
-            select([table_a.c.a])
+            select(table_a.c.b, table_a.c.a).apply_labels(),
+            select(table_a.c.a).where(table_a.c.b == 5),
+            select(table_a.c.a)
             .where(table_a.c.b == 5)
             .where(table_a.c.a == 10),
-            select([table_a.c.a]).where(table_a.c.b == 5).with_for_update(),
-            select([table_a.c.a])
+            select(table_a.c.a).where(table_a.c.b == 5).with_for_update(),
+            select(table_a.c.a)
             .where(table_a.c.b == 5)
             .with_for_update(nowait=True),
-            select([table_a.c.a]).where(table_a.c.b == 5).correlate(table_b),
-            select([table_a.c.a])
+            select(table_a.c.a).where(table_a.c.b == 5).correlate(table_b),
+            select(table_a.c.a)
             .where(table_a.c.b == 5)
             .correlate_except(table_b),
         ),
@@ -389,19 +389,19 @@ class CoreFixtures(object):
             select(table_a.c.a).join(table_c, table_a.c.a == table_c.c.x),
         ),
         lambda: (
-            select([table_a.c.a]).cte(),
-            select([table_a.c.a]).cte(recursive=True),
-            select([table_a.c.a]).cte(name="some_cte", recursive=True),
-            select([table_a.c.a]).cte(name="some_cte"),
-            select([table_a.c.a]).cte(name="some_cte").alias("other_cte"),
-            select([table_a.c.a])
+            select(table_a.c.a).cte(),
+            select(table_a.c.a).cte(recursive=True),
+            select(table_a.c.a).cte(name="some_cte", recursive=True),
+            select(table_a.c.a).cte(name="some_cte"),
+            select(table_a.c.a).cte(name="some_cte").alias("other_cte"),
+            select(table_a.c.a)
             .cte(name="some_cte")
-            .union_all(select([table_a.c.a])),
-            select([table_a.c.a])
+            .union_all(select(table_a.c.a)),
+            select(table_a.c.a)
             .cte(name="some_cte")
-            .union_all(select([table_a.c.b])),
-            select([table_a.c.a]).lateral(),
-            select([table_a.c.a]).lateral(name="bar"),
+            .union_all(select(table_a.c.b)),
+            select(table_a.c.a).lateral(),
+            select(table_a.c.a).lateral(name="bar"),
             table_a.tablesample(func.bernoulli(1)),
             table_a.tablesample(func.bernoulli(1), seed=func.random()),
             table_a.tablesample(func.bernoulli(1), seed=func.other_random()),
@@ -416,12 +416,12 @@ class CoreFixtures(object):
             table_a.insert().values({})._annotate({"nocache": True}),
             table_b.insert(),
             table_b.insert().with_dialect_options(sqlite_foo="some value"),
-            table_b.insert().from_select(["a", "b"], select([table_a])),
+            table_b.insert().from_select(["a", "b"], select(table_a)),
             table_b.insert().from_select(
-                ["a", "b"], select([table_a]).where(table_a.c.a > 5)
+                ["a", "b"], select(table_a).where(table_a.c.a > 5)
             ),
-            table_b.insert().from_select(["a", "b"], select([table_b])),
-            table_b.insert().from_select(["c", "d"], select([table_a])),
+            table_b.insert().from_select(["a", "b"], select(table_b)),
+            table_b.insert().from_select(["c", "d"], select(table_a)),
             table_b.insert().returning(table_b.c.a),
             table_b.insert().returning(table_b.c.a, table_b.c.b),
             table_b.insert().inline(),
@@ -524,31 +524,31 @@ class CoreFixtures(object):
             # ),
         ),
         lambda: (
-            select([table_a.c.a]),
-            select([table_a.c.a]).prefix_with("foo"),
-            select([table_a.c.a]).prefix_with("foo", dialect="mysql"),
-            select([table_a.c.a]).prefix_with("foo", dialect="postgresql"),
-            select([table_a.c.a]).prefix_with("bar"),
-            select([table_a.c.a]).suffix_with("bar"),
+            select(table_a.c.a),
+            select(table_a.c.a).prefix_with("foo"),
+            select(table_a.c.a).prefix_with("foo", dialect="mysql"),
+            select(table_a.c.a).prefix_with("foo", dialect="postgresql"),
+            select(table_a.c.a).prefix_with("bar"),
+            select(table_a.c.a).suffix_with("bar"),
         ),
         lambda: (
-            select([table_a_2.c.a]),
-            select([table_a_2_fs.c.a]),
-            select([table_a_2_bs.c.a]),
+            select(table_a_2.c.a),
+            select(table_a_2_fs.c.a),
+            select(table_a_2_bs.c.a),
         ),
         lambda: (
-            select([table_a.c.a]),
-            select([table_a.c.a]).with_hint(None, "some hint"),
-            select([table_a.c.a]).with_hint(None, "some other hint"),
-            select([table_a.c.a]).with_hint(table_a, "some hint"),
-            select([table_a.c.a])
+            select(table_a.c.a),
+            select(table_a.c.a).with_hint(None, "some hint"),
+            select(table_a.c.a).with_hint(None, "some other hint"),
+            select(table_a.c.a).with_hint(table_a, "some hint"),
+            select(table_a.c.a)
             .with_hint(table_a, "some hint")
             .with_hint(None, "some other hint"),
-            select([table_a.c.a]).with_hint(table_a, "some other hint"),
-            select([table_a.c.a]).with_hint(
+            select(table_a.c.a).with_hint(table_a, "some other hint"),
+            select(table_a.c.a).with_hint(
                 table_a, "some hint", dialect_name="mysql"
             ),
-            select([table_a.c.a]).with_hint(
+            select(table_a.c.a).with_hint(
                 table_a, "some hint", dialect_name="postgresql"
             ),
         ),
@@ -564,32 +564,32 @@ class CoreFixtures(object):
             table_a.alias("b"),
             table_a.alias(),
             table_b.alias("a"),
-            select([table_a.c.a]).alias("a"),
+            select(table_a.c.a).alias("a"),
         ),
         lambda: (
             FromGrouping(table_a.alias("a")),
             FromGrouping(table_a.alias("b")),
         ),
         lambda: (
-            SelectStatementGrouping(select([table_a])),
-            SelectStatementGrouping(select([table_b])),
+            SelectStatementGrouping(select(table_a)),
+            SelectStatementGrouping(select(table_b)),
         ),
         lambda: (
-            select([table_a.c.a]).scalar_subquery(),
-            select([table_a.c.a]).where(table_a.c.b == 5).scalar_subquery(),
+            select(table_a.c.a).scalar_subquery(),
+            select(table_a.c.a).where(table_a.c.b == 5).scalar_subquery(),
         ),
         lambda: (
             exists().where(table_a.c.a == 5),
             exists().where(table_a.c.b == 5),
         ),
         lambda: (
-            union(select([table_a.c.a]), select([table_a.c.b])),
-            union(select([table_a.c.a]), select([table_a.c.b])).order_by("a"),
-            union_all(select([table_a.c.a]), select([table_a.c.b])),
-            union(select([table_a.c.a])),
+            union(select(table_a.c.a), select(table_a.c.b)),
+            union(select(table_a.c.a), select(table_a.c.b)).order_by("a"),
+            union_all(select(table_a.c.a), select(table_a.c.b)),
+            union(select(table_a.c.a)),
             union(
-                select([table_a.c.a]),
-                select([table_a.c.b]).where(table_a.c.b > 5),
+                select(table_a.c.a),
+                select(table_a.c.b).where(table_a.c.b > 5),
             ),
         ),
         lambda: (
@@ -626,7 +626,7 @@ class CoreFixtures(object):
             a2 = table_b_like_a.alias()
 
             stmt = (
-                select([table_a.c.a, a1.c.b, a2.c.b])
+                select(table_a.c.a, a1.c.b, a2.c.b)
                 .where(table_a.c.b == a1.c.b)
                 .where(a1.c.b == a2.c.b)
                 .where(a1.c.a == 5)
@@ -639,7 +639,7 @@ class CoreFixtures(object):
             a2 = table_a.alias()
 
             stmt = (
-                select([table_a.c.a, a1.c.b, a2.c.b])
+                select(table_a.c.a, a1.c.b, a2.c.b)
                 .where(table_a.c.b == a1.c.b)
                 .where(a1.c.b == a2.c.b)
                 .where(a1.c.a == 5)
@@ -650,7 +650,7 @@ class CoreFixtures(object):
         def two():
             inner = one().subquery()
 
-            stmt = select([table_b.c.a, inner.c.a, inner.c.b]).select_from(
+            stmt = select(table_b.c.a, inner.c.a, inner.c.b).select_from(
                 table_b.join(inner, table_b.c.b == inner.c.b)
             )
 
@@ -663,7 +663,7 @@ class CoreFixtures(object):
             ex = exists().where(table_b.c.b == a1.c.a)
 
             stmt = (
-                select([a1.c.a, a2.c.a])
+                select(a1.c.a, a2.c.a)
                 .select_from(a1.join(a2, a1.c.b == a2.c.b))
                 .where(ex)
             )
@@ -676,15 +676,15 @@ class CoreFixtures(object):
     def _statements_w_context_options_fixtures():
 
         return [
-            select([table_a])._add_context_option(opt1, True),
-            select([table_a])._add_context_option(opt1, 5),
-            select([table_a])
+            select(table_a)._add_context_option(opt1, True),
+            select(table_a)._add_context_option(opt1, 5),
+            select(table_a)
             ._add_context_option(opt1, True)
             ._add_context_option(opt2, True),
-            select([table_a])
+            select(table_a)
             ._add_context_option(opt1, True)
             ._add_context_option(opt2, 5),
-            select([table_a])._add_context_option(opt3, True),
+            select(table_a)._add_context_option(opt3, True),
         ]
 
     fixtures.append(_statements_w_context_options_fixtures)
@@ -696,7 +696,7 @@ class CoreFixtures(object):
             l = c.label(None)
 
             # new case as of Id810f485c5f7ed971529489b84694e02a3356d6d
-            subq = select([l]).subquery()
+            subq = select(l).subquery()
 
             # this creates a ColumnClause as a proxy to the Label() that has
             # an anoymous name, so the column has one too.
@@ -712,7 +712,7 @@ class CoreFixtures(object):
             l = c.label(None)
 
             # new case as of Id810f485c5f7ed971529489b84694e02a3356d6d
-            subq = select([l]).subquery()
+            subq = select(l).subquery()
 
             # this creates a ColumnClause as a proxy to the Label() that has
             # an anoymous name, so the column has one too.
@@ -726,10 +726,10 @@ class CoreFixtures(object):
 
             l1, l2 = table_a.c.a.label(None), table_a.c.b.label(None)
 
-            stmt = select([table_a.c.a, table_a.c.b, l1, l2])
+            stmt = select(table_a.c.a, table_a.c.b, l1, l2)
 
             subq = stmt.subquery()
-            return select([subq]).where(subq.c[2] == 10)
+            return select(subq).where(subq.c[2] == 10)
 
         return (
             one(),
@@ -1060,7 +1060,7 @@ class CacheKeyTest(CacheKeyFixture, CoreFixtures, fixtures.TestBase):
         f2 = Foobar2()
         eq_(f2._generate_cache_key(), None)
 
-        s1 = select([column("q"), Foobar2()])
+        s1 = select(column("q"), Foobar2())
 
         eq_(s1._generate_cache_key(), None)
 
@@ -1093,7 +1093,7 @@ class CacheKeyTest(CacheKeyFixture, CoreFixtures, fixtures.TestBase):
     def test_generative_cache_key_regen(self):
         t1 = table("t1", column("a"), column("b"))
 
-        s1 = select([t1])
+        s1 = select(t1)
 
         ck1 = s1._generate_cache_key()
 
@@ -1108,7 +1108,7 @@ class CacheKeyTest(CacheKeyFixture, CoreFixtures, fixtures.TestBase):
     def test_generative_cache_key_regen_w_del(self):
         t1 = table("t1", column("a"), column("b"))
 
-        s1 = select([t1])
+        s1 = select(t1)
 
         ck1 = s1._generate_cache_key()
 
@@ -1196,17 +1196,17 @@ class CompareAndCopyTest(CoreFixtures, fixtures.TestBase):
 
     def test_compare_col_identity(self):
         stmt1 = (
-            select([table_a.c.a, table_b.c.b])
+            select(table_a.c.a, table_b.c.b)
             .where(table_a.c.a == table_b.c.b)
             .alias()
         )
         stmt1_c = (
-            select([table_a.c.a, table_b.c.b])
+            select(table_a.c.a, table_b.c.b)
             .where(table_a.c.a == table_b.c.b)
             .alias()
         )
 
-        stmt2 = union(select([table_a]), select([table_b]))
+        stmt2 = union(select(table_a), select(table_b))
 
         equivalents = {table_a.c.a: [table_b.c.a]}
 
@@ -1389,12 +1389,12 @@ class CompareClausesTest(fixtures.TestBase):
         is_false(l1.compare(l2))
 
     def test_cache_key_limit_offset_values(self):
-        s1 = select([column("q")]).limit(10)
-        s2 = select([column("q")]).limit(25)
-        s3 = select([column("q")]).limit(25).offset(5)
-        s4 = select([column("q")]).limit(25).offset(18)
-        s5 = select([column("q")]).limit(7).offset(12)
-        s6 = select([column("q")]).limit(literal_column("q")).offset(12)
+        s1 = select(column("q")).limit(10)
+        s2 = select(column("q")).limit(25)
+        s3 = select(column("q")).limit(25).offset(5)
+        s4 = select(column("q")).limit(25).offset(18)
+        s5 = select(column("q")).limit(7).offset(12)
+        s6 = select(column("q")).limit(literal_column("q")).offset(12)
 
         for should_eq_left, should_eq_right in [(s1, s2), (s3, s4), (s3, s5)]:
             eq_(
@@ -1481,8 +1481,8 @@ class CompareClausesTest(fixtures.TestBase):
             x_a.compare(x_b._annotate({"bar": True}), compare_annotations=True)
         )
 
-        s1 = select([t.c.x])._annotate({"foo": True})
-        s2 = select([t.c.x])._annotate({"foo": True})
+        s1 = select(t.c.x)._annotate({"foo": True})
+        s2 = select(t.c.x)._annotate({"foo": True})
 
         is_true(s1.compare(s2, compare_annotations=True))
 
@@ -1504,7 +1504,7 @@ class CompareClausesTest(fixtures.TestBase):
         is_true((t.c.x == 5).compare(x_a == 5))
         is_false((t.c.y == 5).compare(x_a == 5))
 
-        s = select([t]).subquery()
+        s = select(t).subquery()
         x_p = s.c.x
         is_false(x_a.compare(x_p))
         is_false(t.c.x.compare(x_p))

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -4901,11 +4901,12 @@ class CorrelateTest(fixtures.TestBase, AssertsCompiledSQL):
             select(t2, s1.correlate_except(t2).alias())
         )
 
-    def test_correlate_except_none(self):
+    @testing.combinations(False, None)
+    def test_correlate_except_none(self, value):
         t1, t2, s1 = self._fixture()
         self._assert_where_all_correlated(
             select(t1, t2).where(
-                t2.c.a == s1.correlate_except(None).scalar_subquery()
+                t2.c.a == s1.correlate_except(value).scalar_subquery()
             )
         )
 
@@ -4937,10 +4938,11 @@ class CorrelateTest(fixtures.TestBase, AssertsCompiledSQL):
             select(t2).having(t2.c.a == s1.scalar_subquery())
         )
 
-    def test_correlate_disabled_where(self):
+    @testing.combinations(False, None)
+    def test_correlate_disabled_where(self, value):
         t1, t2, s1 = self._fixture()
         self._assert_where_uncorrelated(
-            select(t2).where(t2.c.a == s1.correlate(None).scalar_subquery())
+            select(t2).where(t2.c.a == s1.correlate(value).scalar_subquery())
         )
 
     def test_correlate_disabled_column(self):

--- a/test/sql/test_defaults.py
+++ b/test/sql/test_defaults.py
@@ -384,11 +384,11 @@ class DefaultRoundTripTest(fixtures.TablesTest):
 
         def myupdate_with_ctx(ctx):
             conn = ctx.connection
-            return conn.execute(sa.select([sa.text("13")])).scalar()
+            return conn.execute(sa.select(sa.text("13"))).scalar()
 
         def mydefault_using_connection(ctx):
             conn = ctx.connection
-            return conn.execute(sa.select([sa.text("12")])).scalar()
+            return conn.execute(sa.select(sa.text("12"))).scalar()
 
         use_function_defaults = testing.against("postgresql", "mssql")
         is_oracle = testing.against("oracle")
@@ -413,13 +413,11 @@ class DefaultRoundTripTest(fixtures.TablesTest):
             if is_oracle:
                 ts = conn.scalar(
                     sa.select(
-                        [
-                            func.trunc(
-                                func.current_timestamp(),
-                                sa.literal_column("'DAY'"),
-                                type_=sa.Date,
-                            )
-                        ]
+                        func.trunc(
+                            func.current_timestamp(),
+                            sa.literal_column("'DAY'"),
+                            type_=sa.Date,
+                        )
                     )
                 )
                 currenttime = cls.currenttime = func.trunc(
@@ -530,7 +528,7 @@ class DefaultRoundTripTest(fixtures.TablesTest):
         connection.execute(t.insert())
 
         ctexec = connection.execute(
-            sa.select([self.currenttime.label("now")])
+            sa.select(self.currenttime.label("now"))
         ).scalar()
         result = connection.execute(t.select().order_by(t.c.col1))
         today = datetime.date.today()
@@ -897,14 +895,14 @@ class CTEDefaultTest(fixtures.TablesTest):
             expected = (7, 5)
         elif a == "select":
             conn.execute(q.insert().values(x=5, y=10, z=1))
-            cte = sa.select([q.c.z]).cte("c")
+            cte = sa.select(q.c.z).cte("c")
             expected = (5, 10)
 
         if b == "select":
             conn.execute(p.insert().values(s=1))
-            stmt = select([p.c.s, cte.c.z]).where(p.c.s == cte.c.z)
+            stmt = select(p.c.s, cte.c.z).where(p.c.s == cte.c.z)
         elif b == "insert":
-            sel = select([1, cte.c.z])
+            sel = select(1, cte.c.z)
             stmt = (
                 p.insert().from_select(["s", "t"], sel).returning(p.c.s, p.c.t)
             )
@@ -920,7 +918,7 @@ class CTEDefaultTest(fixtures.TablesTest):
             )
         eq_(list(conn.execute(stmt)), [(1, 1)])
 
-        eq_(conn.execute(select([q.c.x, q.c.y])).first(), expected)
+        eq_(conn.execute(select(q.c.x, q.c.y)).first(), expected)
 
 
 class PKDefaultTest(fixtures.TablesTest):
@@ -938,7 +936,7 @@ class PKDefaultTest(fixtures.TablesTest):
                 "id",
                 Integer,
                 primary_key=True,
-                default=sa.select([func.max(t2.c.nextid)]).scalar_subquery(),
+                default=sa.select(func.max(t2.c.nextid)).scalar_subquery(),
             ),
             Column("data", String(30)),
         )
@@ -1079,7 +1077,7 @@ class EmptyInsertTest(fixtures.TestBase):
         connection.execute(t1.insert())
         eq_(
             1,
-            connection.scalar(select([func.count(text("*"))]).select_from(t1)),
+            connection.scalar(select(func.count(text("*"))).select_from(t1)),
         )
         eq_(True, connection.scalar(t1.select()))
 
@@ -1098,7 +1096,7 @@ class AutoIncrementTest(fixtures.TestBase):
         r = connection.execute(single.insert())
         id_ = r.inserted_primary_key[0]
         eq_(id_, 1)
-        eq_(connection.scalar(sa.select([single.c.id])), 1)
+        eq_(connection.scalar(sa.select(single.c.id)), 1)
 
     def test_autoinc_detection_no_affinity(self):
         class MyType(TypeDecorator):
@@ -1191,7 +1189,7 @@ class AutoIncrementTest(fixtures.TestBase):
         connection.execute(dataset_no_autoinc.insert())
         eq_(
             connection.scalar(
-                select([func.count("*")]).select_from(dataset_no_autoinc)
+                select(func.count("*")).select_from(dataset_no_autoinc)
             ),
             1,
         )
@@ -1209,7 +1207,7 @@ class AutoIncrementTest(fixtures.TestBase):
         connection.execute(dataset_no_autoinc.insert())
         eq_(
             connection.scalar(
-                select([func.count("*")]).select_from(dataset_no_autoinc)
+                select(func.count("*")).select_from(dataset_no_autoinc)
             ),
             1,
         )
@@ -1312,7 +1310,7 @@ class SpecialTypePKTest(fixtures.TestBase):
         self._run_test(server_default="1", autoincrement=False)
 
     def test_clause(self):
-        stmt = select([cast("INT_1", type_=self.MyInteger)]).scalar_subquery()
+        stmt = select(cast("INT_1", type_=self.MyInteger)).scalar_subquery()
         self._run_test(default=stmt)
 
     @testing.requires.returning
@@ -1500,7 +1498,7 @@ class InsertFromSelectTest(fixtures.TablesTest):
 
         table.create(connection)
 
-        sel = select([data.c.x, data.c.y])
+        sel = select(data.c.x, data.c.y)
 
         ins = table.insert().from_select(["x", "y"], sel)
         connection.execute(ins)
@@ -1529,7 +1527,7 @@ class InsertFromSelectTest(fixtures.TablesTest):
 
         table.create(connection)
 
-        sel = select([data.c.x, data.c.y])
+        sel = select(data.c.x, data.c.y)
 
         ins = table.insert().from_select(["x", "y"], sel)
         connection.execute(ins)

--- a/test/sql/test_delete.py
+++ b/test/sql/test_delete.py
@@ -116,7 +116,7 @@ class DeleteTest(_DeleteTestBase, fixtures.TablesTest, AssertsCompiledSQL):
         table1, table2 = self.tables.mytable, self.tables.myothertable
 
         # test a non-correlated WHERE clause
-        s = select([table2.c.othername], table2.c.otherid == 7)
+        s = select(table2.c.othername).where(table2.c.otherid == 7)
         self.assert_compile(
             delete(table1, table1.c.name == s.scalar_subquery()),
             "DELETE FROM mytable "
@@ -131,7 +131,7 @@ class DeleteTest(_DeleteTestBase, fixtures.TablesTest, AssertsCompiledSQL):
         table1, table2 = self.tables.mytable, self.tables.myothertable
 
         # test one that is actually correlated...
-        s = select([table2.c.othername], table2.c.otherid == table1.c.myid)
+        s = select(table2.c.othername).where(table2.c.otherid == table1.c.myid)
         self.assert_compile(
             table1.delete(table1.c.name == s.scalar_subquery()),
             "DELETE FROM mytable "

--- a/test/sql/test_deprecations.py
+++ b/test/sql/test_deprecations.py
@@ -749,7 +749,7 @@ class QuoteTest(fixtures.TestBase, AssertsCompiledSQL):
             r"The SelectBase.select\(\) method is deprecated"
         ):
             self.assert_compile(
-                select([col]).select(),
+                select(col).select(),
                 'SELECT anon_1."NEEDS QUOTES_" FROM '
                 '(SELECT NEEDS QUOTES AS "NEEDS QUOTES_") AS anon_1',
             )
@@ -761,7 +761,7 @@ class QuoteTest(fixtures.TestBase, AssertsCompiledSQL):
             r"The SelectBase.select\(\) method is deprecated"
         ):
             self.assert_compile(
-                select([col]).select(),
+                select(col).select(),
                 'SELECT anon_1."NEEDS QUOTES_" FROM (SELECT NEEDS QUOTES AS '
                 '"NEEDS QUOTES_") AS anon_1',
             )
@@ -773,7 +773,7 @@ class QuoteTest(fixtures.TestBase, AssertsCompiledSQL):
             r"The SelectBase.select\(\) method is deprecated"
         ):
             self.assert_compile(
-                select([col]).select(),
+                select(col).select(),
                 'SELECT anon_1."NEEDS QUOTES" FROM (SELECT NEEDS QUOTES AS '
                 '"NEEDS QUOTES") AS anon_1',
             )
@@ -800,7 +800,7 @@ class TextualSelectTest(fixtures.TestBase, AssertsCompiledSQL):
         with testing.expect_deprecated(
             "The SelectBase.c and SelectBase.columns", "Implicit coercion"
         ):
-            stmt = select([table1.c.myid]).select_from(
+            stmt = select(table1.c.myid).select_from(
                 table1.join(t, table1.c.myid == t.c.id)
             )
         compiled = stmt.compile()
@@ -1468,10 +1468,8 @@ class CursorResultTest(fixtures.TablesTest):
             ).connect() as ins_conn:
                 row = ins_conn.execute(
                     select(
-                        [
-                            literal_column("1").label("case_insensitive"),
-                            literal_column("2").label("CaseSensitive"),
-                        ]
+                        literal_column("1").label("case_insensitive"),
+                        literal_column("2").label("CaseSensitive"),
                     )
                 ).first()
 
@@ -1498,11 +1496,9 @@ class CursorResultTest(fixtures.TablesTest):
             ).connect() as ins_conn:
                 row = ins_conn.execute(
                     select(
-                        [
-                            literal_column("1").label("case_insensitive"),
-                            literal_column("2").label("CaseSensitive"),
-                            text("3 AS screw_up_the_cols"),
-                        ]
+                        literal_column("1").label("case_insensitive"),
+                        literal_column("2").label("CaseSensitive"),
+                        text("3 AS screw_up_the_cols"),
                     )
                 ).first()
 

--- a/test/sql/test_insert.py
+++ b/test/sql/test_insert.py
@@ -131,7 +131,7 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
             Column(
                 "col2",
                 Integer,
-                default=select([func.coalesce(func.max(foo.c.id))]),
+                default=select(func.coalesce(func.max(foo.c.id))),
             ),
         )
 
@@ -332,7 +332,7 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
 
     def test_insert_from_select_returning(self):
         table1 = self.tables.mytable
-        sel = select([table1.c.myid, table1.c.name]).where(
+        sel = select(table1.c.myid, table1.c.name).where(
             table1.c.name == "foo"
         )
         ins = (
@@ -351,7 +351,7 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
 
     def test_insert_from_select_select(self):
         table1 = self.tables.mytable
-        sel = select([table1.c.myid, table1.c.name]).where(
+        sel = select(table1.c.myid, table1.c.name).where(
             table1.c.name == "foo"
         )
         ins = self.tables.myothertable.insert().from_select(
@@ -375,7 +375,7 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
             Column("data", String),
         )
 
-        stmt = t1.insert().from_select(("data",), select([t1.c.data]))
+        stmt = t1.insert().from_select(("data",), select(t1.c.data))
 
         self.assert_compile(
             stmt,
@@ -387,9 +387,9 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
     def test_insert_from_select_cte_one(self):
         table1 = self.tables.mytable
 
-        cte = select([table1.c.name]).where(table1.c.name == "bar").cte()
+        cte = select(table1.c.name).where(table1.c.name == "bar").cte()
 
-        sel = select([table1.c.myid, table1.c.name]).where(
+        sel = select(table1.c.myid, table1.c.name).where(
             table1.c.name == cte.c.name
         )
 
@@ -413,9 +413,9 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
 
         table1 = self.tables.mytable
 
-        cte = select([table1.c.name]).where(table1.c.name == "bar").cte()
+        cte = select(table1.c.name).where(table1.c.name == "bar").cte()
 
-        sel = select([table1.c.myid, table1.c.name]).where(
+        sel = select(table1.c.myid, table1.c.name).where(
             table1.c.name == cte.c.name
         )
 
@@ -469,7 +469,7 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
 
     def test_insert_from_select_select_alt_ordering(self):
         table1 = self.tables.mytable
-        sel = select([table1.c.name, table1.c.myid]).where(
+        sel = select(table1.c.name, table1.c.myid).where(
             table1.c.name == "foo"
         )
         ins = self.tables.myothertable.insert().from_select(
@@ -492,7 +492,7 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
             Column("foo", Integer, default=func.foobar()),
         )
         table1 = self.tables.mytable
-        sel = select([table1.c.myid]).where(table1.c.name == "foo")
+        sel = select(table1.c.myid).where(table1.c.name == "foo")
         ins = table.insert().from_select(["id"], sel, include_defaults=False)
         self.assert_compile(
             ins,
@@ -510,7 +510,7 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
             Column("foo", Integer, default=func.foobar()),
         )
         table1 = self.tables.mytable
-        sel = select([table1.c.myid]).where(table1.c.name == "foo")
+        sel = select(table1.c.myid).where(table1.c.name == "foo")
         ins = table.insert().from_select(["id"], sel)
         self.assert_compile(
             ins,
@@ -529,7 +529,7 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
             Column("foo", Integer, default=12),
         )
         table1 = self.tables.mytable
-        sel = select([table1.c.myid]).where(table1.c.name == "foo")
+        sel = select(table1.c.myid).where(table1.c.name == "foo")
         ins = table.insert().from_select(["id"], sel)
         self.assert_compile(
             ins,
@@ -549,7 +549,7 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
             Column("foo", Integer, default=12),
         )
         table1 = self.tables.mytable
-        sel = select([table1.c.myid, table1.c.myid.label("q")]).where(
+        sel = select(table1.c.myid, table1.c.myid.label("q")).where(
             table1.c.name == "foo"
         )
         ins = table.insert().from_select(["id", "foo"], sel)
@@ -574,7 +574,7 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
             Column("foo", Integer, default=foo),
         )
         table1 = self.tables.mytable
-        sel = select([table1.c.myid]).where(table1.c.name == "foo")
+        sel = select(table1.c.myid).where(table1.c.name == "foo")
         ins = table.insert().from_select(["id"], sel)
         self.assert_compile(
             ins,
@@ -595,7 +595,7 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
             Column("bar", String, default="baz"),
         )
 
-        stmt = select([table_.c.foo])
+        stmt = select(table_.c.foo)
         insert = table_.insert().from_select(["foo"], stmt)
 
         self.assert_compile(stmt, "SELECT mytable.foo FROM mytable")
@@ -613,7 +613,7 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
 
     def test_insert_mix_select_values_exception(self):
         table1 = self.tables.mytable
-        sel = select([table1.c.myid, table1.c.name]).where(
+        sel = select(table1.c.myid, table1.c.name).where(
             table1.c.name == "foo"
         )
         ins = self.tables.myothertable.insert().from_select(
@@ -628,7 +628,7 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
 
     def test_insert_mix_values_select_exception(self):
         table1 = self.tables.mytable
-        sel = select([table1.c.myid, table1.c.name]).where(
+        sel = select(table1.c.myid, table1.c.name).where(
             table1.c.name == "foo"
         )
         ins = self.tables.myothertable.insert().values(othername="5")
@@ -659,8 +659,8 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
 
         name = column("name")
         description = column("desc")
-        sel = select([name, mytable.c.description]).union(
-            select([name, description])
+        sel = select(name, mytable.c.description).union(
+            select(name, description)
         )
         ins = mytable.insert().from_select(
             [mytable.c.name, mytable.c.description], sel
@@ -675,7 +675,7 @@ class InsertTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
     def test_insert_from_select_col_values(self):
         table1 = self.tables.mytable
         table2 = self.tables.myothertable
-        sel = select([table1.c.myid, table1.c.name]).where(
+        sel = select(table1.c.myid, table1.c.name).where(
             table1.c.name == "foo"
         )
         ins = table2.insert().from_select(
@@ -831,7 +831,7 @@ class InsertImplicitReturningTest(
 
     def test_insert_select(self):
         table1 = self.tables.mytable
-        sel = select([table1.c.myid, table1.c.name]).where(
+        sel = select(table1.c.myid, table1.c.name).where(
             table1.c.name == "foo"
         )
         ins = self.tables.myothertable.insert().from_select(
@@ -847,7 +847,7 @@ class InsertImplicitReturningTest(
 
     def test_insert_select_return_defaults(self):
         table1 = self.tables.mytable
-        sel = select([table1.c.myid, table1.c.name]).where(
+        sel = select(table1.c.myid, table1.c.name).where(
             table1.c.name == "foo"
         )
         ins = (

--- a/test/sql/test_labels.py
+++ b/test/sql/test_labels.py
@@ -198,7 +198,7 @@ class MaxIdentTest(fixtures.TestBase, AssertsCompiledSQL):
         ta = table2.alias()
         on = table1.c.this_is_the_data_column == ta.c.this_is_the_data_column
         self.assert_compile(
-            select([table1, ta])
+            select(table1, ta)
             .select_from(table1.join(ta, on))
             .where(ta.c.this_is_the_data_column == "data3"),
             "SELECT "
@@ -283,7 +283,7 @@ class MaxIdentTest(fixtures.TestBase, AssertsCompiledSQL):
         s = table1.select(table1.c.this_is_the_primarykey_column == 4).alias(
             "foo"
         )
-        s2 = select([s])
+        s2 = select(s)
         compiled = s2.compile(dialect=self._length_fixture())
         assert set(
             compiled._create_result_map()["this_is_the_data_column"][1]
@@ -303,7 +303,7 @@ class MaxIdentTest(fixtures.TestBase, AssertsCompiledSQL):
         dialect = self._length_fixture()
 
         q = table1.select(table1.c.this_is_the_primarykey_column == 4).alias()
-        s = select([q]).apply_labels()
+        s = select(q).apply_labels()
 
         self.assert_compile(
             s,
@@ -476,7 +476,7 @@ class LabelLengthTest(fixtures.TestBase, AssertsCompiledSQL):
         q = table1.select(table1.c.this_is_the_primarykey_column == 4).alias(
             "foo"
         )
-        x = select([q])
+        x = select(q)
         compile_dialect = default.DefaultDialect(label_length=10)
         self.assert_compile(
             x,
@@ -504,7 +504,7 @@ class LabelLengthTest(fixtures.TestBase, AssertsCompiledSQL):
         q = table1.select(table1.c.this_is_the_primarykey_column == 4).alias(
             "foo"
         )
-        x = select([q])
+        x = select(q)
 
         compile_dialect = default.DefaultDialect(label_length=10)
         self.assert_compile(
@@ -534,7 +534,7 @@ class LabelLengthTest(fixtures.TestBase, AssertsCompiledSQL):
         q = table1.select(table1.c.this_is_the_primarykey_column == 4).alias(
             "foo"
         )
-        x = select([q])
+        x = select(q)
 
         self.assert_compile(
             x,
@@ -560,7 +560,7 @@ class LabelLengthTest(fixtures.TestBase, AssertsCompiledSQL):
         table1 = self.table1
 
         q = table1.select(table1.c.this_is_the_primarykey_column == 4).alias()
-        x = select([q], use_labels=True)
+        x = select(q).apply_labels()
 
         compile_dialect = default.DefaultDialect(label_length=10)
         self.assert_compile(
@@ -587,7 +587,7 @@ class LabelLengthTest(fixtures.TestBase, AssertsCompiledSQL):
     def test_adjustable_5(self):
         table1 = self.table1
         q = table1.select(table1.c.this_is_the_primarykey_column == 4).alias()
-        x = select([q], use_labels=True)
+        x = select(q).apply_labels()
 
         compile_dialect = default.DefaultDialect(label_length=4)
         self.assert_compile(
@@ -645,7 +645,7 @@ class LabelLengthTest(fixtures.TestBase, AssertsCompiledSQL):
         q = table1.select(table1.c.this_is_the_primarykey_column == 4).alias(
             "foo"
         )
-        x = select([q])
+        x = select(q)
 
         dialect = default.DefaultDialect(label_length=10)
         compiled = x.compile(dialect=dialect)
@@ -688,7 +688,7 @@ class LabelLengthTest(fixtures.TestBase, AssertsCompiledSQL):
         )
 
         self.assert_compile(
-            select([other_table, anon]).select_from(j1).apply_labels(),
+            select(other_table, anon).select_from(j1).apply_labels(),
             "SELECT "
             "other_thirty_characters_table_.id "
             "AS other_thirty_characters__1, "
@@ -720,9 +720,9 @@ class LabelLengthTest(fixtures.TestBase, AssertsCompiledSQL):
 
         # 'abcde' is longer than 4, but rendered as itself
         # needs to have all characters
-        s = select([a1])
+        s = select(a1)
         self.assert_compile(
-            select([a1]), "SELECT asdf.abcde FROM a AS asdf", dialect=dialect
+            select(a1), "SELECT asdf.abcde FROM a AS asdf", dialect=dialect
         )
         compiled = s.compile(dialect=dialect)
         assert set(compiled._create_result_map()["abcde"][1]).issuperset(
@@ -730,7 +730,7 @@ class LabelLengthTest(fixtures.TestBase, AssertsCompiledSQL):
         )
 
         # column still there, but short label
-        s = select([a1]).apply_labels()
+        s = select(a1).apply_labels()
         self.assert_compile(
             s, "SELECT asdf.abcde AS _1 FROM a AS asdf", dialect=dialect
         )
@@ -746,7 +746,7 @@ class LabelLengthTest(fixtures.TestBase, AssertsCompiledSQL):
             "tablename", column("columnname_one"), column("columnn_1")
         )
 
-        stmt = select([table1]).apply_labels()
+        stmt = select(table1).apply_labels()
 
         dialect = default.DefaultDialect(label_length=23)
         self.assert_compile(
@@ -797,12 +797,10 @@ class ColExprLabelTest(fixtures.TestBase, AssertsCompiledSQL):
 
         self.assert_compile(
             select(
-                [
-                    table1.c.name,
-                    table1.c.name,
-                    expr(table1.c.name),
-                    expr(table1.c.name),
-                ]
+                table1.c.name,
+                table1.c.name,
+                expr(table1.c.name),
+                expr(table1.c.name),
             ),
             "SELECT some_table.name, some_table.name, "
             "SOME_COL_THING(some_table.name) AS name, "
@@ -814,7 +812,7 @@ class ColExprLabelTest(fixtures.TestBase, AssertsCompiledSQL):
         table1 = self.table1
 
         self.assert_compile(
-            select([table1.c.name + "foo", expr(table1.c.name + "foo")]),
+            select(table1.c.name + "foo", expr(table1.c.name + "foo")),
             "SELECT some_table.name || :name_1 AS anon_1, "
             "SOME_COL_THING(some_table.name || :name_2) AS anon_2 "
             "FROM some_table",
@@ -826,7 +824,7 @@ class ColExprLabelTest(fixtures.TestBase, AssertsCompiledSQL):
 
         self.assert_compile(
             select(
-                [table1.c.name + "foo", expr(table1.c.name + "foo")]
+                table1.c.name + "foo", expr(table1.c.name + "foo")
             ).apply_labels(),
             "SELECT some_table.name || :name_1 AS anon_1, "
             "SOME_COL_THING(some_table.name || :name_2) AS anon_2 "
@@ -839,11 +837,9 @@ class ColExprLabelTest(fixtures.TestBase, AssertsCompiledSQL):
 
         self.assert_compile(
             select(
-                [
-                    expr(table1.c.name.label("foo")),
-                    table1.c.name.label("bar"),
-                    table1.c.value,
-                ]
+                expr(table1.c.name.label("foo")),
+                table1.c.name.label("bar"),
+                table1.c.value,
             ),
             "SELECT SOME_COL_THING(some_table.name) AS foo, "
             "some_table.name AS bar, some_table.value FROM some_table",
@@ -854,11 +850,9 @@ class ColExprLabelTest(fixtures.TestBase, AssertsCompiledSQL):
 
         self.assert_compile(
             select(
-                [
-                    cast(table1.c.name, Integer),
-                    cast(table1.c.name, String),
-                    table1.c.name,
-                ]
+                cast(table1.c.name, Integer),
+                cast(table1.c.name, String),
+                table1.c.name,
             ),
             "SELECT CAST(some_table.name AS INTEGER) AS name, "
             "CAST(some_table.name AS VARCHAR) AS name, "
@@ -870,11 +864,9 @@ class ColExprLabelTest(fixtures.TestBase, AssertsCompiledSQL):
 
         self.assert_compile(
             select(
-                [
-                    type_coerce(table1.c.name, Integer),
-                    type_coerce(table1.c.name, String),
-                    table1.c.name,
-                ]
+                type_coerce(table1.c.name, Integer),
+                type_coerce(table1.c.name, String),
+                table1.c.name,
             ),
             # ideally type_coerce wouldn't label at all...
             "SELECT some_table.name AS name, "
@@ -886,7 +878,7 @@ class ColExprLabelTest(fixtures.TestBase, AssertsCompiledSQL):
         col = column("value", Boolean)
 
         self.assert_compile(
-            select([~col, col]),
+            select(~col, col),
             # not sure if this SQL is right but this is what it was
             # before the new labeling, just different label name
             "SELECT value = 0 AS value, value",
@@ -898,11 +890,9 @@ class ColExprLabelTest(fixtures.TestBase, AssertsCompiledSQL):
 
         self.assert_compile(
             select(
-                [
-                    expr(table1.c.name.label("foo")),
-                    table1.c.name.label("bar"),
-                    table1.c.value,
-                ]
+                expr(table1.c.name.label("foo")),
+                table1.c.name.label("bar"),
+                table1.c.value,
             ).apply_labels(),
             # the expr around label is treated the same way as plain column
             # with label
@@ -917,12 +907,10 @@ class ColExprLabelTest(fixtures.TestBase, AssertsCompiledSQL):
 
         self.assert_compile(
             select(
-                [
-                    table1.c.name,
-                    table1.c.name,
-                    expr(table1.c.name),
-                    expr(table1.c.name),
-                ]
+                table1.c.name,
+                table1.c.name,
+                expr(table1.c.name),
+                expr(table1.c.name),
             ).apply_labels(),
             "SELECT some_table.name AS some_table_name, "
             "some_table.name AS some_table_name__1, "
@@ -936,7 +924,7 @@ class ColExprLabelTest(fixtures.TestBase, AssertsCompiledSQL):
         table1 = self.table1
 
         self.assert_compile(
-            select([table1.c.name, expr(table1.c.value)]).apply_labels(),
+            select(table1.c.name, expr(table1.c.value)).apply_labels(),
             "SELECT some_table.name AS some_table_name, "
             "SOME_COL_THING(some_table.value) "
             "AS some_table_value FROM some_table",

--- a/test/sql/test_lateral.py
+++ b/test/sql/test_lateral.py
@@ -57,7 +57,7 @@ class LateralTest(fixtures.TablesTest, AssertsCompiledSQL):
 
     def test_standalone(self):
         table1 = self.tables.people
-        subq = select([table1.c.people_id]).subquery()
+        subq = select(table1.c.people_id).subquery()
 
         # alias name is not rendered because subquery is not
         # in the context of a FROM clause
@@ -73,7 +73,7 @@ class LateralTest(fixtures.TablesTest, AssertsCompiledSQL):
 
     def test_standalone_implicit_subquery(self):
         table1 = self.tables.people
-        subq = select([table1.c.people_id])
+        subq = select(table1.c.people_id)
 
         # alias name is not rendered because subquery is not
         # in the context of a FROM clause
@@ -89,22 +89,22 @@ class LateralTest(fixtures.TablesTest, AssertsCompiledSQL):
 
     def test_select_from(self):
         table1 = self.tables.people
-        subq = select([table1.c.people_id]).subquery()
+        subq = select(table1.c.people_id).subquery()
 
         # in a FROM context, now you get "AS alias" and column labeling
         self.assert_compile(
-            select([subq.lateral(name="alias")]),
+            select(subq.lateral(name="alias")),
             "SELECT alias.people_id FROM LATERAL "
             "(SELECT people.people_id AS people_id FROM people) AS alias",
         )
 
     def test_select_from_implicit_subquery(self):
         table1 = self.tables.people
-        subq = select([table1.c.people_id])
+        subq = select(table1.c.people_id)
 
         # in a FROM context, now you get "AS alias" and column labeling
         self.assert_compile(
-            select([subq.lateral(name="alias")]),
+            select(subq.lateral(name="alias")),
             "SELECT alias.people_id FROM LATERAL "
             "(SELECT people.people_id AS people_id FROM people) AS alias",
         )
@@ -115,7 +115,7 @@ class LateralTest(fixtures.TablesTest, AssertsCompiledSQL):
 
         # in a FROM context, now you get "AS alias" and column labeling
         self.assert_compile(
-            select([subq.lateral(name="alias")]),
+            select(subq.lateral(name="alias")),
             "SELECT alias.people_id FROM LATERAL "
             "(SELECT people_id FROM people) AS alias",
         )
@@ -123,7 +123,7 @@ class LateralTest(fixtures.TablesTest, AssertsCompiledSQL):
     def test_plain_join(self):
         table1 = self.tables.people
         table2 = self.tables.books
-        subq = select([table2.c.book_id]).where(
+        subq = select(table2.c.book_id).where(
             table2.c.book_owner_id == table1.c.people_id
         )
 
@@ -138,7 +138,7 @@ class LateralTest(fixtures.TablesTest, AssertsCompiledSQL):
 
         # put it in correct context, implicit correlation works fine
         self.assert_compile(
-            select([table1]).select_from(
+            select(table1).select_from(
                 join(table1, lateral(subq.subquery(), name="alias"), true())
             ),
             "SELECT people.people_id, people.age, people.name "
@@ -150,7 +150,7 @@ class LateralTest(fixtures.TablesTest, AssertsCompiledSQL):
         # explicit correlation
         subq = subq.correlate(table1)
         self.assert_compile(
-            select([table1]).select_from(
+            select(table1).select_from(
                 join(table1, lateral(subq.subquery(), name="alias"), true())
             ),
             "SELECT people.people_id, people.age, people.name "
@@ -162,7 +162,7 @@ class LateralTest(fixtures.TablesTest, AssertsCompiledSQL):
     def test_plain_join_implicit_subquery(self):
         table1 = self.tables.people
         table2 = self.tables.books
-        subq = select([table2.c.book_id]).where(
+        subq = select(table2.c.book_id).where(
             table2.c.book_owner_id == table1.c.people_id
         )
 
@@ -177,7 +177,7 @@ class LateralTest(fixtures.TablesTest, AssertsCompiledSQL):
 
         # put it in correct context, implicit correlation works fine
         self.assert_compile(
-            select([table1]).select_from(
+            select(table1).select_from(
                 join(table1, lateral(subq, name="alias"), true())
             ),
             "SELECT people.people_id, people.age, people.name "
@@ -189,7 +189,7 @@ class LateralTest(fixtures.TablesTest, AssertsCompiledSQL):
         # explicit correlation
         subq = subq.correlate(table1)
         self.assert_compile(
-            select([table1]).select_from(
+            select(table1).select_from(
                 join(table1, lateral(subq, name="alias"), true())
             ),
             "SELECT people.people_id, people.age, people.name "
@@ -203,13 +203,13 @@ class LateralTest(fixtures.TablesTest, AssertsCompiledSQL):
         table2 = self.tables.books
 
         subq = (
-            select([table2.c.book_id])
+            select(table2.c.book_id)
             .correlate(table1)
             .where(table1.c.people_id == table2.c.book_owner_id)
             .subquery()
             .lateral()
         )
-        stmt = select([table1, subq.c.book_id]).select_from(
+        stmt = select(table1, subq.c.book_id).select_from(
             table1.join(subq, true())
         )
 
@@ -226,12 +226,12 @@ class LateralTest(fixtures.TablesTest, AssertsCompiledSQL):
         table2 = self.tables.books
 
         subq = (
-            select([table2.c.book_id])
+            select(table2.c.book_id)
             .correlate(table1)
             .where(table1.c.people_id == table2.c.book_owner_id)
             .lateral()
         )
-        stmt = select([table1, subq.c.book_id]).select_from(
+        stmt = select(table1, subq.c.book_id).select_from(
             table1.join(subq, true())
         )
 
@@ -250,7 +250,7 @@ class LateralTest(fixtures.TablesTest, AssertsCompiledSQL):
         srf = lateral(func.generate_series(1, bookcases.c.bookcase_shelves))
 
         self.assert_compile(
-            select([bookcases]).select_from(bookcases.join(srf, true())),
+            select(bookcases).select_from(bookcases.join(srf, true())),
             "SELECT bookcases.bookcase_id, bookcases.bookcase_owner_id, "
             "bookcases.bookcase_shelves, bookcases.bookcase_width "
             "FROM bookcases JOIN "

--- a/test/sql/test_metadata.py
+++ b/test/sql/test_metadata.py
@@ -2801,7 +2801,7 @@ class ConstraintTest(fixtures.TestBase):
 
     def test_column_references_derived(self):
         t1, t2, t3 = self._single_fixture()
-        s1 = tsa.select([tsa.select([t1]).alias()]).subquery()
+        s1 = tsa.select(tsa.select(t1).alias()).subquery()
         assert t2.c.a.references(s1.c.a)
         assert not t2.c.a.references(s1.c.b)
 
@@ -2813,7 +2813,7 @@ class ConstraintTest(fixtures.TestBase):
 
     def test_derived_column_references(self):
         t1, t2, t3 = self._single_fixture()
-        s1 = tsa.select([tsa.select([t2]).alias()]).subquery()
+        s1 = tsa.select(tsa.select(t2).alias()).subquery()
         assert s1.c.a.references(t1.c.a)
         assert not s1.c.a.references(t1.c.b)
 
@@ -2932,7 +2932,7 @@ class ConstraintTest(fixtures.TestBase):
             Column("id", Integer, ForeignKey("t1.id"), primary_key=True),
         )
 
-        s = tsa.select([t2]).subquery()
+        s = tsa.select(t2).subquery()
         t2fk = list(t2.c.id.foreign_keys)[0]
         sfk = list(s.c.id.foreign_keys)[0]
 
@@ -3770,14 +3770,14 @@ class ColumnDefinitionTest(AssertsCompiledSQL, fixtures.TestBase):
         eq_(t1.c.name.my_goofy_thing(), "hi")
 
         # create proxy
-        s = select([t1.select().alias()])
+        s = select(t1.select().alias())
 
         # proxy has goofy thing
         eq_(s.subquery().c.name.my_goofy_thing(), "hi")
 
         # compile works
         self.assert_compile(
-            select([t1.select().alias()]),
+            select(t1.select().alias()),
             "SELECT anon_1.id-, anon_1.name- FROM "
             "(SELECT foo.id- AS id, foo.name- AS name "
             "FROM foo) AS anon_1",
@@ -3802,7 +3802,7 @@ class ColumnDefinitionTest(AssertsCompiledSQL, fixtures.TestBase):
             "'test.sql.test_metadata..*MyColumn'> "
             "object.  Ensure the class includes a _constructor()",
             getattr,
-            select([t1.select().alias()]).subquery(),
+            select(t1.select().alias()).subquery(),
             "c",
         )
 

--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -918,7 +918,7 @@ class BooleanEvalTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_one(self):
         c = column("x", Boolean)
         self.assert_compile(
-            select([c]).where(c),
+            select(c).where(c),
             "SELECT x WHERE x",
             dialect=self._dialect(True),
         )
@@ -926,7 +926,7 @@ class BooleanEvalTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_two_a(self):
         c = column("x", Boolean)
         self.assert_compile(
-            select([c]).where(c),
+            select(c).where(c),
             "SELECT x WHERE x = 1",
             dialect=self._dialect(False),
         )
@@ -934,7 +934,7 @@ class BooleanEvalTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_two_b(self):
         c = column("x", Boolean)
         self.assert_compile(
-            select([c], whereclause=c),
+            select(c).where(c),
             "SELECT x WHERE x = 1",
             dialect=self._dialect(False),
         )
@@ -942,7 +942,7 @@ class BooleanEvalTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_three_a(self):
         c = column("x", Boolean)
         self.assert_compile(
-            select([c]).where(~c),
+            select(c).where(~c),
             "SELECT x WHERE x = 0",
             dialect=self._dialect(False),
         )
@@ -950,7 +950,7 @@ class BooleanEvalTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_three_a_double(self):
         c = column("x", Boolean)
         self.assert_compile(
-            select([c]).where(~~c),
+            select(c).where(~~c),
             "SELECT x WHERE x = 1",
             dialect=self._dialect(False),
         )
@@ -958,7 +958,7 @@ class BooleanEvalTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_three_b(self):
         c = column("x", Boolean)
         self.assert_compile(
-            select([c], whereclause=~c),
+            select(c).where(~c),
             "SELECT x WHERE x = 0",
             dialect=self._dialect(False),
         )
@@ -966,7 +966,7 @@ class BooleanEvalTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_four(self):
         c = column("x", Boolean)
         self.assert_compile(
-            select([c]).where(~c),
+            select(c).where(~c),
             "SELECT x WHERE NOT x",
             dialect=self._dialect(True),
         )
@@ -974,7 +974,7 @@ class BooleanEvalTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_four_double(self):
         c = column("x", Boolean)
         self.assert_compile(
-            select([c]).where(~~c),
+            select(c).where(~~c),
             "SELECT x WHERE x",
             dialect=self._dialect(True),
         )
@@ -982,7 +982,7 @@ class BooleanEvalTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_five_a(self):
         c = column("x", Boolean)
         self.assert_compile(
-            select([c]).having(c),
+            select(c).having(c),
             "SELECT x HAVING x = 1",
             dialect=self._dialect(False),
         )
@@ -990,7 +990,7 @@ class BooleanEvalTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_five_b(self):
         c = column("x", Boolean)
         self.assert_compile(
-            select([c], having=c),
+            select(c).having(c),
             "SELECT x HAVING x = 1",
             dialect=self._dialect(False),
         )
@@ -1155,11 +1155,11 @@ class ConjunctionTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_six_pt_five(self):
         x = column("x")
         self.assert_compile(
-            select([x]).where(or_(x == 7, true())), "SELECT x WHERE true"
+            select(x).where(or_(x == 7, true())), "SELECT x WHERE true"
         )
 
         self.assert_compile(
-            select([x]).where(or_(x == 7, true())),
+            select(x).where(or_(x == 7, true())),
             "SELECT x WHERE 1 = 1",
             dialect=default.DefaultDialect(supports_native_boolean=False),
         )
@@ -1187,26 +1187,26 @@ class ConjunctionTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_eleven(self):
         x = column("x")
         self.assert_compile(
-            select([x]).where(None).where(None), "SELECT x WHERE NULL AND NULL"
+            select(x).where(None).where(None), "SELECT x WHERE NULL AND NULL"
         )
 
     def test_twelve(self):
         x = column("x")
         self.assert_compile(
-            select([x]).where(and_(None, None)), "SELECT x WHERE NULL AND NULL"
+            select(x).where(and_(None, None)), "SELECT x WHERE NULL AND NULL"
         )
 
     def test_thirteen(self):
         x = column("x")
         self.assert_compile(
-            select([x]).where(~and_(None, None)),
+            select(x).where(~and_(None, None)),
             "SELECT x WHERE NOT (NULL AND NULL)",
         )
 
     def test_fourteen(self):
         x = column("x")
         self.assert_compile(
-            select([x]).where(~null()), "SELECT x WHERE NOT NULL"
+            select(x).where(~null()), "SELECT x WHERE NOT NULL"
         )
 
     def test_constants_are_singleton(self):
@@ -1216,27 +1216,27 @@ class ConjunctionTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
     def test_constant_render_distinct(self):
         self.assert_compile(
-            select([null(), null()]), "SELECT NULL AS anon_1, NULL AS anon__1"
+            select(null(), null()), "SELECT NULL AS anon_1, NULL AS anon__1"
         )
         self.assert_compile(
-            select([true(), true()]), "SELECT true AS anon_1, true AS anon__1"
+            select(true(), true()), "SELECT true AS anon_1, true AS anon__1"
         )
         self.assert_compile(
-            select([false(), false()]),
+            select(false(), false()),
             "SELECT false AS anon_1, false AS anon__1",
         )
 
     def test_constant_render_distinct_use_labels(self):
         self.assert_compile(
-            select([null(), null()]).apply_labels(),
+            select(null(), null()).apply_labels(),
             "SELECT NULL AS anon_1, NULL AS anon__1",
         )
         self.assert_compile(
-            select([true(), true()]).apply_labels(),
+            select(true(), true()).apply_labels(),
             "SELECT true AS anon_1, true AS anon__1",
         )
         self.assert_compile(
-            select([false(), false()]).apply_labels(),
+            select(false(), false()).apply_labels(),
             "SELECT false AS anon_1, false AS anon__1",
         )
 
@@ -1409,7 +1409,7 @@ class OperatorPrecedenceTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
     def test_operator_precedence_collate_5(self):
         self.assert_compile(
-            select([self.table1.c.name]).order_by(
+            select(self.table1.c.name).order_by(
                 self.table1.c.name.collate("utf-8").desc()
             ),
             "SELECT mytable.name FROM mytable "
@@ -1418,7 +1418,7 @@ class OperatorPrecedenceTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
     def test_operator_precedence_collate_6(self):
         self.assert_compile(
-            select([self.table1.c.name]).order_by(
+            select(self.table1.c.name).order_by(
                 self.table1.c.name.collate("utf-8").desc().nullslast()
             ),
             "SELECT mytable.name FROM mytable "
@@ -1427,7 +1427,7 @@ class OperatorPrecedenceTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
     def test_operator_precedence_collate_7(self):
         self.assert_compile(
-            select([self.table1.c.name]).order_by(
+            select(self.table1.c.name).order_by(
                 self.table1.c.name.collate("utf-8").asc()
             ),
             "SELECT mytable.name FROM mytable "
@@ -1780,13 +1780,13 @@ class InTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
     def test_in_20(self):
         self.assert_compile(
-            self.table1.c.myid.in_(select([self.table2.c.otherid])),
+            self.table1.c.myid.in_(select(self.table2.c.otherid)),
             "mytable.myid IN (SELECT myothertable.otherid FROM myothertable)",
         )
 
     def test_in_21(self):
         self.assert_compile(
-            ~self.table1.c.myid.in_(select([self.table2.c.otherid])),
+            ~self.table1.c.myid.in_(select(self.table2.c.otherid)),
             "mytable.myid NOT IN "
             "(SELECT myothertable.otherid FROM myothertable)",
         )
@@ -1802,7 +1802,7 @@ class InTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
     def test_in_24(self):
         self.assert_compile(
-            select([self.table1.c.myid.in_(select([self.table2.c.otherid]))]),
+            select(self.table1.c.myid.in_(select(self.table2.c.otherid))),
             "SELECT mytable.myid IN (SELECT myothertable.otherid "
             "FROM myothertable) AS anon_1 FROM mytable",
         )
@@ -1810,11 +1810,9 @@ class InTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_in_25(self):
         self.assert_compile(
             select(
-                [
-                    self.table1.c.myid.in_(
-                        select([self.table2.c.otherid]).scalar_subquery()
-                    )
-                ]
+                self.table1.c.myid.in_(
+                    select(self.table2.c.otherid).scalar_subquery()
+                )
             ),
             "SELECT mytable.myid IN (SELECT myothertable.otherid "
             "FROM myothertable) AS anon_1 FROM mytable",
@@ -1824,8 +1822,8 @@ class InTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         self.assert_compile(
             self.table1.c.myid.in_(
                 union(
-                    select([self.table1.c.myid], self.table1.c.myid == 5),
-                    select([self.table1.c.myid], self.table1.c.myid == 12),
+                    select(self.table1.c.myid).where(self.table1.c.myid == 5),
+                    select(self.table1.c.myid).where(self.table1.c.myid == 12),
                 )
             ),
             "mytable.myid IN ("
@@ -1838,24 +1836,21 @@ class InTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         # test that putting a select in an IN clause does not
         # blow away its ORDER BY clause
         self.assert_compile(
-            select(
-                [self.table1, self.table2],
+            select(self.table1, self.table2)
+            .where(
                 self.table2.c.otherid.in_(
-                    select(
-                        [self.table2.c.otherid],
-                        order_by=[self.table2.c.othername],
-                        limit=10,
-                        correlate=False,
-                    )
-                ),
-                from_obj=[
-                    self.table1.join(
-                        self.table2,
-                        self.table1.c.myid == self.table2.c.otherid,
-                    )
-                ],
-                order_by=[self.table1.c.myid],
-            ),
+                    select(self.table2.c.otherid)
+                    .order_by(self.table2.c.othername)
+                    .limit(10)
+                    .correlate(False),
+                )
+            )
+            .select_from(
+                self.table1.join(
+                    self.table2, self.table1.c.myid == self.table2.c.otherid,
+                )
+            )
+            .order_by(self.table1.c.myid),
             "SELECT mytable.myid, "
             "myothertable.otherid, myothertable.othername FROM mytable "
             "JOIN myothertable ON mytable.myid = myothertable.otherid "
@@ -2166,7 +2161,7 @@ class NegationTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         assert not (self.table1.c.myid + 5)._is_implicitly_boolean
         assert not not_(column("x", Boolean))._is_implicitly_boolean
         assert (
-            not select([self.table1.c.myid])
+            not select(self.table1.c.myid)
             .scalar_subquery()
             ._is_implicitly_boolean
         )
@@ -2988,14 +2983,14 @@ class InSelectableTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_in_select(self):
         t = table("t", column("x"))
 
-        stmt = select([t.c.x])
+        stmt = select(t.c.x)
 
         self.assert_compile(column("q").in_(stmt), "q IN (SELECT t.x FROM t)")
 
     def test_in_subquery_warning(self):
         t = table("t", column("x"))
 
-        stmt = select([t.c.x]).subquery()
+        stmt = select(t.c.x).subquery()
 
         with expect_warnings(
             r"Coercing Subquery object into a select\(\) for use in "
@@ -3010,7 +3005,7 @@ class InSelectableTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_in_subquery_explicit(self):
         t = table("t", column("x"))
 
-        stmt = select([t.c.x]).subquery()
+        stmt = select(t.c.x).subquery()
 
         self.assert_compile(
             column("q").in_(stmt.select()),
@@ -3021,7 +3016,7 @@ class InSelectableTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_in_subquery_alias_implicit(self):
         t = table("t", column("x"))
 
-        stmt = select([t.c.x]).subquery().alias()
+        stmt = select(t.c.x).subquery().alias()
 
         with expect_warnings(
             r"Coercing Alias object into a select\(\) for use in "
@@ -3036,7 +3031,7 @@ class InSelectableTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_in_subquery_alias_explicit(self):
         t = table("t", column("x"))
 
-        stmt = select([t.c.x]).subquery().alias()
+        stmt = select(t.c.x).subquery().alias()
 
         self.assert_compile(
             column("q").in_(stmt.select().scalar_subquery()),
@@ -3066,7 +3061,7 @@ class InSelectableTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_in_cte_implicit(self):
         t = table("t", column("x"))
 
-        stmt = select([t.c.x]).cte()
+        stmt = select(t.c.x).cte()
 
         with expect_warnings(
             r"Coercing CTE object into a select\(\) for use in "
@@ -3083,9 +3078,9 @@ class InSelectableTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_in_cte_explicit(self):
         t = table("t", column("x"))
 
-        stmt = select([t.c.x]).cte()
+        stmt = select(t.c.x).cte()
 
-        s2 = select([column("q").in_(stmt.select().scalar_subquery())])
+        s2 = select(column("q").in_(stmt.select().scalar_subquery()))
 
         self.assert_compile(
             s2,
@@ -3096,9 +3091,9 @@ class InSelectableTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_in_cte_select(self):
         t = table("t", column("x"))
 
-        stmt = select([t.c.x]).cte()
+        stmt = select(t.c.x).cte()
 
-        s2 = select([column("q").in_(stmt.select())])
+        s2 = select(column("q").in_(stmt.select()))
 
         self.assert_compile(
             s2,
@@ -3285,8 +3280,7 @@ class AnyAllTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         t = t_fixture
 
         self.assert_compile(
-            5
-            == any_(select([t.c.data]).where(t.c.data < 10).scalar_subquery()),
+            5 == any_(select(t.c.data).where(t.c.data < 10).scalar_subquery()),
             ":param_1 = ANY (SELECT tab1.data "
             "FROM tab1 WHERE tab1.data < :data_1)",
             checkparams={"data_1": 10, "param_1": 5},
@@ -3297,10 +3291,7 @@ class AnyAllTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
         self.assert_compile(
             5
-            == select([t.c.data])
-            .where(t.c.data < 10)
-            .scalar_subquery()
-            .any_(),
+            == select(t.c.data).where(t.c.data < 10).scalar_subquery().any_(),
             ":param_1 = ANY (SELECT tab1.data "
             "FROM tab1 WHERE tab1.data < :data_1)",
             checkparams={"data_1": 10, "param_1": 5},
@@ -3310,8 +3301,7 @@ class AnyAllTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         t = t_fixture
 
         self.assert_compile(
-            5
-            == all_(select([t.c.data]).where(t.c.data < 10).scalar_subquery()),
+            5 == all_(select(t.c.data).where(t.c.data < 10).scalar_subquery()),
             ":param_1 = ALL (SELECT tab1.data "
             "FROM tab1 WHERE tab1.data < :data_1)",
             checkparams={"data_1": 10, "param_1": 5},
@@ -3322,10 +3312,7 @@ class AnyAllTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
         self.assert_compile(
             5
-            == select([t.c.data])
-            .where(t.c.data < 10)
-            .scalar_subquery()
-            .all_(),
+            == select(t.c.data).where(t.c.data < 10).scalar_subquery().all_(),
             ":param_1 = ALL (SELECT tab1.data "
             "FROM tab1 WHERE tab1.data < :data_1)",
             checkparams={"data_1": 10, "param_1": 5},

--- a/test/sql/test_resultset.py
+++ b/test/sql/test_resultset.py
@@ -134,7 +134,7 @@ class CursorResultTest(fixtures.TablesTest):
         )
 
         sel = (
-            select([users.c.user_id])
+            select(users.c.user_id)
             .where(users.c.user_name == "jack")
             .scalar_subquery()
         )
@@ -209,7 +209,7 @@ class CursorResultTest(fixtures.TablesTest):
         not_in(bar.c.content_type, row._mapping)
 
         row = connection.execute(
-            select([func.now().label("content_type")])
+            select(func.now().label("content_type"))
         ).first()
 
         not_in(content.c.type, row._mapping)
@@ -260,7 +260,7 @@ class CursorResultTest(fixtures.TablesTest):
                 )
 
     def test_column_error_printing(self, connection):
-        result = connection.execute(select([1]))
+        result = connection.execute(select(1))
         row = result.first()
 
         class unprintable(object):
@@ -440,7 +440,7 @@ class CursorResultTest(fixtures.TablesTest):
         # this will create column() objects inside
         # the select(), these need to match on name anyway
         r = connection.execute(
-            select([column("user_id"), column("user_name")])
+            select(column("user_id"), column("user_name"))
             .select_from(table("users"))
             .where(text("user_id=2"))
         ).first()
@@ -552,13 +552,13 @@ class CursorResultTest(fixtures.TablesTest):
 
         # unary expressions
         r = connection.execute(
-            select([users.c.user_name.distinct()]).order_by(users.c.user_name)
+            select(users.c.user_name.distinct()).order_by(users.c.user_name)
         ).first()
         eq_(r._mapping[users.c.user_name], "john")
         eq_(r.user_name, "john")
 
     def test_column_accessor_err(self, connection):
-        r = connection.execute(select([1])).first()
+        r = connection.execute(select(1)).first()
         assert_raises_message(
             AttributeError,
             "Could not locate column in row for column 'foo'",
@@ -681,10 +681,8 @@ class CursorResultTest(fixtures.TablesTest):
     def test_row_case_sensitive(self, connection):
         row = connection.execute(
             select(
-                [
-                    literal_column("1").label("case_insensitive"),
-                    literal_column("2").label("CaseSensitive"),
-                ]
+                literal_column("1").label("case_insensitive"),
+                literal_column("2").label("CaseSensitive"),
             )
         ).first()
 
@@ -704,11 +702,9 @@ class CursorResultTest(fixtures.TablesTest):
         with engines.testing_engine().connect() as ins_conn:
             row = ins_conn.execute(
                 select(
-                    [
-                        literal_column("1").label("case_insensitive"),
-                        literal_column("2").label("CaseSensitive"),
-                        text("3 AS screw_up_the_cols"),
-                    ]
+                    literal_column("1").label("case_insensitive"),
+                    literal_column("2").label("CaseSensitive"),
+                    text("3 AS screw_up_the_cols"),
                 )
             ).first()
 
@@ -820,7 +816,7 @@ class CursorResultTest(fixtures.TablesTest):
         ua = users.alias()
         u2 = users.alias()
         result = connection.execute(
-            select([users.c.user_id, ua.c.user_id]).select_from(
+            select(users.c.user_id, ua.c.user_id).select_from(
                 users.join(ua, true())
             )
         )
@@ -850,7 +846,7 @@ class CursorResultTest(fixtures.TablesTest):
         # but when they're fetched you'll get the ambiguous error.
         connection.execute(users.insert(), user_id=1, user_name="john")
         result = connection.execute(
-            select([users.c.user_id, addresses.c.user_id]).select_from(
+            select(users.c.user_id, addresses.c.user_id).select_from(
                 users.outerjoin(addresses)
             )
         )
@@ -940,10 +936,8 @@ class CursorResultTest(fixtures.TablesTest):
         connection.execute(users.insert(), user_id=1, user_name="john")
         result = connection.execute(
             select(
-                [
-                    users.c.user_id,
-                    type_coerce(users.c.user_id, Integer).label("foo"),
-                ]
+                users.c.user_id,
+                type_coerce(users.c.user_id, Integer).label("foo"),
             )
         )
         row = result.first()
@@ -1122,11 +1116,9 @@ class CursorResultTest(fixtures.TablesTest):
         connection.execute(users.insert(), user_id=1, user_name="foo")
         result = connection.execute(
             select(
-                [
-                    users.c.user_id,
-                    users.c.user_name.label(None),
-                    func.count(literal_column("1")),
-                ]
+                users.c.user_id,
+                users.c.user_name.label(None),
+                func.count(literal_column("1")),
             ).group_by(users.c.user_id, users.c.user_name)
         )
 
@@ -1412,7 +1404,7 @@ class CursorResultTest(fixtures.TablesTest):
                 "Statement is not a compiled expression construct.",
             ),
             (
-                select([1]),
+                select(1),
                 [
                     lambda r: r.last_inserted_params(),
                     lambda r: r.inserted_primary_key,
@@ -1420,12 +1412,12 @@ class CursorResultTest(fixtures.TablesTest):
                 r"Statement is not an insert\(\) expression construct.",
             ),
             (
-                select([1]),
+                select(1),
                 [lambda r: r.last_updated_params()],
                 r"Statement is not an update\(\) expression construct.",
             ),
             (
-                select([1]),
+                select(1),
                 [lambda r: r.prefetch_cols(), lambda r: r.postfetch_cols()],
                 r"Statement is not an insert\(\) "
                 r"or update\(\) expression construct.",
@@ -1533,7 +1525,7 @@ class KeyTargetingTest(fixtures.TablesTest):
 
     def _test_keyed_targeting_no_label_at_all(self, expression, conn):
         lt = literal_column("2")
-        stmt = select([literal_column("1"), expression, lt]).select_from(
+        stmt = select(literal_column("1"), expression, lt).select_from(
             self.tables.keyed1
         )
         row = conn.execute(stmt).first()
@@ -1556,7 +1548,7 @@ class KeyTargetingTest(fixtures.TablesTest):
             return "max(a)"
 
         # assert that there is no "AS max_" or any label of any kind.
-        eq_(str(select([not_named_max()])), "SELECT max(a)")
+        eq_(str(select(not_named_max())), "SELECT max(a)")
 
         nnm = not_named_max()
         self._test_keyed_targeting_no_label_at_all(nnm, connection)
@@ -1571,7 +1563,7 @@ class KeyTargetingTest(fixtures.TablesTest):
             return "max(a)"
 
         # assert that there is no "AS max_" or any label of any kind.
-        eq_(str(select([not_named_max()])), "SELECT max(a)")
+        eq_(str(select(not_named_max())), "SELECT max(a)")
 
         nnm = not_named_max()
         self._test_keyed_targeting_no_label_at_all(nnm, connection)
@@ -1580,7 +1572,7 @@ class KeyTargetingTest(fixtures.TablesTest):
         t1 = text("max(a)")
         t2 = text("min(a)")
 
-        stmt = select([t1, t2]).select_from(self.tables.keyed1)
+        stmt = select(t1, t2).select_from(self.tables.keyed1)
         row = connection.execute(stmt).first()
 
         eq_(row._mapping[t1], "a1")
@@ -1592,7 +1584,7 @@ class KeyTargetingTest(fixtures.TablesTest):
         keyed2 = self.tables.keyed2
 
         row = connection.execute(
-            select([keyed1, keyed2]).select_from(keyed1.join(keyed2, true()))
+            select(keyed1, keyed2).select_from(keyed1.join(keyed2, true()))
         ).first()
 
         # column access is unambiguous
@@ -1617,7 +1609,7 @@ class KeyTargetingTest(fixtures.TablesTest):
         # illustrate why row.b above is ambiguous, and not "b2"; because
         # if we didn't have keyed2, now it matches row.a.  a new column
         # shouldn't be able to grab the value from a previous column.
-        row = connection.execute(select([keyed1])).first()
+        row = connection.execute(select(keyed1)).first()
         eq_(row.b, "a1")
 
     def test_keyed_accessor_composite_conflict_2_fix_w_uselabels(
@@ -1627,7 +1619,7 @@ class KeyTargetingTest(fixtures.TablesTest):
         keyed2 = self.tables.keyed2
 
         row = connection.execute(
-            select([keyed1, keyed2])
+            select(keyed1, keyed2)
             .select_from(keyed1.join(keyed2, true()))
             .apply_labels()
         ).first()
@@ -1643,7 +1635,7 @@ class KeyTargetingTest(fixtures.TablesTest):
         keyed4 = self.tables.keyed4
 
         row = connection.execute(
-            select([keyed1, keyed4]).select_from(keyed1.join(keyed4, true()))
+            select(keyed1, keyed4).select_from(keyed1.join(keyed4, true()))
         ).first()
         eq_(row.b, "b4")
         eq_(row.q, "q4")
@@ -1656,7 +1648,7 @@ class KeyTargetingTest(fixtures.TablesTest):
         keyed3 = self.tables.keyed3
 
         row = connection.execute(
-            select([keyed1, keyed3]).select_from(keyed1.join(keyed3, true()))
+            select(keyed1, keyed3).select_from(keyed1.join(keyed3, true()))
         ).first()
         eq_(row.q, "c1")
 
@@ -1680,7 +1672,7 @@ class KeyTargetingTest(fixtures.TablesTest):
         keyed2 = self.tables.keyed2
 
         row = connection.execute(
-            select([keyed1, keyed2])
+            select(keyed1, keyed2)
             .select_from(keyed1.join(keyed2, true()))
             .apply_labels()
         ).first()
@@ -1711,16 +1703,14 @@ class KeyTargetingTest(fixtures.TablesTest):
 
         stmt = (
             select(
-                [
-                    keyed2.c.a,
-                    keyed3.c.a,
-                    keyed2.c.a,
-                    keyed2.c.a,
-                    keyed3.c.a,
-                    keyed3.c.a,
-                    keyed3.c.d,
-                    keyed3.c.d,
-                ]
+                keyed2.c.a,
+                keyed3.c.a,
+                keyed2.c.a,
+                keyed2.c.a,
+                keyed3.c.a,
+                keyed3.c.a,
+                keyed3.c.d,
+                keyed3.c.d,
             )
             .select_from(keyed2.join(keyed3, true()))
             .apply_labels()
@@ -1766,7 +1756,7 @@ class KeyTargetingTest(fixtures.TablesTest):
         # originally addressed by [ticket:2932], however liberalized
         # Column-targeting rules are deprecated
         a, b = sql.column("a"), sql.column("b")
-        stmt = select([a, b]).select_from(table("keyed2"))
+        stmt = select(a, b).select_from(table("keyed2"))
         row = connection.execute(stmt).first()
 
         in_(a, row._mapping)
@@ -1775,7 +1765,7 @@ class KeyTargetingTest(fixtures.TablesTest):
     def test_columnclause_schema_column_two(self, connection):
         keyed2 = self.tables.keyed2
 
-        stmt = select([keyed2.c.a, keyed2.c.b])
+        stmt = select(keyed2.c.a, keyed2.c.b)
         row = connection.execute(stmt).first()
 
         in_(keyed2.c.a, row._mapping)
@@ -1819,12 +1809,12 @@ class KeyTargetingTest(fixtures.TablesTest):
     def _adapt_result_columns_fixture_one(self):
         keyed1 = self.tables.keyed1
         stmt = (
-            select([keyed1.c.b, keyed1.c.q.label("foo")])
+            select(keyed1.c.b, keyed1.c.q.label("foo"))
             .apply_labels()
             .subquery()
         )
 
-        return select([stmt.c.keyed1_b, stmt.c.foo])
+        return select(stmt.c.keyed1_b, stmt.c.foo)
 
     def _adapt_result_columns_fixture_two(self):
         return text("select a AS keyed2_a, b AS keyed2_b from keyed2").columns(
@@ -1833,14 +1823,14 @@ class KeyTargetingTest(fixtures.TablesTest):
 
     def _adapt_result_columns_fixture_three(self):
         keyed1 = self.tables.keyed1
-        stmt = select([keyed1.c.b, keyed1.c.q.label("foo")]).subquery()
+        stmt = select(keyed1.c.b, keyed1.c.q.label("foo")).subquery()
 
-        return select([stmt.c.b, stmt.c.foo])
+        return select(stmt.c.b, stmt.c.foo)
 
     def _adapt_result_columns_fixture_four(self):
         keyed1 = self.tables.keyed1
 
-        stmt1 = select([keyed1]).apply_labels()
+        stmt1 = select(keyed1).apply_labels()
 
         a1 = keyed1.alias()
         stmt2 = ClauseAdapter(a1).traverse(stmt1)
@@ -2232,7 +2222,7 @@ class AlternateCursorResultTest(fixtures.TablesTest):
         with self._proxy_fixture(cls):
             rows = []
             with self.engine.connect() as conn:
-                r = conn.execute(select([self.table]))
+                r = conn.execute(select(self.table))
                 assert isinstance(r.cursor_strategy, cls)
                 for i in range(5):
                     rows.append(r.fetchone())
@@ -2244,17 +2234,17 @@ class AlternateCursorResultTest(fixtures.TablesTest):
                 rows = r.fetchall()
                 eq_(rows, [(i, "t_%d" % i) for i in range(9, 12)])
 
-                r = conn.execute(select([self.table]))
+                r = conn.execute(select(self.table))
                 rows = r.fetchmany(None)
                 eq_(rows[0], (1, "t_1"))
                 # number of rows here could be one, or the whole thing
                 assert len(rows) == 1 or len(rows) == 11
 
-                r = conn.execute(select([self.table]).limit(1))
+                r = conn.execute(select(self.table).limit(1))
                 r.fetchone()
                 eq_(r.fetchone(), None)
 
-                r = conn.execute(select([self.table]).limit(5))
+                r = conn.execute(select(self.table).limit(5))
                 rows = r.fetchmany(6)
                 eq_(rows, [(i, "t_%d" % i) for i in range(1, 6)])
 
@@ -2272,11 +2262,11 @@ class AlternateCursorResultTest(fixtures.TablesTest):
 
                 self._assert_result_closed(r)
 
-                r = conn.execute(select([self.table]).limit(5))
+                r = conn.execute(select(self.table).limit(5))
                 eq_(r.first(), (1, "t_1"))
                 self._assert_result_closed(r)
 
-                r = conn.execute(select([self.table]).limit(5))
+                r = conn.execute(select(self.table).limit(5))
                 eq_(r.scalar(), 1)
                 self._assert_result_closed(r)
 
@@ -2344,7 +2334,7 @@ class AlternateCursorResultTest(fixtures.TablesTest):
                     cache = {}
                     conn = conn.execution_options(compiled_cache=cache)
 
-                stmt = select([literal("THERE", type_=MyType())])
+                stmt = select(literal("THERE", type_=MyType()))
                 for i in range(2):
                     r = conn.execute(stmt)
                     eq_(r.scalar(), "HI THERE")

--- a/test/sql/test_returning.py
+++ b/test/sql/test_returning.py
@@ -125,7 +125,7 @@ class ReturningTest(fixtures.TestBase, AssertsExecutionResults):
         eq_(result.fetchall(), [(1,)])
 
         result2 = connection.execute(
-            select([table.c.id, table.c.full]).order_by(table.c.id)
+            select(table.c.id, table.c.full).order_by(table.c.id)
         )
         eq_(result2.fetchall(), [(1, True), (2, False)])
 
@@ -215,7 +215,7 @@ class ReturningTest(fixtures.TestBase, AssertsExecutionResults):
         eq_(result.fetchall(), [(1,)])
 
         result2 = connection.execute(
-            select([table.c.id, table.c.full]).order_by(table.c.id)
+            select(table.c.id, table.c.full).order_by(table.c.id)
         )
         eq_(result2.fetchall(), [(2, False)])
 
@@ -241,7 +241,7 @@ class CompositeStatementTest(fixtures.TestBase):
 
         stmt = (
             t2.insert()
-            .values(x=select([t1.c.x]).scalar_subquery())
+            .values(x=select(t1.c.x).scalar_subquery())
             .returning(t2.c.x)
         )
 

--- a/test/sql/test_roles.py
+++ b/test/sql/test_roles.py
@@ -443,7 +443,7 @@ class SubqueryCoercionsTest(fixtures.TestBase, AssertsCompiledSQL):
         table1, table2 = update_from_fixture
 
         # test against a regular constructed subquery
-        s = select([table2], table2.c.otherid == table1.c.myid)
+        s = select(table2).where(table2.c.otherid == table1.c.myid)
         with testing.expect_warnings(
             "implicitly coercing SELECT object to scalar subquery"
         ):

--- a/test/sql/test_select.py
+++ b/test/sql/test_select.py
@@ -57,6 +57,7 @@ class FutureSelectTest(fixtures.TestBase, AssertsCompiledSQL):
         )
 
     def test_legacy_calling_style_col_seq_only(self):
+        # keep [] here
         stmt = select([table1.c.myid]).where(table1.c.myid == table2.c.otherid)
 
         self.assert_compile(

--- a/test/sql/test_sequences.py
+++ b/test/sql/test_sequences.py
@@ -150,7 +150,7 @@ class LegacySequenceExecTest(fixtures.TestBase):
         """test can use next_value() in select column expr"""
 
         s = Sequence("my_sequence")
-        self._assert_seq_result(testing.db.scalar(select([s.next_value()])))
+        self._assert_seq_result(testing.db.scalar(select(s.next_value())))
 
 
 class SequenceExecTest(fixtures.TestBase):
@@ -201,7 +201,7 @@ class SequenceExecTest(fixtures.TestBase):
         """test can use next_value() in select column expr"""
 
         s = Sequence("my_sequence")
-        self._assert_seq_result(connection.scalar(select([s.next_value()])))
+        self._assert_seq_result(connection.scalar(select(s.next_value())))
 
     @testing.requires.sequences_in_other_clauses
     @testing.provide_metadata
@@ -446,7 +446,7 @@ class TableBoundSequenceTest(fixtures.TablesTest):
 
         eq_(
             connection.scalar(
-                sa.select([cartitems.c.cart_id]).where(
+                sa.select(cartitems.c.cart_id).where(
                     cartitems.c.description == "lala"
                 ),
             ),
@@ -526,7 +526,7 @@ class SequenceAsServerDefaultTest(
         t_seq_test = self.tables.t_seq_test
         connection.execute(t_seq_test.insert().values(data="some data"))
 
-        eq_(connection.scalar(select([t_seq_test.c.id])), 1)
+        eq_(connection.scalar(select(t_seq_test.c.id)), 1)
 
     def test_default_textual_server_only(self, connection):
         connection.exec_driver_sql(
@@ -542,7 +542,7 @@ class SequenceAsServerDefaultTest(
         t_seq_test = self.tables.t_seq_test_2
         connection.execute(t_seq_test.insert().values(data="some data"))
 
-        eq_(connection.scalar(select([t_seq_test.c.id])), 1)
+        eq_(connection.scalar(select(t_seq_test.c.id)), 1)
 
     def test_drop_ordering(self):
         with self.sql_execution_asserter(testing.db) as asserter:

--- a/test/sql/test_tablesample.py
+++ b/test/sql/test_tablesample.py
@@ -59,7 +59,7 @@ class TableSampleTest(fixtures.TablesTest, AssertsCompiledSQL):
         table1 = self.tables.people
 
         self.assert_compile(
-            select([table1.tablesample(text("1"), name="alias").c.people_id]),
+            select(table1.tablesample(text("1"), name="alias").c.people_id),
             "SELECT alias.people_id FROM "
             "people AS alias TABLESAMPLE system(1)",
         )

--- a/test/sql/test_type_expressions.py
+++ b/test/sql/test_type_expressions.py
@@ -113,14 +113,14 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
         table = self._fixture()
 
         self.assert_compile(
-            select([table]),
+            select(table),
             "SELECT test_table.x, lower(test_table.y) AS y FROM test_table",
         )
 
     def test_anonymous_expr(self):
         table = self._fixture()
         self.assert_compile(
-            select([cast(table.c.y, String)]),
+            select(cast(table.c.y, String)),
             "SELECT CAST(test_table.y AS VARCHAR) AS y FROM test_table",
         )
 
@@ -128,7 +128,7 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
         table = self._fixture()
 
         self.assert_compile(
-            select([table]).apply_labels(),
+            select(table).apply_labels(),
             "SELECT test_table.x AS test_table_x, "
             "lower(test_table.y) AS test_table_y FROM test_table",
         )
@@ -136,7 +136,7 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
     def test_select_cols_use_labels_result_map_targeting(self):
         table = self._fixture()
 
-        compiled = select([table]).apply_labels().compile()
+        compiled = select(table).apply_labels().compile()
         assert table.c.y in compiled._create_result_map()["test_table_y"][1]
         assert table.c.x in compiled._create_result_map()["test_table_x"][1]
 
@@ -169,7 +169,7 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
     def test_select_binds(self):
         table = self._fixture()
         self.assert_compile(
-            select([table]).where(table.c.y == "hi"),
+            select(table).where(table.c.y == "hi"),
             "SELECT test_table.x, lower(test_table.y) AS y FROM "
             "test_table WHERE test_table.y = lower(:y_1)",
         )
@@ -180,7 +180,7 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
 
         # 'x' is straight String
         self.assert_compile(
-            select([table.c.x]).where(table.c.x == "hi"),
+            select(table.c.x).where(table.c.x == "hi"),
             "SELECT dialect_colexpr(test_table.x) AS x "
             "FROM test_table WHERE test_table.x = dialect_bind(:x_1)",
             dialect=dialect,
@@ -190,7 +190,7 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
         table = self._type_decorator_inside_fixture()
 
         self.assert_compile(
-            select([table]).where(table.c.y == "hi"),
+            select(table).where(table.c.y == "hi"),
             "SELECT test_table.x, inside_colexpr(test_table.y) AS y "
             "FROM test_table WHERE test_table.y = inside_bind(:y_1)",
         )
@@ -204,7 +204,7 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
         # implementation supersedes that, which is the same as with other
         # processor functions
         self.assert_compile(
-            select([table]).where(table.c.y == "hi"),
+            select(table).where(table.c.y == "hi"),
             "SELECT dialect_colexpr(test_table.x) AS x, "
             "dialect_colexpr(test_table.y) AS y FROM test_table "
             "WHERE test_table.y = dialect_bind(:y_1)",
@@ -215,7 +215,7 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
         table = self._type_decorator_outside_fixture()
 
         self.assert_compile(
-            select([table]).where(table.c.y == "hi"),
+            select(table).where(table.c.y == "hi"),
             "SELECT test_table.x, outside_colexpr(test_table.y) AS y "
             "FROM test_table WHERE test_table.y = outside_bind(:y_1)",
         )
@@ -227,7 +227,7 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
         # for "outer", the MyString isn't calling the "impl" functions,
         # so we don't get the "impl"
         self.assert_compile(
-            select([table]).where(table.c.y == "hi"),
+            select(table).where(table.c.y == "hi"),
             "SELECT dialect_colexpr(test_table.x) AS x, "
             "outside_colexpr(test_table.y) AS y "
             "FROM test_table WHERE test_table.y = outside_bind(:y_1)",
@@ -238,7 +238,7 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
         table = self._type_decorator_both_fixture()
 
         self.assert_compile(
-            select([table]).where(table.c.y == "hi"),
+            select(table).where(table.c.y == "hi"),
             "SELECT test_table.x, "
             "outside_colexpr(inside_colexpr(test_table.y)) AS y "
             "FROM test_table WHERE "
@@ -254,7 +254,7 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
         # implementation supersedes that, which is the same as with other
         # processor functions
         self.assert_compile(
-            select([table]).where(table.c.y == "hi"),
+            select(table).where(table.c.y == "hi"),
             "SELECT dialect_colexpr(test_table.x) AS x, "
             "outside_colexpr(dialect_colexpr(test_table.y)) AS y "
             "FROM test_table WHERE "
@@ -266,7 +266,7 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
         table = self._variant_fixture(self._type_decorator_both_fixture())
 
         self.assert_compile(
-            select([table]).where(table.c.y == "hi"),
+            select(table).where(table.c.y == "hi"),
             "SELECT test_table.x, "
             "outside_colexpr(inside_colexpr(test_table.y)) AS y "
             "FROM test_table WHERE "
@@ -276,8 +276,8 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
     def test_compound_select(self):
         table = self._fixture()
 
-        s1 = select([table]).where(table.c.y == "hi")
-        s2 = select([table]).where(table.c.y == "there")
+        s1 = select(table).where(table.c.y == "hi")
+        s2 = select(table).where(table.c.y == "there")
 
         self.assert_compile(
             union(s1, s2),
@@ -290,8 +290,8 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
     def test_select_of_compound_select(self):
         table = self._fixture()
 
-        s1 = select([table]).where(table.c.y == "hi")
-        s2 = select([table]).where(table.c.y == "there")
+        s1 = select(table).where(table.c.y == "hi")
+        s2 = select(table).where(table.c.y == "there")
 
         self.assert_compile(
             union(s1, s2).alias().select(),
@@ -352,7 +352,7 @@ class RoundTripTestBase(object):
         # conversion back to upper
         eq_(
             connection.execute(
-                select([self.tables.test_table]).order_by(
+                select(self.tables.test_table).order_by(
                     self.tables.test_table.c.y
                 )
             ).fetchall(),
@@ -363,14 +363,14 @@ class RoundTripTestBase(object):
         testing.db.execute(
             self.tables.test_table.insert(), {"x": "X1", "y": "Y1"}
         )
-        row = testing.db.execute(select([self.tables.test_table])).first()
+        row = testing.db.execute(select(self.tables.test_table)).first()
         eq_(row._mapping[self.tables.test_table.c.y], "Y1")
 
     def test_targeting_by_string(self):
         testing.db.execute(
             self.tables.test_table.insert(), {"x": "X1", "y": "Y1"}
         )
-        row = testing.db.execute(select([self.tables.test_table])).first()
+        row = testing.db.execute(select(self.tables.test_table)).first()
         eq_(row._mapping["y"], "Y1")
 
     def test_targeting_apply_labels(self):
@@ -378,7 +378,7 @@ class RoundTripTestBase(object):
             self.tables.test_table.insert(), {"x": "X1", "y": "Y1"}
         )
         row = testing.db.execute(
-            select([self.tables.test_table]).apply_labels()
+            select(self.tables.test_table).apply_labels()
         ).first()
         eq_(row._mapping[self.tables.test_table.c.y], "Y1")
 
@@ -388,10 +388,8 @@ class RoundTripTestBase(object):
         )
         row = testing.db.execute(
             select(
-                [
-                    self.tables.test_table.c.x.label("xbar"),
-                    self.tables.test_table.c.y.label("ybar"),
-                ]
+                self.tables.test_table.c.x.label("xbar"),
+                self.tables.test_table.c.y.label("ybar"),
             )
         ).first()
         eq_(row._mapping[self.tables.test_table.c.y], "Y1")

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -604,7 +604,7 @@ class UserDefinedRoundTripTest(_UserDefinedTypeFixture, fixtures.TablesTest):
         self._data_fixture()
 
         stmt = (
-            select([users.c.user_id, users.c.goofy8])
+            select(users.c.user_id, users.c.goofy8)
             .where(users.c.goofy8.in_([15, 9]))
             .order_by(users.c.user_id)
         )
@@ -616,7 +616,7 @@ class UserDefinedRoundTripTest(_UserDefinedTypeFixture, fixtures.TablesTest):
         self._data_fixture()
 
         stmt = (
-            select([users.c.user_id, users.c.goofy8])
+            select(users.c.user_id, users.c.goofy8)
             .where(users.c.goofy8.in_(bindparam("goofy", expanding=True)))
             .order_by(users.c.user_id)
         )
@@ -642,7 +642,7 @@ class UserDefinedTest(
                 return "HI->%s<-THERE" % value
 
         self.assert_compile(
-            select([literal("test", MyType)]),
+            select(literal("test", MyType)),
             "SELECT 'HI->test<-THERE' AS anon_1",
             dialect="default",
             literal_binds=True,
@@ -674,7 +674,7 @@ class UserDefinedTest(
                 return "HI->%s<-THERE" % value
 
         self.assert_compile(
-            select([literal("test", MyType)]),
+            select(literal("test", MyType)),
             "SELECT 'HI->test<-THERE' AS anon_1",
             dialect="default",
             literal_binds=True,
@@ -866,7 +866,7 @@ class TypeCoerceCastTest(fixtures.TablesTest):
         conn.execute(t.insert().values(data=coerce_fn("d1", MyType)))
 
         eq_(
-            conn.execute(select([coerce_fn(t.c.data, MyType)])).fetchall(),
+            conn.execute(select(coerce_fn(t.c.data, MyType))).fetchall(),
             [("BIND_INd1BIND_OUT",)],
         )
 
@@ -890,7 +890,7 @@ class TypeCoerceCastTest(fixtures.TablesTest):
         conn.execute(t.insert().values(data=coerce_fn(MyObj(), MyType)))
 
         eq_(
-            conn.execute(select([coerce_fn(t.c.data, MyType)])).fetchall(),
+            conn.execute(select(coerce_fn(t.c.data, MyType))).fetchall(),
             [("BIND_INTHISISMYOBJBIND_OUT",)],
         )
 
@@ -908,7 +908,7 @@ class TypeCoerceCastTest(fixtures.TablesTest):
 
         eq_(
             conn.execute(
-                select([t.c.data, coerce_fn(t.c.data, MyType)])
+                select(t.c.data, coerce_fn(t.c.data, MyType))
             ).fetchall(),
             [("BIND_INd1", "BIND_INd1BIND_OUT")],
         )
@@ -927,7 +927,7 @@ class TypeCoerceCastTest(fixtures.TablesTest):
 
         eq_(
             conn.execute(
-                select([t.c.data.label("x"), coerce_fn(t.c.data, MyType)])
+                select(t.c.data.label("x"), coerce_fn(t.c.data, MyType))
                 .alias()
                 .select()
             ).fetchall(),
@@ -949,7 +949,7 @@ class TypeCoerceCastTest(fixtures.TablesTest):
         # coerce on left side
         eq_(
             conn.execute(
-                select([t.c.data, coerce_fn(t.c.data, MyType)]).where(
+                select(t.c.data, coerce_fn(t.c.data, MyType)).where(
                     coerce_fn(t.c.data, MyType) == "d1"
                 )
             ).fetchall(),
@@ -959,7 +959,7 @@ class TypeCoerceCastTest(fixtures.TablesTest):
         # coerce on right side
         eq_(
             conn.execute(
-                select([t.c.data, coerce_fn(t.c.data, MyType)]).where(
+                select(t.c.data, coerce_fn(t.c.data, MyType)).where(
                     t.c.data == coerce_fn("d1", MyType)
                 )
             ).fetchall(),
@@ -979,7 +979,7 @@ class TypeCoerceCastTest(fixtures.TablesTest):
         conn.execute(t.insert().values(data=coerce_fn("d1", MyType)))
         eq_(
             conn.execute(
-                select([t.c.data, coerce_fn(t.c.data, MyType)]).where(
+                select(t.c.data, coerce_fn(t.c.data, MyType)).where(
                     t.c.data == coerce_fn(None, MyType)
                 )
             ).fetchall(),
@@ -988,7 +988,7 @@ class TypeCoerceCastTest(fixtures.TablesTest):
 
         eq_(
             conn.execute(
-                select([t.c.data, coerce_fn(t.c.data, MyType)]).where(
+                select(t.c.data, coerce_fn(t.c.data, MyType)).where(
                     coerce_fn(t.c.data, MyType) == None
                 )
             ).fetchall(),  # noqa
@@ -1013,7 +1013,7 @@ class TypeCoerceCastTest(fixtures.TablesTest):
 
         eq_(
             conn.execute(
-                select([t.c.data, coerce_fn(MyFoob(), MyType)])
+                select(t.c.data, coerce_fn(MyFoob(), MyType))
             ).fetchall(),
             [("BIND_INd1", "BIND_INd1BIND_OUT")],
         )
@@ -1030,7 +1030,7 @@ class TypeCoerceCastTest(fixtures.TablesTest):
         t = self.tables.t
         conn.execute(t.insert().values(data=coerce_fn("d1", MyType)))
 
-        stmt = select([t.c.data, coerce_fn(t.c.data, MyType)])
+        stmt = select(t.c.data, coerce_fn(t.c.data, MyType))
 
         def col_to_bind(col):
             if col is t.c.data:
@@ -1071,12 +1071,8 @@ class TypeCoerceCastTest(fixtures.TablesTest):
         conn.execute(t.insert().values(data=coerce_fn("d1", MyType)))
 
         stmt = select(
-            [
-                bindparam(None, "x", String(50), unique=True),
-                coerce_fn(
-                    bindparam(None, "x", String(50), unique=True), MyType
-                ),
-            ]
+            bindparam(None, "x", String(50), unique=True),
+            coerce_fn(bindparam(None, "x", String(50), unique=True), MyType),
         )
 
         eq_(
@@ -1093,7 +1089,7 @@ class TypeCoerceCastTest(fixtures.TablesTest):
         # when cast() is given an already typed value,
         # the type does not take effect on the value itself.
         eq_(
-            connection.scalar(select([coerce_fn(literal("d1"), MyType)])),
+            connection.scalar(select(coerce_fn(literal("d1"), MyType))),
             "d1BIND_OUT",
         )
 
@@ -1110,9 +1106,7 @@ class TypeCoerceCastTest(fixtures.TablesTest):
         )
 
         eq_(
-            connection.execute(
-                select([coerce_fn(t.c.data, MyType)])
-            ).fetchall(),
+            connection.execute(select(coerce_fn(t.c.data, MyType))).fetchall(),
             [("BIND_INd1BIND_OUT",)],
         )
 
@@ -1240,7 +1234,7 @@ class VariantTest(fixtures.TestBase, AssertsCompiledSQL):
 
             conn.execute(t.insert(), x="foo")
 
-            eq_(conn.scalar(select([t.c.x]).where(t.c.x == "foo")), "fooUTWO")
+            eq_(conn.scalar(select(t.c.x).where(t.c.x == "foo")), "fooUTWO")
 
     @testing.only_on("sqlite")
     @testing.provide_metadata
@@ -1259,7 +1253,7 @@ class VariantTest(fixtures.TestBase, AssertsCompiledSQL):
 
             eq_(
                 conn.scalar(
-                    select([t.c.x]).where(
+                    select(t.c.x).where(
                         t.c.x
                         == datetime.datetime(2015, 4, 18, 10, 15, 17, 1059)
                     )
@@ -1620,9 +1614,7 @@ class EnumTest(AssertsCompiledSQL, fixtures.TablesTest):
 
         eq_(
             connection.execute(
-                select(["foo" + enum_table.c.someenum]).order_by(
-                    enum_table.c.id
-                )
+                select("foo" + enum_table.c.someenum).order_by(enum_table.c.id)
             ).fetchall(),
             [("footwo",), ("footwo",), ("fooone",)],
         )
@@ -1651,14 +1643,12 @@ class EnumTest(AssertsCompiledSQL, fixtures.TablesTest):
         non_native_enum_table = self.tables.non_native_enum_table
 
         connection.execute(enum_table.insert(), {"id": 1, "someenum": None})
-        eq_(connection.scalar(select([enum_table.c.someenum])), None)
+        eq_(connection.scalar(select(enum_table.c.someenum)), None)
 
         connection.execute(
             non_native_enum_table.insert(), {"id": 1, "someenum": None}
         )
-        eq_(
-            connection.scalar(select([non_native_enum_table.c.someenum])), None
-        )
+        eq_(connection.scalar(select(non_native_enum_table.c.someenum)), None)
 
     @testing.requires.enforces_check_constraints
     def test_check_constraint(self, connection):
@@ -1783,7 +1773,7 @@ class EnumTest(AssertsCompiledSQL, fixtures.TablesTest):
                 "'four' is not among the defined enum values. "
                 "Enum name: None. Possible values: one, two, three",
                 conn.scalar,
-                select([self.tables.non_native_enum_table.c.someotherenum]),
+                select(self.tables.non_native_enum_table.c.someotherenum),
             )
 
     def test_non_native_round_trip(self, connection):
@@ -1801,10 +1791,8 @@ class EnumTest(AssertsCompiledSQL, fixtures.TablesTest):
         eq_(
             connection.execute(
                 select(
-                    [
-                        non_native_enum_table.c.id,
-                        non_native_enum_table.c.someenum,
-                    ]
+                    non_native_enum_table.c.id,
+                    non_native_enum_table.c.someenum,
                 ).order_by(non_native_enum_table.c.id)
             ).fetchall(),
             [(1, "two"), (2, "two"), (3, "one")],
@@ -2218,7 +2206,7 @@ class BinaryTest(fixtures.TestBase, AssertsExecutionResults):
         connection.execute(binary_table.insert(), data=data)
         eq_(
             connection.scalar(
-                select([func.count("*")])
+                select(func.count("*"))
                 .select_from(binary_table)
                 .where(binary_table.c.data == data)
             ),
@@ -2227,7 +2215,7 @@ class BinaryTest(fixtures.TestBase, AssertsExecutionResults):
 
     @testing.requires.binary_literals
     def test_literal_roundtrip(self, connection):
-        compiled = select([cast(literal(util.b("foo")), LargeBinary)]).compile(
+        compiled = select(cast(literal(util.b("foo")), LargeBinary)).compile(
             dialect=testing.db.dialect, compile_kwargs={"literal_binds": True}
         )
         result = connection.execute(compiled)
@@ -2532,11 +2520,9 @@ class ExpressionTest(
         eq_(
             connection.execute(
                 select(
-                    [
-                        test_table.c.id,
-                        test_table.c.data,
-                        test_table.c.atimestamp,
-                    ]
+                    test_table.c.id,
+                    test_table.c.data,
+                    test_table.c.atimestamp,
                 ).where(expr),
                 {"thedate": datetime.date(2007, 10, 15)},
             ).fetchall(),
@@ -2650,7 +2636,7 @@ class ExpressionTest(
         assert expr.right.type.__class__ is MyTypeDec
 
         eq_(
-            connection.execute(select([expr.label("foo")])).scalar(),
+            connection.execute(select(expr.label("foo"))).scalar(),
             "BIND_INfooBIND_INhiBIND_OUT",
         )
 
@@ -2712,7 +2698,7 @@ class ExpressionTest(
         is_(expr.type.__class__, MyTypeDec)
 
         eq_(
-            connection.execute(select([expr.label("foo")])).scalar(),
+            connection.execute(select(expr.label("foo"))).scalar(),
             "BIND_INfooBIND_IN6BIND_OUT",
         )
 
@@ -2861,10 +2847,10 @@ class ExpressionTest(
         eq_(expr.type, types.NULLTYPE)
 
     def test_distinct(self, connection):
-        s = select([distinct(test_table.c.avalue)])
+        s = select(distinct(test_table.c.avalue))
         eq_(connection.execute(s).scalar(), 25)
 
-        s = select([test_table.c.avalue.distinct()])
+        s = select(test_table.c.avalue.distinct())
         eq_(connection.execute(s).scalar(), 25)
 
         assert distinct(test_table.c.data).type == test_table.c.data.type
@@ -3250,8 +3236,7 @@ class BooleanTest(
             )
 
             eq_(
-                conn.scalar(select([boolean_table.c.unconstrained_value])),
-                True,
+                conn.scalar(select(boolean_table.c.unconstrained_value)), True,
             )
 
     def test_bind_processor_coercion_native_true(self):

--- a/test/sql/test_utils.py
+++ b/test/sql/test_utils.py
@@ -35,7 +35,7 @@ class MiscTest(fixtures.TestBase):
             Column("extra", String(45)),
         )
 
-        subset_select = select([common.c.id, common.c.data]).alias()
+        subset_select = select(common.c.id, common.c.data).alias()
 
         eq_(set(sql_util.find_tables(subset_select)), {common})
 
@@ -50,7 +50,7 @@ class MiscTest(fixtures.TestBase):
         )
 
         calias = common.alias()
-        subset_select = select([common.c.id, calias.c.data]).subquery()
+        subset_select = select(common.c.id, calias.c.data).subquery()
 
         eq_(
             set(sql_util.find_tables(subset_select, include_aliases=True)),
@@ -103,12 +103,12 @@ class MiscTest(fixtures.TestBase):
         (column("q").label(None).desc().label(None), [column("q")]),
         ("foo", []),  # textual label reference
         (
-            select([column("q")]).scalar_subquery().label(None),
-            [select([column("q")]).scalar_subquery().label(None)],
+            select(column("q")).scalar_subquery().label(None),
+            [select(column("q")).scalar_subquery().label(None)],
         ),
         (
-            select([column("q")]).scalar_subquery().label(None).desc(),
-            [select([column("q")]).scalar_subquery().label(None)],
+            select(column("q")).scalar_subquery().label(None).desc(),
+            [select(column("q")).scalar_subquery().label(None)],
         ),
     )
     def test_unwrap_order_by(self, expr, expected):

--- a/test/sql/test_values.py
+++ b/test/sql/test_values.py
@@ -59,7 +59,7 @@ class ValuesTest(fixtures.TablesTest, AssertsCompiledSQL):
             name="Spaces and Cases",
         ).data([(1, "textA", 99), (2, "textB", 88)])
         self.assert_compile(
-            select([v1]),
+            select(v1),
             'SELECT "Spaces and Cases"."CaseSensitive", '
             '"Spaces and Cases"."has spaces" FROM '
             "(VALUES (:param_1, :param_2, :param_3), "
@@ -83,7 +83,7 @@ class ValuesTest(fixtures.TablesTest, AssertsCompiledSQL):
     def test_bound_parameters(self, literal_parameter_fixture):
         literal_parameter_fixture = literal_parameter_fixture(False)
 
-        stmt = select([literal_parameter_fixture])
+        stmt = select(literal_parameter_fixture)
 
         self.assert_compile(
             stmt,
@@ -104,7 +104,7 @@ class ValuesTest(fixtures.TablesTest, AssertsCompiledSQL):
     def test_literal_parameters(self, literal_parameter_fixture):
         literal_parameter_fixture = literal_parameter_fixture(True)
 
-        stmt = select([literal_parameter_fixture])
+        stmt = select(literal_parameter_fixture)
 
         self.assert_compile(
             stmt,
@@ -119,7 +119,7 @@ class ValuesTest(fixtures.TablesTest, AssertsCompiledSQL):
         values = Values(
             column("column1", Integer), column("column2", Integer),
         ).data([(1, 1), (2, 1), (3, 2), (3, 3)])
-        stmt = select([people, values]).select_from(
+        stmt = select(people, values).select_from(
             people.join(values, values.c.column2 == people.c.people_id)
         )
         self.assert_compile(
@@ -148,7 +148,7 @@ class ValuesTest(fixtures.TablesTest, AssertsCompiledSQL):
             column("bookcase_owner_id", Integer),
             name="bookcases",
         ).data([(1, 1), (2, 1), (3, 2), (3, 3)])
-        stmt = select([people, values]).select_from(
+        stmt = select(people, values).select_from(
             people.join(
                 values, values.c.bookcase_owner_id == people.c.people_id
             )
@@ -183,7 +183,7 @@ class ValuesTest(fixtures.TablesTest, AssertsCompiledSQL):
             .data([(1, 1), (2, 1), (3, 2), (3, 3)])
             .alias("bookcases")
         )
-        stmt = select([people, values]).select_from(
+        stmt = select(people, values).select_from(
             people.join(
                 values, values.c.bookcase_owner_id == people.c.people_id
             )
@@ -216,7 +216,7 @@ class ValuesTest(fixtures.TablesTest, AssertsCompiledSQL):
         ).data([(1, 1), (2, 1), (3, 2), (3, 3)])
         values = alias(values, "bookcases")
 
-        stmt = select([people, values]).select_from(
+        stmt = select(people, values).select_from(
             people.join(
                 values, values.c.bookcase_owner_id == people.c.people_id
             )
@@ -252,9 +252,7 @@ class ValuesTest(fixtures.TablesTest, AssertsCompiledSQL):
             .data([(1, 1), (2, 1), (3, 2), (3, 3)])
             .lateral()
         )
-        stmt = select([people, values]).select_from(
-            people.join(values, true())
-        )
+        stmt = select(people, values).select_from(people.join(values, true()))
         self.assert_compile(
             stmt,
             "SELECT people.people_id, people.age, people.name, "
@@ -282,7 +280,7 @@ class ValuesTest(fixtures.TablesTest, AssertsCompiledSQL):
             column("bookcase_owner_id", Integer),
             name="bookcases",
         ).data([(1, 1), (2, 1), (3, 2), (3, 3)])
-        stmt = select([people, values])
+        stmt = select(people, values)
 
         with testing.expect_warnings(
             r"SELECT statement has a cartesian product between FROM "
@@ -297,7 +295,7 @@ class ValuesTest(fixtures.TablesTest, AssertsCompiledSQL):
             column("bookcase_id", Integer),
             column("bookcase_owner_id", Integer),
         ).data([(1, 1), (2, 1), (3, 2), (3, 3)])
-        stmt = select([people, values])
+        stmt = select(people, values)
 
         with testing.expect_warnings(
             r"SELECT statement has a cartesian product between FROM "


### PR DESCRIPTION
This is the first attempt at #4784 and #4790. I expect requested changes on the error messages at the very least, but wanted to post it for review.

### Description

* type_ck has been added
* `_prefix_dict` was renamed `_base_prefix_dict` along with a note to better describe how prefix overrides work (such as 'ck' -> 'type_ck')
* a small change to `_get_prefixes`: only use the `type_` prefix if no name was presented. this was more backwards compatible after writing some test cases.
* test cases! test_metadata has a lot of rewrites and additions to NamingConventionsTest , starting with `test_schematype_ck_name_boolean` and all the way down to `test_schematype_no_ck_name_boolean_no_name`
* newly added- `ConventionDict.debug_info(`
* handled edgecase & test for a constraint with no columns, but a column_name token. improved error message, also added  "debug_info".
* improved error message for having convention that requires a constraint name, but no constraint name available; also added  "debug_info".

### Checklist
This pull request is:
- [x] A documentation / typographical error fix
- [x] A short code fix
        - Fixes: #4784
        - Fixes: #4790
- [ ] A new feature implementation

### Of Importance...

I added a docstring to each test describing the use-case.  These were either explicit from the various tickets or inferred by my best guesses.  They need review.

I also added 2 tests for dealing with PEP-435 enums. The sqlalchemy docs note the classname will be used as the constraint_name, however there were no previous tests concerning this.