### PR TITLE
Add explanation of `polymorphic_identity` to docs

### DIFF
--- a/doc/build/orm/inheritance.rst
+++ b/doc/build/orm/inheritance.rst
@@ -97,11 +97,22 @@ columns), as well as a foreign key reference to the parent table::
             'polymorphic_identity':'manager',
         }
 
-It is most common that the foreign key constraint is established on the same
-column or columns as the primary key itself, however this is not required; a
-column distinct from the primary key may also be made to refer to the parent
-via foreign key.  The way that a JOIN is constructed from the base table to
-subclasses is also directly customizable, however this is rarely necessary.
+Note how a value called ``polymorphic_identity`` has been sepecified for each
+class. This value is closesly related to ``polymorphic_on``; in particular, the
+value of ``polymorphic_identity`` populates the row designated by
+``polymorphic_on``. Each class or subclass gets its own value for
+``polymorphic_identity``. This value should be unique; it is how SQLAlchemy
+tells which class a row belongs to in a polymorphic setup. For instance, in this
+example, every row which represents an ``Employee`` will have the value
+``'employee'`` in its ``type`` row; likewise, every ``Engineer`` will get the
+value ``'engineer'``, and each ``Manager`` will get the value ``'manager'``.
+
+In a polymorphic setup, it is most common that the foreign key constraint is
+established on the same column or columns as the primary key itself, however
+this is not required; a column distinct from the primary key may also be made
+to refer to the parent via foreign key.  The way that a JOIN is constructed
+from the base table to subclasses is also directly customizable, however this
+is rarely necessary.
 
 .. topic:: Joined inheritance primary keys
 


### PR DESCRIPTION
See title.

### Description
Fixes https://github.com/sqlalchemy/sqlalchemy/issues/4951.

The docs neglected to explain exactly how `polymorphic_identity` works--it is a value representation of which type the row belongs to. While this makes a lot of sense in hindsight, it may not be obvious to a beginner.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
