### PR TITLE
Improve testcase condition statement for dialects

### DIFF
--- a/test/engine/test_reflection.py
+++ b/test/engine/test_reflection.py
@@ -1146,10 +1146,7 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
         )
         sa.Index("where", table_a.c["from"])
 
-        # There's currently no way to calculate identifier case
-        # normalization in isolation, so...
-
-        if testing.against("firebird", "oracle"):
+        if meta.bind.dialect.requires_name_normalize:
             check_col = "TRUE"
         else:
             check_col = "true"


### PR DESCRIPTION
We could get dialect.requires_name_normalize rather than use hard code
as "firebird" or "oracle", since we have add `normalize` attribute for
quite a long time.

### Description

Use `dialect.requires_name_normalize` instead `testing.against("firebird", "oracle")`

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
