### PR TITLE
add on_connect to MySQLDialect_pyodbc

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mysql/pyodbc.py
@@ -79,5 +79,18 @@ class MySQLDialect_pyodbc(PyODBCConnector, MySQLDialect):
         else:
             return None
 
+    def on_connect(self):
+        super_ = super(MySQLDialect_pyodbc, self).on_connect()
+
+        def on_connect(conn):
+            if super_ is not None:
+                super_(conn)
+
+            conn.setdecoding(1, encoding='utf-8')  # pyodbc.SQL_CHAR
+            conn.setdecoding(-8, encoding='utf-8')  # pyodbc.SQL_WCHAR
+            conn.setencoding(encoding='utf-8')
+
+        return on_connect
+
 
 dialect = MySQLDialect_pyodbc

--- a/lib/sqlalchemy/dialects/mysql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mysql/pyodbc.py
@@ -23,6 +23,7 @@
 """
 
 import re
+import sys
 
 from .base import MySQLDialect
 from .base import MySQLExecutionContext
@@ -86,9 +87,19 @@ class MySQLDialect_pyodbc(PyODBCConnector, MySQLDialect):
             if super_ is not None:
                 super_(conn)
 
-            conn.setdecoding(1, encoding='utf-8')  # pyodbc.SQL_CHAR
-            conn.setdecoding(-8, encoding='utf-8')  # pyodbc.SQL_WCHAR
-            conn.setencoding(encoding='utf-8')
+            # declare Unicode encoding for pyodbc as per
+            #   https://github.com/mkleehammer/pyodbc/wiki/Unicode
+            pyodbc_SQL_CHAR = 1  # pyodbc.SQL_CHAR
+            pyodbc_SQL_WCHAR = -8  # pyodbc.SQL_WCHAR
+            if sys.version_info.major > 2:
+                conn.setdecoding(pyodbc_SQL_CHAR, encoding='utf-8')
+                conn.setdecoding(pyodbc_SQL_WCHAR, encoding='utf-8')
+                conn.setencoding(encoding='utf-8')
+            else:
+                conn.setdecoding(pyodbc_SQL_CHAR, encoding='utf-8')
+                conn.setdecoding(pyodbc_SQL_WCHAR, encoding='utf-8')
+                conn.setencoding(str, encoding='utf-8')
+                conn.setencoding(unicode, encoding='utf-8')
 
         return on_connect
 


### PR DESCRIPTION
Fixes: #4876

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
add on_connect to MySQLDialect_pyodbc to specify Unicode encoding/decoding settings for the pyodbc connection

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
