### PR TITLE
Add note to hybrid.py setter documentation

### DIFF
--- a/lib/sqlalchemy/ext/hybrid.py
+++ b/lib/sqlalchemy/ext/hybrid.py
@@ -207,6 +207,24 @@ The ``length(self, value)`` method is now called upon set::
     >>> i1.end
     17
 
+.. note:: When defining an setter for a hybrid property or method, the
+   expression method **must** retain the name of the original hybrid, else
+   the new hybrid with the additional state will be attached to the object
+   with the non-matching name. To use the example above::
+
+    class Interval(object):
+        # ...
+
+        @hybrid_property
+        def radius(self):
+            return self.length / 2
+
+        # WRONG - the non-matching name will cause this function to be
+        # ignored
+        @radius.setter
+        def radius_setter(self, radius):
+            self.length = radius * 2
+
 .. _hybrid_bulk_update:
 
 Allowing Bulk ORM Update


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Almost the same note of the defining expression. Although it's already said implicitly in the note of the session before, one searching about getters and setters for hybrid properties may skip it, so it's better redundancy and beeing explicitly about it to avoid headaches.

### Motivation

I had a lot of pain with this issue, and I rechecked the documentation many times trying to solve it but I missed the note on the defining expression because I wasn't interested in using it. I was kind of expecting something like this note.

The redaction here is a suggestion based on the previous note.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [X] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
