### PR TITLE
Improve regex parsing of CHECK constraints.

### DIFF
--- a/doc/build/changelog/unreleased_13/5039.rst
+++ b/doc/build/changelog/unreleased_13/5039.rst
@@ -3,5 +3,5 @@
     :tickets: 5039
 
     Fixed issue where the PostgreSQL dialect would fail to parse a
-    reflected CHECK constraint that was a boolean-valued *function*
-    (as opposed to a boolean-valued *expression*).
+    reflected CHECK constraint that was a boolean-valued function
+    (as opposed to a boolean-valued expression).

--- a/doc/build/changelog/unreleased_13/5039.rst
+++ b/doc/build/changelog/unreleased_13/5039.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: bug, postgresql
+    :tickets: 5039
+
+    Fixed issue where the PostgreSQL dialect would fail to parse a
+    reflected CHECK constraint that was a boolean-valued *function*
+    (as opposed to a boolean-valued *expression*).

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3488,12 +3488,13 @@ class PGDialect(default.DefaultDialect):
             # "CHECK (((a > 1) AND (a < 5)))"
             # "CHECK (((a = 1) OR ((a > 2) AND (a < 5))))"
             # "CHECK (((a > 1) AND (a < 5))) NOT VALID"
-            m = re.match(r"^CHECK *\(\((.+)\)\)( NOT VALID)?$", src)
+            # "CHECK (some_boolean_function(a))"
+            m = re.match(r"^CHECK *\((.+)\)( NOT VALID)?$", src)
             if not m:
                 util.warn("Could not parse CHECK constraint text: %r" % src)
                 sqltext = ""
             else:
-                sqltext = m.group(1)
+                sqltext = re.sub(r'^\((.+)\)$', r'\1', m.group(1))
             entry = {"name": name, "sqltext": sqltext}
             if m and m.group(2):
                 entry["dialect_options"] = {"not_valid": True}

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -1538,7 +1538,7 @@ class ReflectionTest(fixtures.TestBase):
         sa.event.listen(meta, "before_create",
                         sa.DDL(udf_create))
         sa.event.listen(meta, "after_drop",
-                        sa.DDL("DROP FUNCTION is_positive"))
+                        sa.DDL("DROP FUNCTION is_positive(integer)"))
 
         cc_table = Table(
             "pgsql_cc",

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -18,7 +18,6 @@ from sqlalchemy import Sequence
 from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy import testing
-from sqlalchemy import text
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.dialects.postgresql import base as postgresql
@@ -1550,7 +1549,7 @@ class ReflectionTest(fixtures.TestBase):
             CheckConstraint("is_positive(a)", name="cc3"),
         )
 
-        cc_table.create()
+        meta.create_all()
 
         reflected = Table("pgsql_cc", MetaData(), autoload_with=testing.db)
 


### PR DESCRIPTION
Fixes: #5039

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Avoid parse warnings for PostgreSQL CHECK constraints that are a simple function call.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
