### PR TITLE
python3 does not support comparison between NoneType and tuple

### DIFF
--- a/lib/sqlalchemy/dialects/oracle/base.py
+++ b/lib/sqlalchemy/dialects/oracle/base.py
@@ -1290,7 +1290,7 @@ class OracleDialect(default.DefaultDialect):
         super(OracleDialect, self).initialize(connection)
 
         self.implicit_returning = self.__dict__.get(
-            "implicit_returning", self.server_version_info > (10,)
+            "implicit_returning", self.server_version_info and self.server_version_info > (10,)
         )
 
         if self._is_oracle_8:
@@ -1302,7 +1302,7 @@ class OracleDialect(default.DefaultDialect):
         # dialect does not need compat levels below 12.2, so don't query
         # in those cases
 
-        if self.server_version_info < (12, 2):
+        if self.server_version_info and self.server_version_info < (12, 2):
             return self.server_version_info
         try:
             compat = connection.execute(
@@ -1315,9 +1315,9 @@ class OracleDialect(default.DefaultDialect):
             try:
                 return tuple(int(x) for x in compat.split("."))
             except:
-                return self.server_version_info
+                return self.server_version_info if self.server_version_info else ()
         else:
-            return self.server_version_info
+            return self.server_version_info if self.server_version_info else ()
 
     @property
     def _is_oracle_8(self):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Python3 does not allow comparison between `NoneType` and `tuple`. Without this change we get error mentioned in the issue https://github.com/sqlalchemy/sqlalchemy/issues/4964

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
