### PR TITLE
Treat ODBC connection string keywords as case-insensitive.

### DIFF
--- a/lib/sqlalchemy/connectors/pyodbc.py
+++ b/lib/sqlalchemy/connectors/pyodbc.py
@@ -58,7 +58,7 @@ class PyODBCConnector(Connector):
                     token = "'%s'" % token
                 return token
 
-            keys = dict((k, check_quote(v)) for k, v in keys.items())
+            keys = dict((k.lower(), check_quote(v)) for k, v in keys.items())
 
             dsn_connection = "dsn" in keys or (
                 "host" in keys and "database" not in keys

--- a/test/dialect/mssql/test_engine.py
+++ b/test/dialect/mssql/test_engine.py
@@ -47,7 +47,7 @@ class ParseConnectTest(fixtures.TestBase):
         )
         connection = dialect.create_connect_args(u)
         dsn_string = connection[0][0]
-        assert ";LANGUAGE=us_english" in dsn_string
+        assert ";language=us_english" in dsn_string
         assert ";foo=bar" in dsn_string
 
     def test_pyodbc_hostname(self):
@@ -85,6 +85,27 @@ class ParseConnectTest(fixtures.TestBase):
         eq_(
             [
                 [
+                    "Server=hostspec;Database=database;UI"
+                    "D=username;PWD=password"
+                ],
+                {},
+            ],
+            connection,
+        )
+
+    def test_pyodbc_uppercase_driver_keyword_no_warn(self):
+        dialect = pyodbc.dialect()
+        u = url.make_url("mssql://username:password@hostspec/database"
+                         "?DRIVER=ODBC Driver 17 for SQL Server")
+
+        # without assert_warnings (as in test_pyodbc_host_no_driver, above)
+        #   this test will fail here if a warning is issued
+        connection = dialect.create_connect_args(u)
+
+        eq_(
+            [
+                [
+                    "DRIVER={ODBC Driver 17 for SQL Server};"
                     "Server=hostspec;Database=database;UI"
                     "D=username;PWD=password"
                 ],
@@ -141,9 +162,9 @@ class ParseConnectTest(fixtures.TestBase):
             connection[0][0]
             in (
                 "DRIVER={SQL Server};Server=hostspec;Database=database;"
-                "UID=username;PWD=password;foo=bar;LANGUAGE=us_english",
+                "UID=username;PWD=password;foo=bar;language=us_english",
                 "DRIVER={SQL Server};Server=hostspec;Database=database;UID="
-                "username;PWD=password;LANGUAGE=us_english;foo=bar",
+                "username;PWD=password;language=us_english;foo=bar",
             ),
             True,
         )


### PR DESCRIPTION
Fixes: #4576

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Treat ODBC connection string keywords as case-insensitive (for mssql+pyodbc).

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
