### PR TITLE
Add CTE prefixes

### DIFF
--- a/doc/build/changelog/unreleased_13/5040.rst
+++ b/doc/build/changelog/unreleased_13/5040.rst
@@ -1,0 +1,10 @@
+.. change::
+    :tags: usecase, postgresql
+    :tickets: 5040
+
+    Added support for CTE prefixes so that it is possible to specify
+    MATERIALIZED or NOT MATERIALIZED. They were added in PostgreSQL 12.
+
+    .. seealso::
+
+        :meth:`.HasCTE.cte`

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -1851,7 +1851,8 @@ class SQLCompiler(Compiled):
                     kwargs["positional_names"] = self.cte_positional[cte] = []
 
                 assert kwargs.get("subquery", False) is False
-                text += " AS \n(%s)" % (
+                text += " AS %s\n(%s)" % (
+                    self._generate_prefixes(cte, cte._prefixes, **kwargs),
                     cte.element._compiler_dispatch(
                         self, asfrom=True, **kwargs
                     ),

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -1451,7 +1451,7 @@ class TableSample(AliasedReturnsRows):
             return functions.func.system(self.sampling)
 
 
-class CTE(Generative, HasSuffixes, AliasedReturnsRows):
+class CTE(Generative, HasPrefixes, HasSuffixes, AliasedReturnsRows):
     """Represent a Common Table Expression.
 
     The :class:`.CTE` object is obtained using the
@@ -1469,6 +1469,7 @@ class CTE(Generative, HasSuffixes, AliasedReturnsRows):
             ("_restates", InternalTraversal.dp_clauseelement_unordered_set),
             ("recursive", InternalTraversal.dp_boolean),
         ]
+        + HasPrefixes._traverse_internals
         + HasSuffixes._traverse_internals
     )
 
@@ -1490,11 +1491,14 @@ class CTE(Generative, HasSuffixes, AliasedReturnsRows):
         recursive=False,
         _cte_alias=None,
         _restates=frozenset(),
+        _prefixes=None,
         _suffixes=None,
     ):
         self.recursive = recursive
         self._cte_alias = _cte_alias
         self._restates = _restates
+        if _prefixes:
+            self._prefixes = _prefixes
         if _suffixes:
             self._suffixes = _suffixes
         super(CTE, self)._init(selectable, name=name)
@@ -1526,6 +1530,7 @@ class CTE(Generative, HasSuffixes, AliasedReturnsRows):
             name=name,
             recursive=self.recursive,
             _cte_alias=self,
+            _prefixes=self._prefixes,
             _suffixes=self._suffixes,
         )
 
@@ -1535,6 +1540,7 @@ class CTE(Generative, HasSuffixes, AliasedReturnsRows):
             name=self.name,
             recursive=self.recursive,
             _restates=self._restates.union([self]),
+            _prefixes=self._prefixes,
             _suffixes=self._suffixes,
         )
 
@@ -1544,6 +1550,7 @@ class CTE(Generative, HasSuffixes, AliasedReturnsRows):
             name=self.name,
             recursive=self.recursive,
             _restates=self._restates.union([self]),
+            _prefixes=self._prefixes,
             _suffixes=self._suffixes,
         )
 
@@ -1575,8 +1582,14 @@ class HasCTE(roles.HasCTERole):
         to be delivered to the FROM clause of the statement as well
         as to a WITH clause at the top of the statement.
 
+        It is also possible to specify MATERIALIZED or NOT MATERIALIZED prefix.
+        They were added in PostgreSQL 12 to prevent or force inlining of CTEs.
+
         .. versionchanged:: 1.1 Added support for UPDATE/INSERT/DELETE as
            CTE, CTEs added to UPDATE/INSERT/DELETE.
+
+        .. versionchanged:: 1.3.13 Added support for prefixes.
+           In particular - MATERIALIZED and NOT MATERIALIZED.
 
         :param name: name given to the common table expression.  Like
          :meth:`._FromClause.alias`, the name can be left as ``None``

--- a/test/sql/test_cte.py
+++ b/test/sql/test_cte.py
@@ -903,6 +903,28 @@ class CTETest(fixtures.TestBase, AssertsCompiledSQL):
             'ON anon_1."order" = "order"."order"',
         )
 
+    def test_prefixes(self):
+        orders = table("order", column("order"))
+        s = select([orders.c.order]).cte("regional_sales")
+        s = s.prefix_with("NOT MATERIALIZED", dialect="postgresql")
+        stmt = select([orders]).where(orders.c.order > s.c.order)
+
+        self.assert_compile(
+            stmt,
+            'WITH regional_sales AS (SELECT "order"."order" AS "order" '
+            'FROM "order") SELECT "order"."order" FROM "order", '
+            'regional_sales WHERE "order"."order" > regional_sales."order"',
+        )
+
+        self.assert_compile(
+            stmt,
+            'WITH regional_sales AS NOT MATERIALIZED '
+            '(SELECT "order"."order" AS "order" '
+            'FROM "order") SELECT "order"."order" FROM "order", '
+            'regional_sales WHERE "order"."order" > regional_sales."order"',
+            dialect="postgresql"
+        )
+
     def test_suffixes(self):
         orders = table("order", column("order"))
         s = select([orders.c.order]).cte("regional_sales")


### PR DESCRIPTION
Fixes: #5040

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Added support for CTE prefixes so that it is possible to specify MATERIALIZED or NOT MATERIALIZED.
They were added in PostgreSQL 12.

Thanks to @zzzeek for the patch.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
