### PR TITLE
Fix Python 3.8 SyntaxWarning: "is not" with a literal

### DIFF
--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -176,7 +176,7 @@ class Query(Generative):
         self._primary_entity = None
         self._has_mapper_entities = False
 
-        if entities is not ():
+        if entities != ():
             for ent in util.to_list(entities):
                 entity_wrapper(self, ent)
 


### PR DESCRIPTION
### Description

Fixes this warning from Python 3.8 in `Query._set_entities`:

```
lib/sqlalchemy/orm/query.py:179: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if entities is not ():
```

Fixes #4938.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
