### PR TITLE
fix error in test_round_trip for TimeTest with mysql+pyodbc

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mysql/pyodbc.py
@@ -29,6 +29,7 @@ from .base import MySQLExecutionContext
 from .types import TIME
 from ... import util
 from ...connectors.pyodbc import PyODBCConnector
+from ...sql.sqltypes import Time
 
 
 class _pyodbcTIME(TIME):
@@ -50,7 +51,7 @@ class MySQLExecutionContext_pyodbc(MySQLExecutionContext):
 
 
 class MySQLDialect_pyodbc(PyODBCConnector, MySQLDialect):
-    colspecs = util.update_copy(MySQLDialect.colspecs, {TIME: _pyodbcTIME})
+    colspecs = util.update_copy(MySQLDialect.colspecs, {Time: _pyodbcTIME})
     supports_unicode_statements = False
     execution_ctx_cls = MySQLExecutionContext_pyodbc
 

--- a/lib/sqlalchemy/dialects/mysql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mysql/pyodbc.py
@@ -26,8 +26,18 @@ import re
 
 from .base import MySQLDialect
 from .base import MySQLExecutionContext
+from .types import TIME
 from ... import util
 from ...connectors.pyodbc import PyODBCConnector
+
+
+class _pyodbcTIME(TIME):
+    def result_processor(self, dialect, coltype):
+        def process(value):
+            # pyodbc already returns a datetime.time object, so no need to convert
+            return value
+
+        return process
 
 
 class MySQLExecutionContext_pyodbc(MySQLExecutionContext):
@@ -40,6 +50,7 @@ class MySQLExecutionContext_pyodbc(MySQLExecutionContext):
 
 
 class MySQLDialect_pyodbc(PyODBCConnector, MySQLDialect):
+    colspecs = util.update_copy(MySQLDialect.colspecs, {TIME: _pyodbcTIME})
     supports_unicode_statements = False
     execution_ctx_cls = MySQLExecutionContext_pyodbc
 

--- a/lib/sqlalchemy/dialects/mysql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mysql/pyodbc.py
@@ -35,7 +35,7 @@ from ...sql.sqltypes import Time
 class _pyodbcTIME(TIME):
     def result_processor(self, dialect, coltype):
         def process(value):
-            # pyodbc already returns a datetime.time object, so no need to convert
+            # pyodbc returns a datetime.time object; no need to convert
             return value
 
         return process

--- a/lib/sqlalchemy/dialects/mysql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mysql/pyodbc.py
@@ -40,7 +40,7 @@ class MySQLExecutionContext_pyodbc(MySQLExecutionContext):
 
 
 class MySQLDialect_pyodbc(PyODBCConnector, MySQLDialect):
-    supports_unicode_statements = False
+    supports_unicode_statements = True
     execution_ctx_cls = MySQLExecutionContext_pyodbc
 
     pyodbc_driver_name = "MySQL"

--- a/lib/sqlalchemy/dialects/mysql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mysql/pyodbc.py
@@ -40,7 +40,7 @@ class MySQLExecutionContext_pyodbc(MySQLExecutionContext):
 
 
 class MySQLDialect_pyodbc(PyODBCConnector, MySQLDialect):
-    supports_unicode_statements = True
+    supports_unicode_statements = False
     execution_ctx_cls = MySQLExecutionContext_pyodbc
 
     pyodbc_driver_name = "MySQL"

--- a/lib/sqlalchemy/dialects/mysql/types.py
+++ b/lib/sqlalchemy/dialects/mysql/types.py
@@ -422,17 +422,22 @@ class TIME(sqltypes.TIME):
         time = datetime.time
 
         def process(value):
-            # convert from a timedelta value
             if value is not None:
-                microseconds = value.microseconds
-                seconds = value.seconds
-                minutes = seconds // 60
-                return time(
-                    minutes // 60,
-                    minutes % 60,
-                    seconds - minutes * 60,
-                    microsecond=microseconds,
-                )
+                if isinstance(value, datetime.timedelta):
+                    # convert timedelta value to datetime.time
+                    microseconds = value.microseconds
+                    seconds = value.seconds
+                    minutes = seconds // 60
+                    return time(
+                        minutes // 60,
+                        minutes % 60,
+                        seconds - minutes * 60,
+                        microsecond=microseconds,
+                    )
+                elif isinstance(value, datetime.time):
+                    return value
+                else:
+                    raise ValueError("Unexpected type: %s" % type(value))
             else:
                 return None
 

--- a/lib/sqlalchemy/dialects/mysql/types.py
+++ b/lib/sqlalchemy/dialects/mysql/types.py
@@ -422,22 +422,17 @@ class TIME(sqltypes.TIME):
         time = datetime.time
 
         def process(value):
+            # convert from a timedelta value
             if value is not None:
-                if isinstance(value, datetime.timedelta):
-                    # convert timedelta value to datetime.time
-                    microseconds = value.microseconds
-                    seconds = value.seconds
-                    minutes = seconds // 60
-                    return time(
-                        minutes // 60,
-                        minutes % 60,
-                        seconds - minutes * 60,
-                        microsecond=microseconds,
-                    )
-                elif isinstance(value, datetime.time):
-                    return value
-                else:
-                    raise ValueError("Unexpected type: %s" % type(value))
+                microseconds = value.microseconds
+                seconds = value.seconds
+                minutes = seconds // 60
+                return time(
+                    minutes // 60,
+                    minutes % 60,
+                    seconds - minutes * 60,
+                    microsecond=microseconds,
+                )
             else:
                 return None
 


### PR DESCRIPTION
Fixes: #4879

### Description
create mysql+pyodbc-specific `_pyodbcTIME` class to avoid error thrown by `result_processor` in the (more) generic mysql/types.py.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
