### PR TITLE
Add DATETIMEOFFSET support for mssql+pyodbc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ test/test_schema.db
 *test_schema.db
 .idea
 /Pipfile*
+/db_idents.txt

--- a/lib/sqlalchemy/dialects/mssql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mssql/pyodbc.py
@@ -118,7 +118,7 @@ in order to use this flag::
 
 """  # noqa
 
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 import decimal
 import re
 import struct
@@ -370,13 +370,15 @@ class MSDialect_pyodbc(PyODBCConnector, MSDialect):
 
             # output converter function for datetimeoffset
             def _handle_datetimeoffset(dto_value):
-                # ref: https://github.com/mkleehammer/pyodbc/issues/134#issuecomment-281739794
-                tup = struct.unpack("<6hI2h", dto_value)  # e.g., (2017, 3, 16, 10, 35, 18, 0, -6, 0)
-                return datetime(tup[0], tup[1], tup[2], tup[3], tup[4], tup[5], tup[6] // 1000,
-                                timezone(timedelta(hours=tup[7], minutes=tup[8])))
+                tup = struct.unpack("<6hI2h", dto_value)
+                return datetime(tup[0], tup[1], tup[2],
+                                tup[3], tup[4], tup[5], tup[6] // 1000,
+                                timezone(timedelta(hours=tup[7],
+                                                   minutes=tup[8])))
 
             odbc_SQL_SS_TIMESTAMPOFFSET = -155  # as defined in SQLNCLI.h
-            conn.add_output_converter(odbc_SQL_SS_TIMESTAMPOFFSET, _handle_datetimeoffset)
+            conn.add_output_converter(odbc_SQL_SS_TIMESTAMPOFFSET,
+                                      _handle_datetimeoffset)
 
         return on_connect
 

--- a/test/dialect/mssql/test_types.py
+++ b/test/dialect/mssql/test_types.py
@@ -730,14 +730,16 @@ class TypeRoundTripTest(
         d2 = datetime.datetime(2007, 10, 30, 11, 2, 32)
         dto = datetime.datetime(2007, 10, 30, 11, 2, 32, 0,
                                 datetime.timezone(datetime.timedelta(hours=1)))
-        t.insert().execute(adate=d1, adatetime=d2, atime=t1, adatetimeoffset=dto)
+        t.insert().execute(adate=d1, adatetime=d2, atime=t1,
+                           adatetimeoffset=dto)
 
         # NOTE: this previously passed 'd2' for "adate" even though
         # "adate" is a date column; we asserted that it truncated w/o issue.
         # As of pyodbc 4.0.22, this is no longer accepted, was accepted
         # in 4.0.21.  See also the new pyodbc assertions regarding numeric
         # precision.
-        t.insert().execute(adate=d1, adatetime=d2, atime=d2, adatetimeoffset=dto)
+        t.insert().execute(adate=d1, adatetime=d2, atime=d2,
+                           adatetimeoffset=dto)
 
         x = t.select().execute().fetchall()[0]
         self.assert_(x.adate.__class__ == datetime.date)
@@ -747,10 +749,12 @@ class TypeRoundTripTest(
 
         t.delete().execute()
 
-        t.insert().execute(adate=d1, adatetime=d2, atime=t1, adatetimeoffset=dto)
+        t.insert().execute(adate=d1, adatetime=d2, atime=t1,
+                           adatetimeoffset=dto)
 
         eq_(
-            select([t.c.adate, t.c.atime, t.c.adatetime, t.c.adatetimeoffset], t.c.adate == d1)
+            select([t.c.adate, t.c.atime, t.c.adatetime, t.c.adatetimeoffset],
+                   t.c.adate == d1)
             .execute()
             .fetchall(),
             [(d1, t1, d2, dto)],

--- a/test/dialect/mssql/test_types.py
+++ b/test/dialect/mssql/test_types.py
@@ -36,6 +36,7 @@ from sqlalchemy.databases import mssql
 from sqlalchemy.dialects.mssql import ROWVERSION
 from sqlalchemy.dialects.mssql import TIMESTAMP
 from sqlalchemy.dialects.mssql.base import _MSDate
+from sqlalchemy.dialects.mssql.base import DATETIMEOFFSET
 from sqlalchemy.dialects.mssql.base import MS_2005_VERSION
 from sqlalchemy.dialects.mssql.base import MS_2008_VERSION
 from sqlalchemy.dialects.mssql.base import TIME
@@ -721,34 +722,38 @@ class TypeRoundTripTest(
             Column("adate", Date),
             Column("atime", Time),
             Column("adatetime", DateTime),
+            Column("adatetimeoffset", DATETIMEOFFSET),
         )
         metadata.create_all()
         d1 = datetime.date(2007, 10, 30)
         t1 = datetime.time(11, 2, 32)
         d2 = datetime.datetime(2007, 10, 30, 11, 2, 32)
-        t.insert().execute(adate=d1, adatetime=d2, atime=t1)
+        dto = datetime.datetime(2007, 10, 30, 11, 2, 32, 0,
+                                datetime.timezone(datetime.timedelta(hours=1)))
+        t.insert().execute(adate=d1, adatetime=d2, atime=t1, adatetimeoffset=dto)
 
         # NOTE: this previously passed 'd2' for "adate" even though
         # "adate" is a date column; we asserted that it truncated w/o issue.
         # As of pyodbc 4.0.22, this is no longer accepted, was accepted
         # in 4.0.21.  See also the new pyodbc assertions regarding numeric
         # precision.
-        t.insert().execute(adate=d1, adatetime=d2, atime=d2)
+        t.insert().execute(adate=d1, adatetime=d2, atime=d2, adatetimeoffset=dto)
 
         x = t.select().execute().fetchall()[0]
         self.assert_(x.adate.__class__ == datetime.date)
         self.assert_(x.atime.__class__ == datetime.time)
         self.assert_(x.adatetime.__class__ == datetime.datetime)
+        self.assert_(x.adatetimeoffset.__class__ == datetime.datetime)
 
         t.delete().execute()
 
-        t.insert().execute(adate=d1, adatetime=d2, atime=t1)
+        t.insert().execute(adate=d1, adatetime=d2, atime=t1, adatetimeoffset=dto)
 
         eq_(
-            select([t.c.adate, t.c.atime, t.c.adatetime], t.c.adate == d1)
+            select([t.c.adate, t.c.atime, t.c.adatetime, t.c.adatetimeoffset], t.c.adate == d1)
             .execute()
             .fetchall(),
-            [(d1, t1, d2)],
+            [(d1, t1, d2, dto)],
         )
 
     @emits_warning_on("mssql+mxodbc", r".*does not have any indexes.*")


### PR DESCRIPTION
Fixes: #4983

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Add a pyodbc output converter function to decode DATETIMEOFFSET values received from the server, and a bind_processor to format timezone-aware `datetime` objects as strings for INSERT and UPDATE.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
