### PR TITLE
added additional error message to is_disconnect() for Firebird dialects

### DIFF
--- a/lib/sqlalchemy/dialects/firebird/kinterbasdb.py
+++ b/lib/sqlalchemy/dialects/firebird/kinterbasdb.py
@@ -188,7 +188,8 @@ class FBDialect_kinterbasdb(FBDialect):
         ):
             msg = str(e)
             return (
-                "Unable to complete network request to host" in msg
+                "Error writing data to the connection" in msg
+                or "Unable to complete network request to host" in msg
                 or "Invalid connection state" in msg
                 or "Invalid cursor state" in msg
                 or "connection shutdown" in msg


### PR DESCRIPTION
### Description
None of the error messages checked in `is_disconnect()` for Firebird databases seemed to correspond to the error I actually saw when a connection was no longer valid. So, I added the message that I did get. #4903

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.
