### PR TITLE
PGDialect.get_check_constraints: Handle "NOT VALID"

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3451,7 +3451,7 @@ class PGDialect(default.DefaultDialect):
         # "CHECK (((a > 1) AND (a < 5)))"
         # "CHECK (((a = 1) OR ((a > 2) AND (a < 5))))"
         def match_cons(src):
-            m = re.match(r"^CHECK *\(\((.+)\)\)$", src)
+            m = re.match(r"^CHECK *\(\((.+)\)\)( NOT VALID)?$", src)
             if not m:
                 util.warn("Could not parse CHECK constraint text: %r" % src)
                 return ""

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -1535,6 +1535,25 @@ class ReflectionTest(fixtures.TestBase):
             ):
                 testing.db.dialect.get_check_constraints(conn, "foo")
 
+    def test_reflect_with_not_valid_check_constraint(self):
+        conn = mock.Mock(
+            execute=lambda *arg, **kw: mock.Mock(
+                fetchall=lambda: [
+                    ("some name", "CHECK ((a IS NOT NULL)) NOT VALID")
+                ]
+            )
+        )
+        with mock.patch.object(
+            testing.db.dialect, "get_table_oid", lambda *arg, **kw: 1
+        ):
+            check_constraints = testing.db.dialect.get_check_constraints(
+                conn, "foo"
+            )
+            eq_(
+                check_constraints,
+                [{u"name": u"some name", u"sqltext": u"a IS NOT NULL"}],
+            )
+
 
 class CustomTypeReflectionTest(fixtures.TestBase):
     class CustomType(object):


### PR DESCRIPTION
### Description

PostgreSQL supports creating "not valid" check constraints that contain
the string " NOT VALID" in their declaration. Here, we update our
regular expression to properly parse check constraints that have yet to
be validated.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.