### PR TITLE
New cx_Oracle dialect connection option to handle text encoding errors

### DIFF
--- a/test/dialect/oracle/test_types.py
+++ b/test/dialect/oracle/test_types.py
@@ -731,6 +731,13 @@ class TypesTest(fixtures.TestBase):
         value = testing.db.scalar("SELECT 'hello' FROM DUAL")
         assert isinstance(value, util.text_type)
 
+    @testing.only_on("oracle+cx_oracle", "cx_oracle-specific feature")
+    @testing.provide_metadata
+    def test_text_encoding_errors(self):
+        engine = testing_engine(options=dict(text_encoding_errors="replace"))
+        value = engine.scalar("SELECT 'Hello' FROM DUAL")
+        assert value == 'Hello'
+
     @testing.provide_metadata
     def test_reflect_dates(self):
         metadata = self.metadata


### PR DESCRIPTION
Added a new connection option named `text_encoding_errors` to allow the handling of text encoding errors when using the cx_Oracle dialect.

Fixes: #4799 

### Description
There are cases when Oracle contains "corrupt data", meaning data which cannot be encoded with UTF8 properly. This should be rare, but when it happens, then the current behaviour of SQLAlchemy+cx_Oracle to error out.
To allow different handling this error the above connection option has been added

See more detials https://github.com/sqlalchemy/sqlalchemy/issues/4799

Unfortunately testing corrupted UTF8 characters is very hard (how do you insert them into the database in the first place?), so I have only included a simple test. Anyone is welcome to add a "full" test if figures out how to insert corrupted characters into Oracle.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ x ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
