### PR TITLE
Raise InvalidRequestError when `get` is called with None

### DIFF
--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -948,6 +948,14 @@ class Query(Generative):
 
         mapper = self._only_full_mapper_zero("get")
 
+        is_none = primary_key_identity is None
+        if is_none:
+            raise sa_exc.InvalidRequestError(
+                "Invalid value None passed to formulate "
+                "primary key for query.get(); primary key columns are %s"
+                % ",".join("'%s'" % c for c in mapper.primary_key)
+            )
+
         is_dict = isinstance(primary_key_identity, dict)
         if not is_dict:
             primary_key_identity = util.to_list(primary_key_identity)

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -780,13 +780,6 @@ class GetTest(QueryTest):
 
         s = users.outerjoin(addresses)
 
-    def test_get_none_pk(self):
-        User = self.classes.User
-
-        s = Session()
-        q = s.query(User.id)
-        assert_raises(sa_exc.InvalidRequestError, q.get, None)
-
         class UserThing(fixtures.ComparableEntity):
             pass
 
@@ -801,6 +794,13 @@ class GetTest(QueryTest):
         sess = create_session()
         u10 = sess.query(UserThing).get((10, None))
         eq_(u10, UserThing(id=10))
+
+    def test_get_none_pk(self):
+        User = self.classes.User
+
+        s = Session()
+        q = s.query(User.id)
+        assert_raises(sa_exc.InvalidRequestError, q.get, None)
 
     def test_no_criterion(self):
         """test that get()/load() does not use preexisting filter/etc.

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -780,6 +780,13 @@ class GetTest(QueryTest):
 
         s = users.outerjoin(addresses)
 
+    def test_get_none_pk(self):
+        User = self.classes.User
+
+        s = Session()
+        q = s.query(User.id)
+        assert_raises(sa_exc.InvalidRequestError, q.get, None)
+
         class UserThing(fixtures.ComparableEntity):
             pass
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Fixes #4915 

Adds an explicit `None` check to `_get_impl`. If `primary_key_identity`is `None`, raise an `InvalidRequestError`.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.


