### PR TITLE
Show how to install pytest in the testing README

### DIFF
--- a/README.unittests.rst
+++ b/README.unittests.rst
@@ -46,7 +46,9 @@ connectivity, multi process support, as well as lots of skip / database
 selection rules.
 
 Running tests with py.test directly grants more immediate control over
-database options and test selection.
+database options and test selection. To run py.test directly, install it::
+
+    pip install pytest pytest-xdist
 
 A generic py.test run looks like::
 

--- a/README.unittests.rst
+++ b/README.unittests.rst
@@ -46,7 +46,8 @@ connectivity, multi process support, as well as lots of skip / database
 selection rules.
 
 Running tests with py.test directly grants more immediate control over
-database options and test selection. To run py.test directly, install it::
+database options and test selection. To run py.test directly, first
+install it::
 
     pip install pytest pytest-xdist
 


### PR DESCRIPTION
### Description

This PR adds a brief note to the testing README showing how to install pytest. Without it, new contributors like myself will hit the `unrecognized arguments: --max-worker-restart=5` error reported in #4900.

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
