### PR TITLE
Add note on the use of tuple_() for the IN operator in the docs

### DIFF
--- a/doc/build/orm/tutorial.rst
+++ b/doc/build/orm/tutorial.rst
@@ -783,16 +783,12 @@ Here's a rundown of some of the most common operators used in
         session.query(User.name).filter(User.name.like('%ed%'))
     ))
 
- .. note:: for composite (multi-column) IN queries, group columns together
-    using :func:`.tuple_` :
-
-    .. sourcecode:: python
-
-        from sqlalchemy import tuple_
-        query.filter(
-            tuple_(User.name, User.nickname).\
-            in_([('ed', 'edsnickname'), ('wendy', 'windy')])
-        )
+    # use tuple_() for composite (multi-column) queries
+    from sqlalchemy import tuple_
+    query.filter(
+        tuple_(User.name, User.nickname).\
+        in_([('ed', 'edsnickname'), ('wendy', 'windy')])
+    )
 
 * :meth:`NOT IN <.ColumnOperators.notin_>`::
 

--- a/doc/build/orm/tutorial.rst
+++ b/doc/build/orm/tutorial.rst
@@ -784,7 +784,15 @@ Here's a rundown of some of the most common operators used in
     ))
 
  .. note:: for composite (multi-column) IN queries, group columns together
-    using :func:`.tuple_`
+    using :func:`.tuple_` :
+
+    .. sourcecode:: python
+
+        from sqlalchemy import tuple_
+        query.filter(
+            tuple_(User.name, User.nickname).\
+            in_([('ed', 'edsnickname'), ('wendy', 'windy')])
+        )
 
 * :meth:`NOT IN <.ColumnOperators.notin_>`::
 

--- a/doc/build/orm/tutorial.rst
+++ b/doc/build/orm/tutorial.rst
@@ -783,6 +783,9 @@ Here's a rundown of some of the most common operators used in
         session.query(User.name).filter(User.name.like('%ed%'))
     ))
 
+ .. note:: for composite (multi-column) IN queries, group columns together
+    using :func:`.tuple_`
+
 * :meth:`NOT IN <.ColumnOperators.notin_>`::
 
     query.filter(~User.name.in_(['ed', 'wendy', 'jack']))


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
I added a note pointing to the definition of `tuple_()` in the ORM tutorial part showcasing the `in_()` operator.
It took me so long to figure out how to make a composite IN query I thought I might as well help others find it faster in the docs
### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
