### PR TITLE
Expect ordering NULLs to work and skip nested aggregate tests on sqlite >= 3.30.

### DIFF
--- a/test/requirements.py
+++ b/test/requirements.py
@@ -772,7 +772,8 @@ class DefaultRequirements(SuiteRequirements):
     @property
     def nullsordering(self):
         """Target backends that support nulls ordering."""
-        return fails_on_everything_except("postgresql", "oracle", "firebird")
+        return fails_on_everything_except("postgresql", "oracle", "firebird",
+                                          "sqlite >= 3.30.0")
 
     @property
     def reflects_pk_names(self):

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -788,7 +788,7 @@ class DefaultRequirements(SuiteRequirements):
         """target database can select an aggregate from a subquery that's
         also using an aggregate"""
 
-        return skip_if(["mssql"])
+        return skip_if(["mssql", "sqlite"])
 
     @property
     def array_type(self):


### PR DESCRIPTION
This fixes/skips the tests I mentioned in issue #4920.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
SQlite 3.30 introduced support for ordering NULLs. The current tests didn't reflect that, this PR fixes it.

Nested aggregates seem to have stopped working as well, this PR skips the respective tests.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
