### PR TITLE
Fix DATETIMEOFFSET formatting to preserve fractional seconds.

### DIFF
--- a/README.unittests.rst
+++ b/README.unittests.rst
@@ -189,6 +189,12 @@ Additional steps specific to individual databases are as follows::
 
      ALTER DATABASE test SET default_text_search_config = 'pg_catalog.english'
 
+    For two-phase transaction support, the max_prepared_transactions
+    configuration variable must be set to a non-zero value in postgresql.conf.
+    See
+    https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-MAX-PREPARED-TRANSACTIONS
+    for further background.
+
     ORACLE: a user named "test_schema" is created in addition to the default
     user.
 

--- a/doc/build/changelog/unreleased_13/5040.rst
+++ b/doc/build/changelog/unreleased_13/5040.rst
@@ -1,0 +1,11 @@
+.. change::
+    :tags: usecase, postgresql
+    :tickets: 5040
+
+    Added support for prefixes to the :class:`.CTE` construct, to allow
+    support for Postgresql 12 "MATERIALIZED" and "NOT MATERIALIZED" phrases.
+    Pull request courtesy Marat Sharafutdinov.
+
+    .. seealso::
+
+        :meth:`.HasCTE.cte`

--- a/doc/build/changelog/unreleased_13/5045.rst
+++ b/doc/build/changelog/unreleased_13/5045.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: bug, mssql
+    :tickets: 5045
+
+    Fixed issue where a timezone-aware ``datetime`` value being converted
+    to string (for use as a parameter value of a ``datetimeoffset``
+    column) was omitting the fractional seconds.

--- a/doc/build/changelog/unreleased_13/5048.rst
+++ b/doc/build/changelog/unreleased_13/5048.rst
@@ -1,0 +1,15 @@
+.. change::
+    :tags: bug, engine
+    :tickets: 5048
+
+    Fixed issue where the collection of value processors on a
+    :class:`.Compiled` object would be mutated when "expanding IN" parameters
+    were used with a datatype that has bind value processors; in particular,
+    this would mean that when using statement caching and/or baked queries, the
+    same compiled._bind_processors collection would be mutated concurrently.
+    Since these processors are the same function for a given bind parameter
+    namespace every time, there was no actual negative effect of this issue,
+    however, the execution of a :class:`.Compiled` object should never be
+    causing any changes in its state, especially given that they are intended
+    to be thread-safe and reusable once fully constructed.
+

--- a/doc/build/changelog/unreleased_13/5050.rst
+++ b/doc/build/changelog/unreleased_13/5050.rst
@@ -1,9 +1,0 @@
-.. change::
-    :tags: bug, orm
-    :tickets: 5050
-
-    Fixed a reference cycle which could impact the GC behavior of the
-    :class:`.WeakSequence` object, currently used within one place in certain
-    mapper configurations.  The issue only affects configuration-time
-    structures. Pull request courtesy Carson Ip.
-

--- a/doc/build/changelog/unreleased_13/5050.rst
+++ b/doc/build/changelog/unreleased_13/5050.rst
@@ -1,0 +1,9 @@
+.. change::
+    :tags: bug, orm
+    :tickets: 5050
+
+    Fixed a reference cycle which could impact the GC behavior of the
+    :class:`.WeakSequence` object, currently used within one place in certain
+    mapper configurations.  The issue only affects configuration-time
+    structures. Pull request courtesy Carson Ip.
+

--- a/doc/build/changelog/unreleased_13/5056.rst
+++ b/doc/build/changelog/unreleased_13/5056.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: bug, orm, engine
+    :tickets: 5056, 5050
+
+    Added test support and repaired a wide variety of unnecessary reference
+    cycles created for short-lived objects, mostly in the area of ORM queries.
+    Thanks much to Carson Ip for the help on this.
+

--- a/doc/build/changelog/unreleased_13/5057.rst
+++ b/doc/build/changelog/unreleased_13/5057.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: tests, postgresql
+    :tickets: 5057
+
+    Improved detection of two phase transactions requirement for the PostgreSQL
+    database by testing that max_prepared_transactions is set to a value
+    greater than 0.  Pull request courtesy Federico Caselli.
+

--- a/doc/build/changelog/unreleased_13/5065.rst
+++ b/doc/build/changelog/unreleased_13/5065.rst
@@ -1,0 +1,17 @@
+.. change::
+    :tags: bug, orm
+    :tickets: 5065
+
+    Fixed bug where usage of joined eager loading would not properly wrap the
+    query inside of a subquery when :meth:`.Query.group_by` were used against
+    the query.   When any kind of result-limiting approach is used, such as
+    DISTINCT, LIMIT, OFFSET, joined eager loading embeds the row-limited query
+    inside of a subquery so that the collection results are not impacted.   For
+    some reason, the presence of GROUP BY was never included in this criterion,
+    even though it has a similar effect as using DISTINCT.   Additionally, the
+    bug would prevent using GROUP BY at all for a joined eager load query for
+    most database platforms which forbid non-aggregated, non-grouped columns
+    from being in the query, as the additional columns for the joined eager
+    load would not be accepted by the database.
+
+

--- a/doc/build/changelog/unreleased_13/rel_join.rst
+++ b/doc/build/changelog/unreleased_13/rel_join.rst
@@ -1,0 +1,10 @@
+.. change::
+    :tags: performance, orm
+
+    Identified a performance issue in the system by which a join is constructed
+    based on a mapped relationship.   The clause adaption system would be used
+    for the majority of join expressions including in the common case where no
+    adaptation is needed.   The conditions under which this adaptation occur
+    have been refined so that average non-aliased joins along a simple
+    relationship without a "secondary" table use about 70% less function calls.
+

--- a/doc/build/changelog/unreleased_14/4645.rst
+++ b/doc/build/changelog/unreleased_14/4645.rst
@@ -1,0 +1,18 @@
+.. change::
+    :tags: feature, sql
+    :tickets: 4645
+
+    The "expanding IN" feature, which generates IN expressions at query
+    execution time which are based on the particular parameters associated with
+    the statement execution, is now used for all IN expressions made against
+    lists of literal values.   This allows IN expressions to be fully cacheable
+    independently of the list of values being passed, and also includes support
+    for empty lists. For any scenario where the IN expression contains
+    non-literal SQL expressions, the old behavior of pre-rendering for each
+    position in the IN is maintained. The change also completes support for
+    expanding IN with tuples, where previously type-specific bind processors
+    weren't taking effect.
+
+    .. seealso::
+
+        :ref:`change_4645`

--- a/examples/sharding/attribute_shard.py
+++ b/examples/sharding/attribute_shard.py
@@ -17,11 +17,8 @@ from sqlalchemy.sql import operators
 from sqlalchemy.sql import visitors
 
 
-# db1 is used for id generation. The "pool_threadlocal"
-# causes the id_generator() to use the same connection as that
-# of an ongoing transaction within db1.
 echo = True
-db1 = create_engine("sqlite://", echo=echo, pool_threadlocal=True)
+db1 = create_engine("sqlite://", echo=echo)
 db2 = create_engine("sqlite://", echo=echo)
 db3 = create_engine("sqlite://", echo=echo)
 db4 = create_engine("sqlite://", echo=echo)
@@ -220,20 +217,7 @@ def _get_query_comparisons(query):
         clauses.add(column)
 
     def visit_binary(binary):
-        # special handling for "col IN (params)"
-        if (
-            binary.left in clauses
-            and binary.operator == operators.in_op
-            and hasattr(binary.right, "clauses")
-        ):
-            comparisons.append(
-                (
-                    binary.left,
-                    binary.operator,
-                    tuple(binds[bind] for bind in binary.right.clauses),
-                )
-            )
-        elif binary.left in clauses and binary.right in binds:
+        if binary.left in clauses and binary.right in binds:
             comparisons.append(
                 (binary.left, binary.operator, binds[binary.right])
             )

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -1909,14 +1909,14 @@ class MSSQLStrictCompiler(MSSQLCompiler):
     ansi_bind_rules = True
 
     def visit_in_op_binary(self, binary, operator, **kw):
-        kw["literal_binds"] = True
+        kw["literal_execute"] = True
         return "%s IN %s" % (
             self.process(binary.left, **kw),
             self.process(binary.right, **kw),
         )
 
     def visit_notin_op_binary(self, binary, operator, **kw):
-        kw["literal_binds"] = True
+        kw["literal_execute"] = True
         return "%s NOT IN %s" % (
             self.process(binary.left, **kw),
             self.process(binary.right, **kw),

--- a/lib/sqlalchemy/dialects/mssql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mssql/pyodbc.py
@@ -235,9 +235,9 @@ class _ODBCDateTimeOffset(DATETIMEOFFSET):
     def bind_processor(self, dialect):
         def process(value):
             """Convert to string format required by T-SQL."""
-            dto_string = value.strftime("%Y-%m-%d %H:%M:%S %z")
+            dto_string = value.strftime("%Y-%m-%d %H:%M:%S.%f %z")
             # offset needs a colon, e.g., -0700 -> -07:00
-            return dto_string[:23] + ":" + dto_string[23:]
+            return dto_string[:30] + ":" + dto_string[30:]
 
         return process
 

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2969,8 +2969,6 @@ class MySQLDialect(default.DefaultDialect):
             raise exc.NoSuchTableError(full_name)
         return row[1].strip()
 
-        return sql
-
     def _describe_table(self, connection, table, charset=None, full_name=None):
         """Run DESCRIBE for a ``Table`` and return processed rows."""
 

--- a/lib/sqlalchemy/engine/create.py
+++ b/lib/sqlalchemy/engine/create.py
@@ -23,7 +23,16 @@ from .. import util
         ":func:`.create_mock_engine` going forward.  For general "
         "customization of create_engine which may have been accomplished "
         "using strategies, see :class:`.CreateEnginePlugin`.",
-    )
+    ),
+    empty_in_strategy=(
+        "1.4",
+        "The :paramref:`.create_engine.empty_in_strategy` keyword is "
+        "deprecated, and no longer has any effect.  All IN expressions "
+        "are now rendered using "
+        'the "expanding parameter" strategy which renders a set of bound'
+        'expressions, or an "empty set" SELECT, at statement execution'
+        "time.",
+    ),
 )
 def create_engine(url, **kwargs):
     """Create a new :class:`.Engine` instance.
@@ -130,23 +139,8 @@ def create_engine(url, **kwargs):
             logging.
 
 
-    :param empty_in_strategy:  The SQL compilation strategy to use when
-        rendering an IN or NOT IN expression for :meth:`.ColumnOperators.in_`
-        where the right-hand side
-        is an empty set.   This is a string value that may be one of
-        ``static``, ``dynamic``, or ``dynamic_warn``.   The ``static``
-        strategy is the default, and an IN comparison to an empty set
-        will generate a simple false expression "1 != 1".   The ``dynamic``
-        strategy behaves like that of SQLAlchemy 1.1 and earlier, emitting
-        a false expression of the form "expr != expr", which has the effect
-        of evaluting to NULL in the case of a null expression.
-        ``dynamic_warn`` is the same as ``dynamic``, however also emits a
-        warning when an empty set is encountered; this because the "dynamic"
-        comparison is typically poorly performing on most databases.
-
-        .. versionadded:: 1.2  Added the ``empty_in_strategy`` setting and
-           additionally defaulted the behavior for empty-set IN comparisons
-           to a static boolean expression.
+    :param empty_in_strategy:   No longer used; SQLAlchemy now uses
+        "empty set" behavior for IN in all cases.
 
     :param encoding: Defaults to ``utf-8``.  This is the string
         encoding used by SQLAlchemy for string encode/decode
@@ -411,6 +405,8 @@ def create_engine(url, **kwargs):
             return create_mock_engine(url, **kwargs)
         else:
             raise exc.ArgumentError("unknown strategy: %r" % strat)
+
+    kwargs.pop("empty_in_strategy", None)
 
     # create url.URL object
     u = _url.make_url(url)

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -773,6 +773,8 @@ class DefaultExecutionContext(interfaces.ExecutionContext):
         processors = compiled._bind_processors
 
         if compiled.literal_execute_params:
+            # copy processors for this case as they will be mutated
+            processors = dict(processors)
             positiontup = self._literal_execute_parameters(
                 compiled, processors
             )

--- a/lib/sqlalchemy/orm/events.py
+++ b/lib/sqlalchemy/orm/events.py
@@ -350,14 +350,27 @@ class InstanceEvents(event.Events):
         """
 
     def refresh_flush(self, target, flush_context, attrs):
-        """Receive an object instance after one or more attributes have
-        been refreshed within the persistence of the object.
+        """Receive an object instance after one or more attributes that
+        contain a column-level default or onupdate handler have been refreshed
+        during persistence of the object's state.
 
         This event is the same as :meth:`.InstanceEvents.refresh` except
-        it is invoked within the unit of work flush process, and the values
-        here typically come from the process of handling an INSERT or
-        UPDATE, such as via the RETURNING clause or from Python-side default
-        values.
+        it is invoked within the unit of work flush process, and includes
+        only non-primary-key columns that have column level default or
+        onupdate handlers, including Python callables as well as server side
+        defaults and triggers which may be fetched via the RETURNING clause.
+
+        .. note::
+
+            While the :meth:`.InstanceEvents.refresh_flush` event is triggered
+            for an object that was INSERTed as well as for an object that was
+            UPDATEd, the event is geared primarily  towards the UPDATE process;
+            it is mostly an internal artifact that INSERT actions can also
+            trigger this event, and note that **primary key columns for an
+            INSERTed row are explicitly omitted** from this event.  In order to
+            intercept the newly INSERTed state of an object, the
+            :meth:`.SessionEvents.pending_to_persistent` and
+            :meth:`.MapperEvents.after_insert` are better choices.
 
         .. versionadded:: 1.0.5
 
@@ -369,6 +382,12 @@ class InstanceEvents(event.Events):
          which handles the details of the flush.
         :param attrs: sequence of attribute names which
          were populated.
+
+        .. seealso::
+
+            :ref:`orm_server_defaults`
+
+            :ref:`metadata_defaults_toplevel`
 
         """
 

--- a/lib/sqlalchemy/orm/interfaces.py
+++ b/lib/sqlalchemy/orm/interfaces.py
@@ -525,9 +525,7 @@ class StrategizedProperty(MapperProperty):
     def _get_context_loader(self, context, path):
         load = None
 
-        # use EntityRegistry.__getitem__()->PropRegistry here so
-        # that the path is stated in terms of our base
-        search_path = dict.__getitem__(path, self)
+        search_path = path[self]
 
         # search among: exact match, "attr.*", "default" strategy
         # if any.

--- a/lib/sqlalchemy/orm/mapper.py
+++ b/lib/sqlalchemy/orm/mapper.py
@@ -2807,9 +2807,6 @@ class Mapper(sql_base.HasCacheKey, InspectionAttr):
         if self.base_mapper.local_table in tables:
             return None
 
-        class ColumnsNotAvailable(Exception):
-            pass
-
         def visit_binary(binary):
             leftcol = binary.left
             rightcol = binary.right
@@ -2824,7 +2821,7 @@ class Mapper(sql_base.HasCacheKey, InspectionAttr):
                     passive=attributes.PASSIVE_NO_INITIALIZE,
                 )
                 if leftval in orm_util._none_set:
-                    raise ColumnsNotAvailable()
+                    raise _OptGetColumnsNotAvailable()
                 binary.left = sql.bindparam(
                     None, leftval, type_=binary.right.type
                 )
@@ -2836,7 +2833,7 @@ class Mapper(sql_base.HasCacheKey, InspectionAttr):
                     passive=attributes.PASSIVE_NO_INITIALIZE,
                 )
                 if rightval in orm_util._none_set:
-                    raise ColumnsNotAvailable()
+                    raise _OptGetColumnsNotAvailable()
                 binary.right = sql.bindparam(
                     None, rightval, type_=binary.right.type
                 )
@@ -2860,7 +2857,7 @@ class Mapper(sql_base.HasCacheKey, InspectionAttr):
                             {"binary": visit_binary},
                         )
                     )
-        except ColumnsNotAvailable:
+        except _OptGetColumnsNotAvailable:
             return None
 
         cond = sql.and_(*allconds)
@@ -3126,6 +3123,10 @@ class Mapper(sql_base.HasCacheKey, InspectionAttr):
                     result[table].append((m, m._inherits_equated_pairs))
 
         return result
+
+
+class _OptGetColumnsNotAvailable(Exception):
+    pass
 
 
 def configure_mappers():

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -3479,6 +3479,7 @@ class Query(Generative):
             kwargs.get("limit") is not None
             or kwargs.get("offset") is not None
             or kwargs.get("distinct", False)
+            or kwargs.get("group_by", False)
         )
 
     def exists(self):

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -2235,7 +2235,7 @@ class Query(Generative):
         while "prev" in jp:
             f, prev = jp["prev"]
             prev = prev.copy()
-            prev[f] = jp
+            prev[f] = jp.copy()
             jp["prev"] = (f, prev)
             jp = prev
         self._joinpath = jp

--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -1044,6 +1044,7 @@ class RelationshipProperty(StrategizedProperty):
                 source_selectable=adapt_from,
                 source_polymorphic=True,
                 of_type_mapper=of_type_mapper,
+                alias_secondary=True,
             )
             if sj is not None:
                 return pj & sj
@@ -2215,12 +2216,18 @@ class RelationshipProperty(StrategizedProperty):
         dest_polymorphic=False,
         dest_selectable=None,
         of_type_mapper=None,
+        alias_secondary=False,
     ):
+
+        aliased = False
+
+        if alias_secondary and self.secondary is not None:
+            aliased = True
+
         if source_selectable is None:
             if source_polymorphic and self.parent.with_polymorphic:
                 source_selectable = self.parent._with_polymorphic_selectable
 
-        aliased = False
         if dest_selectable is None:
             dest_selectable = self.entity.selectable
             if dest_polymorphic and self.mapper.with_polymorphic:
@@ -2229,13 +2236,20 @@ class RelationshipProperty(StrategizedProperty):
             if self._is_self_referential and source_selectable is None:
                 dest_selectable = dest_selectable._anonymous_fromclause()
                 aliased = True
-        else:
+        elif dest_selectable is not self.mapper._with_polymorphic_selectable:
             aliased = True
 
         dest_mapper = of_type_mapper or self.mapper
 
         single_crit = dest_mapper._single_table_criterion
-        aliased = aliased or (source_selectable is not None)
+        aliased = aliased or (
+            source_selectable is not None
+            and (
+                source_selectable
+                is not self.parent._with_polymorphic_selectable
+                or source_selectable._is_subquery
+            )
+        )
 
         (
             primaryjoin,

--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -2283,6 +2283,7 @@ def _annotate_columns(element, annotations):
 
     if element is not None:
         element = clone(element)
+    clone = None  # remove gc cycles
     return element
 
 

--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -1070,11 +1070,11 @@ class SubqueryLoader(PostLoader):
 
         # build up a path indicating the path from the leftmost
         # entity to the thing we're subquery loading.
-        with_poly_info = path.get(
+        with_poly_entity = path.get(
             context.attributes, "path_with_polymorphic", None
         )
-        if with_poly_info is not None:
-            effective_entity = with_poly_info.entity
+        if with_poly_entity is not None:
+            effective_entity = with_poly_entity
         else:
             effective_entity = self.entity
 
@@ -1571,11 +1571,13 @@ class JoinedLoader(AbstractRelationshipLoader):
                 chained_from_outerjoin,
             )
 
-        with_poly_info = path.get(
+        with_poly_entity = path.get(
             context.attributes, "path_with_polymorphic", None
         )
-        if with_poly_info is not None:
-            with_polymorphic = with_poly_info.with_polymorphic_mappers
+        if with_poly_entity is not None:
+            with_polymorphic = inspect(
+                with_poly_entity
+            ).with_polymorphic_mappers
         else:
             with_polymorphic = None
 
@@ -1593,7 +1595,7 @@ class JoinedLoader(AbstractRelationshipLoader):
             chained_from_outerjoin=chained_from_outerjoin,
         )
 
-        if with_poly_info is not None and None in set(
+        if with_poly_entity is not None and None in set(
             context.secondary_columns
         ):
             raise sa_exc.InvalidRequestError(
@@ -1622,7 +1624,6 @@ class JoinedLoader(AbstractRelationshipLoader):
 
         # otherwise figure it out.
         alias = loadopt.local_opts["eager_from_alias"]
-
         root_mapper, prop = path[-2:]
 
         if alias is not None:
@@ -1633,11 +1634,11 @@ class JoinedLoader(AbstractRelationshipLoader):
             )
         else:
             if path.contains(context.attributes, "path_with_polymorphic"):
-                with_poly_info = path.get(
+                with_poly_entity = path.get(
                     context.attributes, "path_with_polymorphic"
                 )
                 adapter = orm_util.ORMAdapter(
-                    with_poly_info.entity,
+                    with_poly_entity,
                     equivalents=prop.mapper._equivalent_columns,
                 )
             else:
@@ -1721,11 +1722,11 @@ class JoinedLoader(AbstractRelationshipLoader):
         parentmapper,
         chained_from_outerjoin,
     ):
-        with_poly_info = path.get(
+        with_poly_entity = path.get(
             context.attributes, "path_with_polymorphic", None
         )
-        if with_poly_info:
-            to_adapt = with_poly_info.entity
+        if with_poly_entity:
+            to_adapt = with_poly_entity
         else:
             to_adapt = self._gen_pooled_aliased_class(context)
 
@@ -2284,12 +2285,12 @@ class SelectInLoader(PostLoader, util.MemoizedSlots):
 
         # build up a path indicating the path from the leftmost
         # entity to the thing we're subquery loading.
-        with_poly_info = path_w_prop.get(
+        with_poly_entity = path_w_prop.get(
             context.attributes, "path_with_polymorphic", None
         )
 
-        if with_poly_info is not None:
-            effective_entity = with_poly_info.entity
+        if with_poly_entity is not None:
+            effective_entity = with_poly_entity
         else:
             effective_entity = self.entity
 

--- a/lib/sqlalchemy/orm/util.py
+++ b/lib/sqlalchemy/orm/util.py
@@ -8,6 +8,7 @@
 
 import re
 import types
+import weakref
 
 from . import attributes  # noqa
 from .base import _class_to_mapper  # noqa
@@ -583,14 +584,14 @@ class AliasedInsp(sql_base.HasCacheKey, InspectionAttr):
         adapt_on_names,
         represents_outer_join,
     ):
-        self.entity = entity
+        self._weak_entity = weakref.ref(entity)
         self.mapper = mapper
         self.selectable = (
             self.persist_selectable
         ) = self.local_table = selectable
         self.name = name
         self.polymorphic_on = polymorphic_on
-        self._base_alias = _base_alias or self
+        self._base_alias = weakref.ref(_base_alias or self)
         self._use_mapper_path = _use_mapper_path
         self.represents_outer_join = represents_outer_join
 
@@ -625,6 +626,10 @@ class AliasedInsp(sql_base.HasCacheKey, InspectionAttr):
         self._adapt_on_names = adapt_on_names
         self._target = mapper.class_
 
+    @property
+    def entity(self):
+        return self._weak_entity()
+
     is_aliased_class = True
     "always returns True"
 
@@ -643,7 +648,7 @@ class AliasedInsp(sql_base.HasCacheKey, InspectionAttr):
         :class:`.AliasedInsp`."""
         return self.mapper.class_
 
-    @util.memoized_property
+    @property
     def _path_registry(self):
         if self._use_mapper_path:
             return self.mapper._path_registry
@@ -659,7 +664,7 @@ class AliasedInsp(sql_base.HasCacheKey, InspectionAttr):
             "adapt_on_names": self._adapt_on_names,
             "with_polymorphic_mappers": self.with_polymorphic_mappers,
             "with_polymorphic_discriminator": self.polymorphic_on,
-            "base_alias": self._base_alias,
+            "base_alias": self._base_alias(),
             "use_mapper_path": self._use_mapper_path,
             "represents_outer_join": self.represents_outer_join,
         }
@@ -1241,7 +1246,7 @@ def _entity_corresponds_to(given, entity):
     """
     if entity.is_aliased_class:
         if given.is_aliased_class:
-            if entity._base_alias is given._base_alias:
+            if entity._base_alias() is given._base_alias():
                 return True
         return False
     elif given.is_aliased_class:

--- a/lib/sqlalchemy/orm/util.py
+++ b/lib/sqlalchemy/orm/util.py
@@ -1035,6 +1035,7 @@ class _ORMJoin(expression.Join):
                 source_polymorphic=True,
                 dest_polymorphic=True,
                 of_type_mapper=right_info.mapper,
+                alias_secondary=True,
             )
 
             if sj is not None:

--- a/lib/sqlalchemy/pool/base.py
+++ b/lib/sqlalchemy/pool/base.py
@@ -511,6 +511,19 @@ class _ConnectionRecord(object):
 
     def get_connection(self):
         recycle = False
+
+        # NOTE: the various comparisons here are assuming that measurable time
+        # passes between these state changes.  however, time.time() is not
+        # guaranteed to have sub-second precision.  comparisons of
+        # "invalidation time" to "starttime" should perhaps use >= so that the
+        # state change can take place assuming no measurable  time has passed,
+        # however this does not guarantee correct behavior here as if time
+        # continues to not pass, it will try to reconnect repeatedly until
+        # these timestamps diverge, so in that sense using > is safer.  Per
+        # https://stackoverflow.com/a/1938096/34549, Windows time.time() may be
+        # within 16 milliseconds accuracy, so unit tests for connection
+        # invalidation need a sleep of at least this long between initial start
+        # time and invalidation for the logic below to work reliably.
         if self.connection is None:
             self.info.clear()
             self.__connect()

--- a/lib/sqlalchemy/sql/annotation.py
+++ b/lib/sqlalchemy/sql/annotation.py
@@ -247,6 +247,7 @@ def _deep_annotate(element, annotations, exclude=None):
 
     if element is not None:
         element = clone(element)
+    clone = None  # remove gc cycles
     return element
 
 
@@ -271,6 +272,7 @@ def _deep_deannotate(element, values=None):
 
     if element is not None:
         element = clone(element)
+    clone = None  # remove gc cycles
     return element
 
 

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -1851,7 +1851,8 @@ class SQLCompiler(Compiled):
                     kwargs["positional_names"] = self.cte_positional[cte] = []
 
                 assert kwargs.get("subquery", False) is False
-                text += " AS \n(%s)" % (
+                text += " AS %s\n(%s)" % (
+                    self._generate_prefixes(cte, cte._prefixes, **kwargs),
                     cte.element._compiler_dispatch(
                         self, asfrom=True, **kwargs
                     ),

--- a/lib/sqlalchemy/sql/dml.py
+++ b/lib/sqlalchemy/sql/dml.py
@@ -15,7 +15,6 @@ from .base import _from_objects
 from .base import _generative
 from .base import DialectKWArgs
 from .base import Executable
-from .elements import _clone
 from .elements import and_
 from .elements import ClauseElement
 from .elements import Null
@@ -203,6 +202,9 @@ class UpdateBase(
             selectable = self.table
 
         self._hints = self._hints.union({(selectable, dialect_name): text})
+
+    def _copy_internals(self, **kw):
+        raise NotImplementedError()
 
 
 class ValuesBase(UpdateBase):
@@ -623,12 +625,6 @@ class Insert(ValuesBase):
         self.include_insert_from_select_defaults = include_defaults
         self.select = coercions.expect(roles.DMLSelectRole, select)
 
-    def _copy_internals(self, clone=_clone, **kw):
-        # TODO: coverage
-        self.parameters = self.parameters.copy()
-        if self.select is not None:
-            self.select = _clone(self.select)
-
 
 class Update(ValuesBase):
     """Represent an Update construct.
@@ -785,11 +781,6 @@ class Update(ValuesBase):
         else:
             return ()
 
-    def _copy_internals(self, clone=_clone, **kw):
-        # TODO: coverage
-        self._whereclause = clone(self._whereclause, **kw)
-        self.parameters = self.parameters.copy()
-
     @_generative
     def where(self, whereclause):
         """return a new update() construct with the given expression added to
@@ -921,7 +912,3 @@ class Delete(UpdateBase):
                 seen.update(item._cloned_set)
 
         return froms
-
-    def _copy_internals(self, clone=_clone, **kw):
-        # TODO: coverage
-        self._whereclause = clone(self._whereclause, **kw)

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -255,6 +255,12 @@ class ClauseElement(
         """
         s = util.column_set()
         f = self
+
+        # note this creates a cycle, asserted in test_memusage. however,
+        # turning this into a plain @property adds tends of thousands of method
+        # calls to Core / ORM performance tests, so the small overhead
+        # introduced by the relatively small amount of short term cycles
+        # produced here is preferable
         while f is not None:
             s.add(f)
             f = f._is_clone_of

--- a/lib/sqlalchemy/sql/operators.py
+++ b/lib/sqlalchemy/sql/operators.py
@@ -538,17 +538,15 @@ class ColumnOperators(Operators):
 
             stmt.where(column.in_([]))
 
-          In this calling form, the expression renders a "false" expression,
-          e.g.::
+          In this calling form, the expression renders an "empty set"
+          expression.  These expressions are tailored to individual backends
+          and are generaly trying to get an empty SELECT statement as a
+          subuqery.  Such as on SQLite, the expression is::
 
-            WHERE 1 != 1
+            WHERE col IN (SELECT 1 FROM (SELECT 1) WHERE 1!=1)
 
-          This "false" expression has historically had different behaviors
-          in older SQLAlchemy versions, see
-          :paramref:`.create_engine.empty_in_strategy` for behavioral options.
-
-          .. versionchanged:: 1.2 simplified the behavior of "empty in"
-             expressions
+          .. versionchanged:: 1.4  empty IN expressions now use an
+             execution-time generated SELECT subquery in all cases.
 
         * A bound parameter, e.g. :func:`.bindparam`, may be used if it
           includes the :paramref:`.bindparam.expanding` flag::
@@ -1341,16 +1339,6 @@ def comma_op(a, b):
     raise NotImplementedError()
 
 
-@comparison_op
-def empty_in_op(a, b):
-    raise NotImplementedError()
-
-
-@comparison_op
-def empty_notin_op(a, b):
-    raise NotImplementedError()
-
-
 def filter_op(a, b):
     raise NotImplementedError()
 
@@ -1473,8 +1461,6 @@ _PRECEDENCE = {
     ne: 5,
     is_distinct_from: 5,
     isnot_distinct_from: 5,
-    empty_in_op: 5,
-    empty_notin_op: 5,
     gt: 5,
     lt: 5,
     ge: 5,

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -3695,10 +3695,10 @@ class Select(
             clone(f, **kw) for f in self._from_obj
         ).union(f for f in new_froms.values() if isinstance(f, Join))
 
-        self._correlate = set(clone(f) for f in self._correlate)
+        self._correlate = set(clone(f, **kw) for f in self._correlate)
         if self._correlate_except:
             self._correlate_except = set(
-                clone(f) for f in self._correlate_except
+                clone(f, **kw) for f in self._correlate_except
             )
 
         # 4. clone other things.   The difficulty here is that Column

--- a/lib/sqlalchemy/sql/traversals.py
+++ b/lib/sqlalchemy/sql/traversals.py
@@ -743,6 +743,14 @@ class TraversalComparatorStrategy(InternalTraversal, util.MemoizedSlots):
         else:
             return COMPARE_FAILED
 
+    def compare_bindparam(self, left, right, **kw):
+        compare_values = kw.pop("compare_values", True)
+        if compare_values:
+            return []
+        else:
+            # this means, "skip these, we already compared"
+            return ["callable", "value"]
+
 
 class ColIdentityComparatorStrategy(TraversalComparatorStrategy):
     def compare_column_element(

--- a/lib/sqlalchemy/sql/traversals.py
+++ b/lib/sqlalchemy/sql/traversals.py
@@ -29,6 +29,8 @@ def compare(obj1, obj2, **kw):
 class HasCacheKey(object):
     _cache_key_traversal = NO_CACHE
 
+    __slots__ = ()
+
     def _gen_cache_key(self, anon_map, bindparams):
         """return an optional cache key.
 

--- a/lib/sqlalchemy/sql/util.py
+++ b/lib/sqlalchemy/sql/util.py
@@ -226,6 +226,7 @@ def visit_binary_product(fn, expr):
                     yield e
 
     list(visit(expr))
+    visit = None  # remove gc cycles
 
 
 def find_tables(
@@ -881,7 +882,7 @@ class ColumnAdapter(ClauseAdapter):
             anonymize_labels=anonymize_labels,
         )
 
-        self.columns = util.populate_column_dict(self._locate_col)
+        self.columns = util.WeakPopulateDict(self._locate_col)
         if self.include_fn or self.exclude_fn:
             self.columns = self._IncludeExcludeMapping(self, self.columns)
         self.adapt_required = adapt_required
@@ -907,7 +908,7 @@ class ColumnAdapter(ClauseAdapter):
         ac = self.__class__.__new__(self.__class__)
         ac.__dict__.update(self.__dict__)
         ac._wrap = adapter
-        ac.columns = util.populate_column_dict(ac._locate_col)
+        ac.columns = util.WeakPopulateDict(ac._locate_col)
         if ac.include_fn or ac.exclude_fn:
             ac.columns = self._IncludeExcludeMapping(ac, ac.columns)
 
@@ -942,4 +943,4 @@ class ColumnAdapter(ClauseAdapter):
 
     def __setstate__(self, state):
         self.__dict__.update(state)
-        self.columns = util.PopulateDict(self._locate_col)
+        self.columns = util.WeakPopulateDict(self._locate_col)

--- a/lib/sqlalchemy/sql/visitors.py
+++ b/lib/sqlalchemy/sql/visitors.py
@@ -722,7 +722,7 @@ def cloned_traverse(obj, opts, visitors):
                         return newelem
 
                 cloned[id(elem)] = newelem = elem._clone()
-                newelem._copy_internals(clone=clone)
+                newelem._copy_internals(clone=clone, **kw)
                 meth = visitors.get(newelem.__visit_name__, None)
                 if meth:
                     meth(newelem)
@@ -730,6 +730,7 @@ def cloned_traverse(obj, opts, visitors):
 
     if obj is not None:
         obj = clone(obj)
+    clone = None  # remove gc cycles
     return obj
 
 
@@ -786,4 +787,5 @@ def replacement_traverse(obj, opts, replace):
 
     if obj is not None:
         obj = clone(obj, **opts)
+    clone = None  # remove gc cycles
     return obj

--- a/lib/sqlalchemy/testing/assertions.py
+++ b/lib/sqlalchemy/testing/assertions.py
@@ -340,12 +340,15 @@ class AssertsCompiledSQL(object):
         result,
         params=None,
         checkparams=None,
+        check_literal_execute=None,
+        check_post_param=None,
         dialect=None,
         checkpositional=None,
         check_prefetch=None,
         use_default_dialect=False,
         allow_dialect_select=False,
         literal_binds=False,
+        render_postcompile=False,
         schema_translate_map=None,
     ):
         if use_default_dialect:
@@ -376,6 +379,9 @@ class AssertsCompiledSQL(object):
 
         if literal_binds:
             compile_kwargs["literal_binds"] = True
+
+        if render_postcompile:
+            compile_kwargs["render_postcompile"] = True
 
         if isinstance(clause, orm.Query):
             context = clause._compile_context()
@@ -418,6 +424,22 @@ class AssertsCompiledSQL(object):
             eq_(tuple([p[x] for x in c.positiontup]), checkpositional)
         if check_prefetch is not None:
             eq_(c.prefetch, check_prefetch)
+        if check_literal_execute is not None:
+            eq_(
+                {
+                    c.bind_names[b]: b.effective_value
+                    for b in c.literal_execute_params
+                },
+                check_literal_execute,
+            )
+        if check_post_param is not None:
+            eq_(
+                {
+                    c.bind_names[b]: b.effective_value
+                    for b in c.post_compile_params
+                },
+                check_post_param,
+            )
 
 
 class ComparesTables(object):

--- a/lib/sqlalchemy/testing/profiling.py
+++ b/lib/sqlalchemy/testing/profiling.py
@@ -221,7 +221,7 @@ class ProfileStatsFile(object):
         profile_f.close()
 
 
-def function_call_count(variance=0.05):
+def function_call_count(variance=0.05, times=1):
     """Assert a target for a test case's function call count.
 
     The main purpose of this assertion is to detect changes in
@@ -234,8 +234,11 @@ def function_call_count(variance=0.05):
 
     def decorate(fn):
         def wrap(*args, **kw):
+            timerange = range(times)
             with count_functions(variance=variance):
-                return fn(*args, **kw)
+                for time in timerange:
+                    rv = fn(*args, **kw)
+                return rv
 
         return update_wrapper(wrap, fn)
 

--- a/lib/sqlalchemy/testing/util.py
+++ b/lib/sqlalchemy/testing/util.py
@@ -66,6 +66,21 @@ def picklers():
             yield pickle_.loads, lambda d: pickle_.dumps(d, protocol)
 
 
+if py2k:
+
+    def random_choices(population, k=1):
+        pop = list(population)
+        # lame but works :)
+        random.shuffle(pop)
+        return pop[0:k]
+
+
+else:
+
+    def random_choices(population, k=1):
+        return random.choices(population, k=k)
+
+
 def round_decimal(value, prec):
     if isinstance(value, float):
         return round(value, prec)

--- a/lib/sqlalchemy/util/__init__.py
+++ b/lib/sqlalchemy/util/__init__.py
@@ -31,7 +31,6 @@ from ._collections import OrderedDict  # noqa
 from ._collections import OrderedIdentitySet  # noqa
 from ._collections import OrderedProperties  # noqa
 from ._collections import OrderedSet  # noqa
-from ._collections import populate_column_dict  # noqa
 from ._collections import PopulateDict  # noqa
 from ._collections import Properties  # noqa
 from ._collections import ScopedRegistry  # noqa
@@ -42,6 +41,7 @@ from ._collections import to_set  # noqa
 from ._collections import unique_list  # noqa
 from ._collections import UniqueAppender  # noqa
 from ._collections import update_copy  # noqa
+from ._collections import WeakPopulateDict  # noqa
 from ._collections import WeakSequence  # noqa
 from .compat import b  # noqa
 from .compat import b64decode  # noqa

--- a/lib/sqlalchemy/util/_collections.py
+++ b/lib/sqlalchemy/util/_collections.py
@@ -676,15 +676,17 @@ class IdentitySet(object):
 
 class WeakSequence(object):
     def __init__(self, __elements=()):
+        def _remove(item, selfref=weakref.ref(self)):
+            self = selfref()
+            if self is not None:
+                self._storage.remove(item)
+        self._remove = _remove
         self._storage = [
-            weakref.ref(element, self._remove) for element in __elements
+            weakref.ref(element, _remove) for element in __elements
         ]
 
     def append(self, item):
         self._storage.append(weakref.ref(item, self._remove))
-
-    def _remove(self, ref):
-        self._storage.remove(ref)
 
     def __len__(self):
         return len(self._storage)

--- a/test/aaa_profiling/test_memusage.py
+++ b/test/aaa_profiling/test_memusage.py
@@ -6,6 +6,7 @@ import weakref
 
 import sqlalchemy as sa
 from sqlalchemy import ForeignKey
+from sqlalchemy import inspect
 from sqlalchemy import Integer
 from sqlalchemy import MetaData
 from sqlalchemy import select
@@ -15,9 +16,14 @@ from sqlalchemy import Unicode
 from sqlalchemy import util
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm import clear_mappers
+from sqlalchemy.orm import configure_mappers
 from sqlalchemy.orm import create_session
+from sqlalchemy.orm import join as orm_join
+from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import Load
 from sqlalchemy.orm import mapper
 from sqlalchemy.orm import relationship
+from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm import subqueryload
@@ -26,12 +32,16 @@ from sqlalchemy.orm.session import _sessions
 from sqlalchemy.processors import to_decimal_processor_factory
 from sqlalchemy.processors import to_unicode_processor_factory
 from sqlalchemy.sql import column
+from sqlalchemy.sql import util as sql_util
+from sqlalchemy.sql.visitors import cloned_traverse
+from sqlalchemy.sql.visitors import replacement_traverse
 from sqlalchemy.testing import engines
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing.schema import Column
 from sqlalchemy.testing.schema import Table
 from sqlalchemy.testing.util import gc_collect
+from ..orm import _fixtures
 
 
 class A(fixtures.ComparableEntity):
@@ -44,6 +54,28 @@ class B(fixtures.ComparableEntity):
 
 class ASub(A):
     pass
+
+
+def assert_cycles(expected=0):
+    def decorate(fn):
+        def go():
+            fn()  # warmup, configure mappers, caches, etc.
+
+            gc_collect()
+            gc_collect()
+            gc_collect()  # multiple calls seem to matter
+
+            # gc.set_debug(gc.DEBUG_COLLECTABLE)
+            try:
+                return fn()  # run for real
+            finally:
+                unreachable = gc_collect()
+                assert unreachable <= expected
+                gc_collect()
+
+        return go
+
+    return decorate
 
 
 def profile_memory(
@@ -1066,3 +1098,362 @@ class MemUsageWBackendTest(EnsureZeroed):
             go()
         finally:
             metadata.drop_all()
+
+
+class CycleTest(_fixtures.FixtureTest):
+    __tags__ = ("memory_intensive",)
+    __requires__ = ("cpython", "no_windows")
+
+    run_setup_mappers = "once"
+    run_inserts = "once"
+    run_deletes = None
+
+    @classmethod
+    def setup_mappers(cls):
+        cls._setup_stock_mapping()
+
+    def test_query(self):
+        User, Address = self.classes("User", "Address")
+        configure_mappers()
+
+        s = Session()
+
+        @assert_cycles()
+        def go():
+            return s.query(User).all()
+
+        go()
+
+    def test_query_alias(self):
+        User, Address = self.classes("User", "Address")
+        configure_mappers()
+
+        s = Session()
+
+        u1 = aliased(User)
+
+        @assert_cycles()
+        def go():
+            s.query(u1).all()
+
+        go()
+
+    def test_entity_path_w_aliased(self):
+        User, Address = self.classes("User", "Address")
+        configure_mappers()
+
+        @assert_cycles()
+        def go():
+            u1 = aliased(User)
+            inspect(u1)._path_registry[User.addresses.property]
+
+        go()
+
+    def test_orm_objects_from_query(self):
+        User, Address = self.classes("User", "Address")
+        configure_mappers()
+
+        s = Session()
+
+        def generate():
+            objects = s.query(User).filter(User.id == 7).all()
+            gc_collect()
+            return objects
+
+        @assert_cycles()
+        def go():
+            generate()
+
+        go()
+
+    def test_orm_objects_from_query_w_selectinload(self):
+        User, Address = self.classes("User", "Address")
+
+        s = Session()
+
+        def generate():
+            objects = s.query(User).options(selectinload(User.addresses)).all()
+            gc_collect()
+            return objects
+
+        @assert_cycles()
+        def go():
+            generate()
+
+        go()
+
+    def test_selectinload_option_unbound(self):
+        User, Address = self.classes("User", "Address")
+
+        @assert_cycles()
+        def go():
+            selectinload(User.addresses)
+
+        go()
+
+    def test_selectinload_option_bound(self):
+        User, Address = self.classes("User", "Address")
+
+        @assert_cycles()
+        def go():
+            Load(User).selectinload(User.addresses)
+
+        go()
+
+    def test_orm_path(self):
+        User, Address = self.classes("User", "Address")
+
+        @assert_cycles()
+        def go():
+            inspect(User)._path_registry[User.addresses.property][
+                inspect(Address)
+            ]
+
+        go()
+
+    def test_joinedload_option_unbound(self):
+        User, Address = self.classes("User", "Address")
+
+        @assert_cycles()
+        def go():
+            joinedload(User.addresses)
+
+        go()
+
+    def test_joinedload_option_bound(self):
+        User, Address = self.classes("User", "Address")
+
+        @assert_cycles()
+        def go():
+            l1 = Load(User).joinedload(User.addresses)
+            l1._generate_cache_key()
+
+        go()
+
+    def test_orm_objects_from_query_w_joinedload(self):
+        User, Address = self.classes("User", "Address")
+
+        s = Session()
+
+        def generate():
+            objects = s.query(User).options(joinedload(User.addresses)).all()
+            gc_collect()
+            return objects
+
+        @assert_cycles()
+        def go():
+            generate()
+
+        go()
+
+    def test_query_filtered(self):
+        User, Address = self.classes("User", "Address")
+
+        s = Session()
+
+        @assert_cycles()
+        def go():
+            return s.query(User).filter(User.id == 7).all()
+
+        go()
+
+    def test_query_joins(self):
+        User, Address = self.classes("User", "Address")
+
+        s = Session()
+
+        # cycles here are due to ClauseElement._cloned_set
+        @assert_cycles(3)
+        def go():
+            s.query(User).join(User.addresses).all()
+
+        go()
+
+    def test_plain_join(self):
+        users, addresses = self.tables("users", "addresses")
+
+        @assert_cycles()
+        def go():
+            str(users.join(addresses))
+
+        go()
+
+    def test_plain_join_select(self):
+        users, addresses = self.tables("users", "addresses")
+
+        # cycles here are due to ClauseElement._cloned_set
+        @assert_cycles(6)
+        def go():
+            s = select([users]).select_from(users.join(addresses))
+            s._froms
+
+        go()
+
+    def test_orm_join(self):
+        User, Address = self.classes("User", "Address")
+
+        @assert_cycles()
+        def go():
+            str(orm_join(User, Address, User.addresses))
+
+        go()
+
+    def test_join_via_query_relationship(self):
+        User, Address = self.classes("User", "Address")
+        configure_mappers()
+
+        s = Session()
+
+        @assert_cycles()
+        def go():
+            s.query(User).join(User.addresses)
+
+        go()
+
+    def test_join_via_query_to_entity(self):
+        User, Address = self.classes("User", "Address")
+        configure_mappers()
+
+        s = Session()
+
+        @assert_cycles()
+        def go():
+            s.query(User).join(Address)
+
+        go()
+
+    def test_core_select(self):
+        User, Address = self.classes("User", "Address")
+        configure_mappers()
+
+        s = Session()
+
+        stmt = s.query(User).join(User.addresses).statement
+
+        @assert_cycles()
+        def go():
+            s.execute(stmt)
+
+        go()
+
+    def test_adapt_statement_replacement_traversal(self):
+        User, Address = self.classes("User", "Address")
+
+        statement = select([User]).select_from(
+            orm_join(User, Address, User.addresses)
+        )
+
+        @assert_cycles()
+        def go():
+            replacement_traverse(statement, {}, lambda x: None)
+
+        go()
+
+    def test_adapt_statement_cloned_traversal(self):
+        User, Address = self.classes("User", "Address")
+
+        statement = select([User]).select_from(
+            orm_join(User, Address, User.addresses)
+        )
+
+        @assert_cycles()
+        def go():
+            cloned_traverse(statement, {}, {})
+
+        go()
+
+    def test_column_adapter_lookup(self):
+        User, Address = self.classes("User", "Address")
+
+        u1 = aliased(User)
+
+        @assert_cycles()
+        def go():
+            adapter = sql_util.ColumnAdapter(inspect(u1).selectable)
+            adapter.columns[User.id]
+
+        go()
+
+    def test_orm_aliased(self):
+        User, Address = self.classes("User", "Address")
+
+        @assert_cycles()
+        def go():
+            u1 = aliased(User)
+            inspect(u1)
+
+        go()
+
+    @testing.fails
+    def test_the_counter(self):
+        @assert_cycles()
+        def go():
+            x = []
+            x.append(x)
+
+        go()
+
+    def test_weak_sequence(self):
+        class Foo(object):
+            pass
+
+        f = Foo()
+
+        @assert_cycles()
+        def go():
+            util.WeakSequence([f])
+
+        go()
+
+    @testing.provide_metadata
+    def test_optimized_get(self):
+
+        from sqlalchemy.ext.declarative import declarative_base
+
+        Base = declarative_base(metadata=self.metadata)
+
+        class Employee(Base):
+            __tablename__ = "employee"
+            id = Column(
+                Integer, primary_key=True, test_needs_autoincrement=True
+            )
+            type = Column(String(10))
+            __mapper_args__ = {"polymorphic_on": type}
+
+        class Engineer(Employee):
+            __tablename__ = " engineer"
+            id = Column(ForeignKey("employee.id"), primary_key=True)
+
+            engineer_name = Column(String(50))
+            __mapper_args__ = {"polymorphic_identity": "engineer"}
+
+        Base.metadata.create_all(testing.db)
+
+        s = Session(testing.db)
+        s.add(Engineer(engineer_name="wally"))
+        s.commit()
+        s.close()
+
+        @assert_cycles()
+        def go():
+            e1 = s.query(Employee).first()
+            e1.engineer_name
+
+        go()
+
+    def test_visit_binary_product(self):
+        a, b, q, e, f, j, r = [column(chr_) for chr_ in "abqefjr"]
+
+        from sqlalchemy import and_, func
+        from sqlalchemy.sql.util import visit_binary_product
+
+        expr = and_((a + b) == q + func.sum(e + f), j == r)
+
+        def visit(expr, left, right):
+            pass
+
+        @assert_cycles()
+        def go():
+            visit_binary_product(visit, expr)
+
+        go()

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -188,19 +188,6 @@ class WeakSequenceTest(fixtures.TestBase):
         eq_(len(w), 2)
         eq_(len(w._storage), 2)
 
-    @testing.requires.predictable_gc
-    def test_cleanout_container(self):
-        import weakref
-
-        class Foo(object):
-            pass
-
-        f = Foo()
-        w = WeakSequence([f])
-        w_wref = weakref.ref(w)
-        del w
-        eq_(w_wref(), None)
-
 
 class OrderedDictTest(fixtures.TestBase):
     def test_odict(self):

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -188,6 +188,19 @@ class WeakSequenceTest(fixtures.TestBase):
         eq_(len(w), 2)
         eq_(len(w._storage), 2)
 
+    @testing.requires.predictable_gc
+    def test_cleanout_container(self):
+        import weakref
+
+        class Foo(object):
+            pass
+
+        f = Foo()
+        w = WeakSequence([f])
+        w_wref = weakref.ref(w)
+        del w
+        eq_(w_wref(), None)
+
 
 class OrderedDictTest(fixtures.TestBase):
     def test_odict(self):

--- a/test/dialect/mssql/test_types.py
+++ b/test/dialect/mssql/test_types.py
@@ -735,7 +735,7 @@ class TypeRoundTripTest(
             11,
             2,
             32,
-            0,
+            123456,
             util.timezone(datetime.timedelta(hours=1)),
         )
         t.insert().execute(

--- a/test/engine/test_deprecations.py
+++ b/test/engine/test_deprecations.py
@@ -59,6 +59,18 @@ class CreateEngineTest(fixtures.TestBase):
                 strategy="threadlocal",
             )
 
+    def test_empty_in_keyword(self):
+        with testing.expect_deprecated(
+            "The create_engine.empty_in_strategy keyword is deprecated, "
+            "and no longer has any effect."
+        ):
+            create_engine(
+                "postgresql://",
+                empty_in_strategy="static",
+                module=Mock(),
+                _initialize=False,
+            )
+
 
 class TransactionTest(fixtures.TestBase):
     __backend__ = True

--- a/test/engine/test_pool.py
+++ b/test/engine/test_pool.py
@@ -1217,11 +1217,16 @@ class QueuePoolTest(PoolTestBase):
         is_(c2.connection, c_ref())
 
         c2_rec = c2._connection_record
+
+        # ensure pool invalidate time will be later than starttime
+        # for ConnectionRecord objects above
+        time.sleep(0.1)
         c2.invalidate(soft=True)
+
         is_(c2_rec.connection, c2.connection)
 
         c2.close()
-        time.sleep(0.5)
+
         c3 = p.connect()
         is_not_(c3.connection, c_ref())
         is_(c3._connection_record, c2_rec)
@@ -1285,6 +1290,7 @@ class QueuePoolTest(PoolTestBase):
         time.sleep(1.5)
         self._assert_cleanup_on_pooled_reconnect(dbapi, p)
 
+    @testing.requires.timing_intensive
     def test_connect_handler_not_called_for_recycled(self):
         """test [ticket:3497]"""
 
@@ -1299,6 +1305,10 @@ class QueuePoolTest(PoolTestBase):
         c2.close()
 
         dbapi.shutdown(True)
+
+        # ensure pool invalidate time will be later than starttime
+        # for ConnectionRecord objects above
+        time.sleep(0.1)
 
         bad = p.connect()
         p._invalidate(bad)
@@ -1323,6 +1333,7 @@ class QueuePoolTest(PoolTestBase):
             [call.connect(ANY, ANY), call.checkout(ANY, ANY, ANY)],
         )
 
+    @testing.requires.timing_intensive
     def test_connect_checkout_handler_always_gets_info(self):
         """test [ticket:3497]"""
 
@@ -1335,6 +1346,10 @@ class QueuePoolTest(PoolTestBase):
         c2.close()
 
         dbapi.shutdown(True)
+
+        # ensure pool invalidate time will be later than starttime
+        # for ConnectionRecord objects above
+        time.sleep(0.1)
 
         bad = p.connect()
         p._invalidate(bad)

--- a/test/ext/declarative/test_mixin.py
+++ b/test/ext/declarative/test_mixin.py
@@ -1399,9 +1399,9 @@ class DeclarativeMixinPropertyTest(
         self.assert_compile(
             s.query(Derived.data_syn).filter(Derived.data_syn == "foo"),
             "SELECT test.data AS test_data FROM test WHERE test.data = "
-            ":data_1 AND test.type IN (:type_1)",
+            ":data_1 AND test.type IN ([POSTCOMPILE_type_1])",
             dialect="default",
-            checkparams={"type_1": "derived", "data_1": "foo"},
+            checkparams={"type_1": ["derived"], "data_1": "foo"},
         )
 
     def test_column_in_mapper_args(self):

--- a/test/ext/test_horizontal_shard.py
+++ b/test/ext/test_horizontal_shard.py
@@ -113,8 +113,8 @@ class ShardTest(object):
                         if binary.operator == operators.eq:
                             ids.append(shard_lookup[binary.right.value])
                         elif binary.operator == operators.in_op:
-                            for bind in binary.right.clauses:
-                                ids.append(shard_lookup[bind.value])
+                            for value in binary.right.value:
+                                ids.append(shard_lookup[value])
 
             if query._criterion is not None:
                 FindContinent().traverse(query._criterion)

--- a/test/ext/test_serializer.py
+++ b/test/ext/test_serializer.py
@@ -243,7 +243,6 @@ class SerializeTest(AssertsCompiledSQL, fixtures.MappedTest):
         j2 = serializer.loads(serializer.dumps(j, -1), users.metadata)
         assert j2.left is j.left
         assert j2.right is j.right
-        assert j2._target_adapter._next
 
     @testing.exclude(
         "sqlite", "<=", (3, 5, 9), "id comparison failing on the buildbot"

--- a/test/orm/inheritance/test_relationship.py
+++ b/test/orm/inheritance/test_relationship.py
@@ -1913,7 +1913,7 @@ class JoinedloadOverWPolyAliased(
             joinedload(cls.links).joinedload(Link.child).joinedload(cls.links)
         )
         if cls is self.classes.Sub1:
-            extra = " WHERE parent.type IN (:type_1)"
+            extra = " WHERE parent.type IN ([POSTCOMPILE_type_1])"
         else:
             extra = ""
 
@@ -1943,7 +1943,7 @@ class JoinedloadOverWPolyAliased(
         )
 
         if Link.child.property.mapper.class_ is self.classes.Sub1:
-            extra = "AND parent_1.type IN (:type_1) "
+            extra = "AND parent_1.type IN ([POSTCOMPILE_type_1]) "
         else:
             extra = ""
 

--- a/test/orm/inheritance/test_single.py
+++ b/test/orm/inheritance/test_single.py
@@ -267,7 +267,7 @@ class SingleInheritanceTest(testing.AssertsCompiledSQL, fixtures.MappedTest):
             "employees.engineer_info AS "
             "employees_engineer_info, employees.type "
             "AS employees_type FROM employees WHERE "
-            "employees.type IN (:type_1, :type_2)) AS "
+            "employees.type IN ([POSTCOMPILE_type_1])) AS "
             "anon_1",
             use_default_dialect=True,
         )
@@ -282,13 +282,13 @@ class SingleInheritanceTest(testing.AssertsCompiledSQL, fixtures.MappedTest):
             sess.query(a1.employee_id).select_from(a1),
             "SELECT employees_1.employee_id AS employees_1_employee_id "
             "FROM employees AS employees_1 WHERE employees_1.type "
-            "IN (:type_1, :type_2)",
+            "IN ([POSTCOMPILE_type_1])",
         )
 
         self.assert_compile(
             sess.query(literal("1")).select_from(a1),
             "SELECT :param_1 AS anon_1 FROM employees AS employees_1 "
-            "WHERE employees_1.type IN (:type_1, :type_2)",
+            "WHERE employees_1.type IN ([POSTCOMPILE_type_1])",
         )
 
     def test_union_modifiers(self):
@@ -311,7 +311,7 @@ class SingleInheritanceTest(testing.AssertsCompiledSQL, fixtures.MappedTest):
             "employees.engineer_info AS employees_engineer_info, "
             "employees.type AS employees_type FROM employees "
             "WHERE employees.engineer_info = :engineer_info_1 "
-            "AND employees.type IN (:type_1, :type_2) "
+            "AND employees.type IN ([POSTCOMPILE_type_1]) "
             "%(token)s "
             "SELECT employees.employee_id AS employees_employee_id, "
             "employees.name AS employees_name, "
@@ -319,7 +319,7 @@ class SingleInheritanceTest(testing.AssertsCompiledSQL, fixtures.MappedTest):
             "employees.engineer_info AS employees_engineer_info, "
             "employees.type AS employees_type FROM employees "
             "WHERE employees.manager_data = :manager_data_1 "
-            "AND employees.type IN (:type_3)) AS anon_1"
+            "AND employees.type IN ([POSTCOMPILE_type_2])) AS anon_1"
         )
 
         for meth, token in [
@@ -334,11 +334,10 @@ class SingleInheritanceTest(testing.AssertsCompiledSQL, fixtures.MappedTest):
                 meth(q2),
                 assert_sql % {"token": token},
                 checkparams={
-                    "manager_data_1": "bar",
-                    "type_2": "juniorengineer",
-                    "type_3": "manager",
                     "engineer_info_1": "foo",
-                    "type_1": "engineer",
+                    "type_1": ["engineer", "juniorengineer"],
+                    "manager_data_1": "bar",
+                    "type_2": ["manager"],
                 },
             )
 
@@ -352,7 +351,7 @@ class SingleInheritanceTest(testing.AssertsCompiledSQL, fixtures.MappedTest):
             "SELECT count(*) AS count_1 "
             "FROM (SELECT employees.employee_id AS employees_employee_id "
             "FROM employees "
-            "WHERE employees.type IN (:type_1, :type_2)) AS anon_1",
+            "WHERE employees.type IN ([POSTCOMPILE_type_1])) AS anon_1",
             use_default_dialect=True,
         )
 
@@ -422,7 +421,7 @@ class SingleInheritanceTest(testing.AssertsCompiledSQL, fixtures.MappedTest):
             ),
             "SELECT EXISTS (SELECT 1 FROM employees WHERE "
             "employees.name = :name_1 AND employees.type "
-            "IN (:type_1, :type_2)) AS anon_1",
+            "IN ([POSTCOMPILE_type_1])) AS anon_1",
         )
 
     def test_type_filtering(self):
@@ -566,7 +565,7 @@ class RelationshipFromSingleTest(
             "employee_stuff_name, anon_1.employee_id "
             "AS anon_1_employee_id FROM (SELECT "
             "employee.id AS employee_id FROM employee "
-            "WHERE employee.type IN (:type_1)) AS anon_1 "
+            "WHERE employee.type IN ([POSTCOMPILE_type_1])) AS anon_1 "
             "JOIN employee_stuff ON anon_1.employee_id "
             "= employee_stuff.employee_id ORDER BY "
             "anon_1.employee_id",
@@ -713,7 +712,7 @@ class RelationshipToSingleTest(
             "companies.name AS companies_name FROM companies "
             "LEFT OUTER JOIN employees AS employees_1 ON "
             "companies.company_id = employees_1.company_id "
-            "AND employees_1.type IN (:type_1)",
+            "AND employees_1.type IN ([POSTCOMPILE_type_1])",
         )
 
     def test_join_explicit_onclause_no_discriminator(self):
@@ -768,7 +767,8 @@ class RelationshipToSingleTest(
             "companies.name AS companies_name, "
             "employees.name AS employees_name "
             "FROM companies LEFT OUTER JOIN employees ON companies.company_id "
-            "= employees.company_id AND employees.type IN (:type_1)",
+            "= employees.company_id "
+            "AND employees.type IN ([POSTCOMPILE_type_1])",
         )
 
     def test_outer_join_prop_alias(self):
@@ -797,7 +797,8 @@ class RelationshipToSingleTest(
             "companies.name AS companies_name, employees_1.name AS "
             "employees_1_name FROM companies LEFT OUTER "
             "JOIN employees AS employees_1 ON companies.company_id "
-            "= employees_1.company_id AND employees_1.type IN (:type_1)",
+            "= employees_1.company_id "
+            "AND employees_1.type IN ([POSTCOMPILE_type_1])",
         )
 
     def test_outer_join_literal_onclause(self):
@@ -831,7 +832,7 @@ class RelationshipToSingleTest(
             "employees.company_id AS employees_company_id FROM companies "
             "LEFT OUTER JOIN employees ON "
             "companies.company_id = employees.company_id "
-            "AND employees.type IN (:type_1)",
+            "AND employees.type IN ([POSTCOMPILE_type_1])",
         )
 
     def test_outer_join_literal_onclause_alias(self):
@@ -866,7 +867,7 @@ class RelationshipToSingleTest(
             "employees_1.company_id AS employees_1_company_id "
             "FROM companies LEFT OUTER JOIN employees AS employees_1 ON "
             "companies.company_id = employees_1.company_id "
-            "AND employees_1.type IN (:type_1)",
+            "AND employees_1.type IN ([POSTCOMPILE_type_1])",
         )
 
     def test_outer_join_no_onclause(self):
@@ -898,7 +899,7 @@ class RelationshipToSingleTest(
             "employees.company_id AS employees_company_id "
             "FROM companies LEFT OUTER JOIN employees ON "
             "companies.company_id = employees.company_id "
-            "AND employees.type IN (:type_1)",
+            "AND employees.type IN ([POSTCOMPILE_type_1])",
         )
 
     def test_outer_join_no_onclause_alias(self):
@@ -931,7 +932,7 @@ class RelationshipToSingleTest(
             "employees_1.company_id AS employees_1_company_id "
             "FROM companies LEFT OUTER JOIN employees AS employees_1 ON "
             "companies.company_id = employees_1.company_id "
-            "AND employees_1.type IN (:type_1)",
+            "AND employees_1.type IN ([POSTCOMPILE_type_1])",
         )
 
     def test_correlated_column_select(self):
@@ -965,7 +966,8 @@ class RelationshipToSingleTest(
             "SELECT companies.company_id AS companies_company_id, "
             "(SELECT count(employees.employee_id) AS count_1 "
             "FROM employees WHERE employees.company_id = "
-            "companies.company_id AND employees.type IN (:type_1)) AS anon_1 "
+            "companies.company_id "
+            "AND employees.type IN ([POSTCOMPILE_type_1])) AS anon_1 "
             "FROM companies",
         )
 
@@ -1041,8 +1043,8 @@ class RelationshipToSingleTest(
                 "ON companies.company_id = employees.company_id "
                 "JOIN employees "
                 "ON companies.company_id = employees.company_id "
-                "AND employees.type IN (:type_1) "
-                "WHERE employees.type IN (:type_2)",
+                "AND employees.type IN ([POSTCOMPILE_type_1]) "
+                "WHERE employees.type IN ([POSTCOMPILE_type_2])",
             )
 
     def test_relationship_to_subclass(self):
@@ -1307,7 +1309,7 @@ class ManyToManyToSingleTest(fixtures.MappedTest, AssertsCompiledSQL):
             "child.name AS child_name "
             "FROM parent LEFT OUTER JOIN (m2m AS m2m_1 "
             "JOIN child ON child.id = m2m_1.child_id "
-            "AND child.discriminator IN (:discriminator_1)) "
+            "AND child.discriminator IN ([POSTCOMPILE_discriminator_1])) "
             "ON parent.id = m2m_1.parent_id",
         )
 
@@ -1324,7 +1326,8 @@ class ManyToManyToSingleTest(fixtures.MappedTest, AssertsCompiledSQL):
             "FROM parent LEFT OUTER JOIN "
             "(m2m AS m2m_1 JOIN child AS child_1 "
             "ON child_1.id = m2m_1.child_id AND child_1.discriminator "
-            "IN (:discriminator_1)) ON parent.id = m2m_1.parent_id",
+            "IN ([POSTCOMPILE_discriminator_1])) "
+            "ON parent.id = m2m_1.parent_id",
         )
 
 
@@ -1536,7 +1539,7 @@ class SingleFromPolySelectableTest(
             "engineer.manager_id AS engineer_manager_id "
             "FROM employee JOIN engineer ON employee.id = engineer.id) "
             "AS anon_1 "
-            "WHERE anon_1.employee_type IN (:type_1)",
+            "WHERE anon_1.employee_type IN ([POSTCOMPILE_type_1])",
         )
 
     def test_query_wpoly_single_inh_subclass(self):
@@ -1563,7 +1566,7 @@ class SingleFromPolySelectableTest(
             "engineer.engineer_info AS engineer_engineer_info, "
             "engineer.manager_id AS engineer_manager_id "
             "FROM employee JOIN engineer ON employee.id = engineer.id) "
-            "AS anon_1 WHERE anon_1.employee_type IN (:type_1)",
+            "AS anon_1 WHERE anon_1.employee_type IN ([POSTCOMPILE_type_1])",
         )
 
     def test_single_inh_subclass_join_joined_inh_subclass(self):
@@ -1582,7 +1585,7 @@ class SingleFromPolySelectableTest(
             "JOIN (employee AS employee_1 JOIN engineer AS engineer_1 "
             "ON employee_1.id = engineer_1.id) "
             "ON engineer_1.manager_id = manager.id "
-            "WHERE employee.type IN (:type_1)",
+            "WHERE employee.type IN ([POSTCOMPILE_type_1])",
         )
 
     def test_single_inh_subclass_join_wpoly_joined_inh_subclass(self):
@@ -1619,7 +1622,7 @@ class SingleFromPolySelectableTest(
             "FROM employee "
             "JOIN engineer ON employee.id = engineer.id) AS anon_1 "
             "ON anon_1.manager_id = manager.id "
-            "WHERE employee.type IN (:type_1)",
+            "WHERE employee.type IN ([POSTCOMPILE_type_1])",
         )
 
     def test_joined_inh_subclass_join_single_inh_subclass(self):
@@ -1639,7 +1642,7 @@ class SingleFromPolySelectableTest(
             "JOIN (employee AS employee_1 JOIN manager AS manager_1 "
             "ON employee_1.id = manager_1.id) "
             "ON engineer.manager_id = manager_1.id "
-            "AND employee_1.type IN (:type_1)",
+            "AND employee_1.type IN ([POSTCOMPILE_type_1])",
         )
 
 

--- a/test/orm/test_cache_key.py
+++ b/test/orm/test_cache_key.py
@@ -23,7 +23,8 @@ class CacheKeyTest(CacheKeyFixture, _fixtures.FixtureTest):
         User, Address, Keyword = self.classes("User", "Address", "Keyword")
 
         self._run_cache_key_fixture(
-            lambda: (inspect(User), inspect(Address), inspect(aliased(User)))
+            lambda: (inspect(User), inspect(Address), inspect(aliased(User))),
+            compare_values=True,
         )
 
     def test_attributes(self):
@@ -40,7 +41,8 @@ class CacheKeyTest(CacheKeyFixture, _fixtures.FixtureTest):
                 User.addresses,
                 Address.email_address,
                 aliased(User).addresses,
-            )
+            ),
+            compare_values=True,
         )
 
     def test_unbound_options(self):
@@ -68,7 +70,8 @@ class CacheKeyTest(CacheKeyFixture, _fixtures.FixtureTest):
                 .defer(Item.description),
                 defaultload(User.orders).defaultload(Order.items),
                 defaultload(User.orders),
-            )
+            ),
+            compare_values=True,
         )
 
     def test_bound_options(self):
@@ -94,7 +97,8 @@ class CacheKeyTest(CacheKeyFixture, _fixtures.FixtureTest):
                 .defer(Item.description),
                 Load(User).defaultload(User.orders).defaultload(Order.items),
                 Load(User).defaultload(User.orders),
-            )
+            ),
+            compare_values=True,
         )
 
     def test_bound_options_equiv_on_strname(self):

--- a/test/orm/test_deferred.py
+++ b/test/orm/test_deferred.py
@@ -1129,8 +1129,8 @@ class DeferredOptionsTest(AssertsCompiledSQL, _fixtures.FixtureTest):
         expected = [
             (
                 "SELECT users.id AS users_id, users.name AS users_name "
-                "FROM users WHERE users.id IN (:id_1, :id_2)",
-                {"id_2": 8, "id_1": 7},
+                "FROM users WHERE users.id IN ([POSTCOMPILE_id_1])",
+                {"id_1": [7, 8]},
             ),
             (
                 "SELECT addresses.id AS addresses_id, "

--- a/test/orm/test_eager_relations.py
+++ b/test/orm/test_eager_relations.py
@@ -1109,6 +1109,46 @@ class EagerTest(_fixtures.FixtureTest, testing.AssertsCompiledSQL):
 
         self.assert_sql_count(testing.db, go, 1)
 
+    def test_group_by_only(self):
+        # like distinct(), a group_by() has a similar effect so the
+        # joined eager load needs to subquery for this as well
+        users, Address, addresses, User = (
+            self.tables.users,
+            self.classes.Address,
+            self.tables.addresses,
+            self.classes.User,
+        )
+
+        mapper(
+            User,
+            users,
+            properties={
+                "addresses": relationship(
+                    mapper(Address, addresses),
+                    lazy="joined",
+                    order_by=addresses.c.email_address,
+                )
+            },
+        )
+
+        q = create_session().query(User)
+        eq_(
+            [
+                User(id=7, addresses=[Address(id=1)]),
+                User(
+                    id=8,
+                    addresses=[
+                        Address(id=3, email_address="ed@bettyboop.com"),
+                        Address(id=4, email_address="ed@lala.com"),
+                        Address(id=2, email_address="ed@wood.com"),
+                    ],
+                ),
+                User(id=9, addresses=[Address(id=5)]),
+                User(id=10, addresses=[]),
+            ],
+            q.order_by(User.id).group_by(User).all(),  # group by all columns
+        )
+
     def test_limit_2(self):
         keywords, items, item_keywords, Keyword, Item = (
             self.tables.keywords,
@@ -3478,7 +3518,7 @@ class LoadOnExistingTest(_fixtures.FixtureTest):
 
         self.assert_sql_count(testing.db, go, 1)
 
-        assert 'addresses' in u1.__dict__
+        assert "addresses" in u1.__dict__
 
     def test_populate_existing_propagate(self):
         # both SelectInLoader and SubqueryLoader receive the loaded collection

--- a/test/orm/test_froms.py
+++ b/test/orm/test_froms.py
@@ -2479,7 +2479,7 @@ class SelectFromTest(QueryTest, AssertsCompiledSQL):
             sess.query(User).join(sel, User.id > sel.c.id),
             "SELECT users.id AS users_id, users.name AS users_name FROM "
             "users JOIN (SELECT users.id AS id, users.name AS name FROM users "
-            "WHERE users.id IN (:id_1, :id_2)) "
+            "WHERE users.id IN ([POSTCOMPILE_id_1])) "
             "AS anon_1 ON users.id > anon_1.id",
         )
 
@@ -2490,8 +2490,9 @@ class SelectFromTest(QueryTest, AssertsCompiledSQL):
             "SELECT users_1.id AS users_1_id, users_1.name AS users_1_name "
             "FROM users AS users_1, ("
             "SELECT users.id AS id, users.name AS name FROM users "
-            "WHERE users.id IN (:id_1, :id_2)) AS anon_1 "
+            "WHERE users.id IN ([POSTCOMPILE_id_1])) AS anon_1 "
             "WHERE users_1.id > anon_1.id",
+            check_post_param={"id_1": [7, 8]},
         )
 
         self.assert_compile(
@@ -2500,8 +2501,9 @@ class SelectFromTest(QueryTest, AssertsCompiledSQL):
             .join(ualias, ualias.id > sel.c.id),
             "SELECT users_1.id AS users_1_id, users_1.name AS users_1_name "
             "FROM (SELECT users.id AS id, users.name AS name "
-            "FROM users WHERE users.id IN (:id_1, :id_2)) AS anon_1 "
+            "FROM users WHERE users.id IN ([POSTCOMPILE_id_1])) AS anon_1 "
             "JOIN users AS users_1 ON users_1.id > anon_1.id",
+            check_post_param={"id_1": [7, 8]},
         )
 
         self.assert_compile(
@@ -2510,8 +2512,9 @@ class SelectFromTest(QueryTest, AssertsCompiledSQL):
             .join(ualias, ualias.id > User.id),
             "SELECT users_1.id AS users_1_id, users_1.name AS users_1_name "
             "FROM (SELECT users.id AS id, users.name AS name FROM "
-            "users WHERE users.id IN (:id_1, :id_2)) AS anon_1 "
+            "users WHERE users.id IN ([POSTCOMPILE_id_1])) AS anon_1 "
             "JOIN users AS users_1 ON users_1.id > anon_1.id",
+            check_post_param={"id_1": [7, 8]},
         )
 
         salias = aliased(User, sel)
@@ -2519,8 +2522,9 @@ class SelectFromTest(QueryTest, AssertsCompiledSQL):
             sess.query(salias).join(ualias, ualias.id > salias.id),
             "SELECT anon_1.id AS anon_1_id, anon_1.name AS anon_1_name FROM "
             "(SELECT users.id AS id, users.name AS name "
-            "FROM users WHERE users.id IN (:id_1, :id_2)) AS anon_1 "
+            "FROM users WHERE users.id IN ([POSTCOMPILE_id_1])) AS anon_1 "
             "JOIN users AS users_1 ON users_1.id > anon_1.id",
+            check_post_param={"id_1": [7, 8]},
         )
 
         self.assert_compile(
@@ -2531,8 +2535,9 @@ class SelectFromTest(QueryTest, AssertsCompiledSQL):
             "FROM "
             "(SELECT users.id AS id, users.name AS name "
             "FROM users WHERE users.id "
-            "IN (:id_1, :id_2)) AS anon_1 "
+            "IN ([POSTCOMPILE_id_1])) AS anon_1 "
             "JOIN users AS users_1 ON users_1.id > anon_1.id",
+            check_post_param={"id_1": [7, 8]},
         )
 
     def test_aliased_class_vs_nonaliased(self):

--- a/test/orm/test_of_type.py
+++ b/test/orm/test_of_type.py
@@ -1003,9 +1003,10 @@ class SubclassRelationshipTest3(
         "c.id AS c_id, c.type AS c_type, c.b_id AS c_b_id, a.id AS a_id, "
         "a.type AS a_type "
         "FROM a LEFT OUTER JOIN b ON "
-        "a.id = b.a_id AND b.type IN (:type_1) "
+        "a.id = b.a_id AND b.type IN ([POSTCOMPILE_type_1]) "
         "LEFT OUTER JOIN c ON "
-        "b.id = c.b_id AND c.type IN (:type_2) WHERE a.type IN (:type_3)"
+        "b.id = c.b_id AND c.type IN ([POSTCOMPILE_type_2]) "
+        "WHERE a.type IN ([POSTCOMPILE_type_3])"
     )
 
     _query2 = (
@@ -1013,10 +1014,10 @@ class SubclassRelationshipTest3(
         "ccc.id AS ccc_id, ccc.type AS ccc_type, ccc.b_id AS ccc_b_id, "
         "aaa.id AS aaa_id, aaa.type AS aaa_type "
         "FROM a AS aaa LEFT OUTER JOIN b AS bbb "
-        "ON aaa.id = bbb.a_id AND bbb.type IN (:type_1) "
+        "ON aaa.id = bbb.a_id AND bbb.type IN ([POSTCOMPILE_type_1]) "
         "LEFT OUTER JOIN c AS ccc ON "
-        "bbb.id = ccc.b_id AND ccc.type IN (:type_2) "
-        "WHERE aaa.type IN (:type_3)"
+        "bbb.id = ccc.b_id AND ccc.type IN ([POSTCOMPILE_type_2]) "
+        "WHERE aaa.type IN ([POSTCOMPILE_type_3])"
     )
 
     _query3 = (
@@ -1024,10 +1025,10 @@ class SubclassRelationshipTest3(
         "c.id AS c_id, c.type AS c_type, c.b_id AS c_b_id, "
         "aaa.id AS aaa_id, aaa.type AS aaa_type "
         "FROM a AS aaa LEFT OUTER JOIN b AS bbb "
-        "ON aaa.id = bbb.a_id AND bbb.type IN (:type_1) "
+        "ON aaa.id = bbb.a_id AND bbb.type IN ([POSTCOMPILE_type_1]) "
         "LEFT OUTER JOIN c ON "
-        "bbb.id = c.b_id AND c.type IN (:type_2) "
-        "WHERE aaa.type IN (:type_3)"
+        "bbb.id = c.b_id AND c.type IN ([POSTCOMPILE_type_2]) "
+        "WHERE aaa.type IN ([POSTCOMPILE_type_3])"
     )
 
     def _test(self, join_of_type, of_type_for_c1, aliased_):

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -1756,7 +1756,7 @@ class OperatorTest(QueryTest, AssertsCompiledSQL):
     def test_in(self):
         User = self.classes.User
 
-        self._test(User.id.in_(["a", "b"]), "users.id IN (:id_1, :id_2)")
+        self._test(User.id.in_(["a", "b"]), "users.id IN ([POSTCOMPILE_id_1])")
 
     def test_in_on_relationship_not_supported(self):
         User, Address = self.classes.User, self.classes.Address

--- a/test/orm/test_relationships.py
+++ b/test/orm/test_relationships.py
@@ -432,11 +432,11 @@ class DirectSelfRefFKTest(fixtures.MappedTest, AssertsCompiledSQL):
 
     this is an **extremely** unusual case::
 
-    Entity
-    ------
-     path -------+
-       ^         |
-       +---------+
+        Entity
+        ------
+         path -------+
+           ^         |
+           +---------+
 
     In this case, one-to-many and many-to-one are no longer accurate.
     Both relationships return collections.   I'm not sure if this is a good

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -3031,8 +3031,8 @@ class SingleInhSubclassTest(
             q.all,
             CompiledSQL(
                 'SELECT "user".id AS user_id, "user".type AS user_type '
-                'FROM "user" WHERE "user".type IN (:type_1)',
-                {"type_1": "employer"},
+                'FROM "user" WHERE "user".type IN ([POSTCOMPILE_type_1])',
+                {"type_1": ["employer"]},
             ),
             CompiledSQL(
                 "SELECT role.user_id AS role_user_id, role.id AS role_id "
@@ -3155,8 +3155,8 @@ class M2OWDegradeTest(
             q.all,
             CompiledSQL(
                 "SELECT a.id AS a_id, a.b_id AS a_b_id, a.q AS a_q "
-                "FROM a WHERE a.id IN (:id_1, :id_2) ORDER BY a.id",
-                [{"id_1": 1, "id_2": 3}],
+                "FROM a WHERE a.id IN ([POSTCOMPILE_id_1]) ORDER BY a.id",
+                [{"id_1": [1, 3]}],
             ),
             CompiledSQL(
                 "SELECT b.id AS b_id, b.x AS b_x, b.y AS b_y "
@@ -3184,8 +3184,8 @@ class M2OWDegradeTest(
             q.all,
             CompiledSQL(
                 "SELECT a.id AS a_id, a.q AS a_q "
-                "FROM a WHERE a.id IN (:id_1, :id_2) ORDER BY a.id",
-                [{"id_1": 1, "id_2": 3}],
+                "FROM a WHERE a.id IN ([POSTCOMPILE_id_1]) ORDER BY a.id",
+                [{"id_1": [1, 3]}],
             ),
             # in the very unlikely case that the the FK col on parent is
             # deferred, we degrade to the JOIN version so that we don't need to

--- a/test/orm/test_utils.py
+++ b/test/orm/test_utils.py
@@ -936,9 +936,9 @@ class PathRegistryInhTest(_poly_fixtures._Polymorphic):
 
         p_poly = with_polymorphic(Person, [Engineer])
         e_poly = inspect(p_poly.Engineer)
-        p_poly = inspect(p_poly)
+        p_poly_insp = inspect(p_poly)
 
-        p1 = PathRegistry.coerce((p_poly, emapper.attrs.machines))
+        p1 = PathRegistry.coerce((p_poly_insp, emapper.attrs.machines))
 
         # polymorphic AliasedClass - the path uses _entity_for_mapper()
         # to get the most specific sub-entity

--- a/test/profiles.txt
+++ b/test/profiles.txt
@@ -543,6 +543,22 @@ test.aaa_profiling.test_orm.DeferOptionsTest.test_defer_many_cols 3.7_postgresql
 test.aaa_profiling.test_orm.DeferOptionsTest.test_defer_many_cols 3.7_sqlite_pysqlite_dbapiunicode_cextensions 23259
 test.aaa_profiling.test_orm.DeferOptionsTest.test_defer_many_cols 3.7_sqlite_pysqlite_dbapiunicode_nocextensions 30268
 
+# TEST: test.aaa_profiling.test_orm.JoinConditionTest.test_a_to_b_aliased
+
+test.aaa_profiling.test_orm.JoinConditionTest.test_a_to_b_aliased 3.7_sqlite_pysqlite_dbapiunicode_nocextensions 10313
+
+# TEST: test.aaa_profiling.test_orm.JoinConditionTest.test_a_to_b_plain
+
+test.aaa_profiling.test_orm.JoinConditionTest.test_a_to_b_plain 3.7_sqlite_pysqlite_dbapiunicode_nocextensions 3256
+
+# TEST: test.aaa_profiling.test_orm.JoinConditionTest.test_a_to_d
+
+test.aaa_profiling.test_orm.JoinConditionTest.test_a_to_d 3.7_sqlite_pysqlite_dbapiunicode_nocextensions 106798
+
+# TEST: test.aaa_profiling.test_orm.JoinConditionTest.test_a_to_d_aliased
+
+test.aaa_profiling.test_orm.JoinConditionTest.test_a_to_d_aliased 3.7_sqlite_pysqlite_dbapiunicode_nocextensions 104564
+
 # TEST: test.aaa_profiling.test_orm.JoinedEagerLoadTest.test_build_query
 
 test.aaa_profiling.test_orm.JoinedEagerLoadTest.test_build_query 2.7_mssql_pyodbc_dbapiunicode_nocextensions 439163

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -7,12 +7,14 @@ import sys
 
 from sqlalchemy import exc
 from sqlalchemy import util
+from sqlalchemy.sql import text
 from sqlalchemy.testing import exclusions
 from sqlalchemy.testing.exclusions import against
 from sqlalchemy.testing.exclusions import fails_if
 from sqlalchemy.testing.exclusions import fails_on
 from sqlalchemy.testing.exclusions import fails_on_everything_except
 from sqlalchemy.testing.exclusions import LambdaPredicate
+from sqlalchemy.testing.exclusions import NotPredicate
 from sqlalchemy.testing.exclusions import only_if
 from sqlalchemy.testing.exclusions import only_on
 from sqlalchemy.testing.exclusions import skip_if
@@ -645,6 +647,23 @@ class DefaultRequirements(SuiteRequirements):
     def two_phase_transactions(self):
         """Target database must support two-phase transactions."""
 
+        def pg_prepared_transaction(config):
+            if not against(config, "postgresql"):
+                return False
+
+            with config.db.connect() as conn:
+                try:
+                    num = conn.scalar(
+                        text(
+                            "select cast(setting AS integer) from pg_settings "
+                            "where name = 'max_prepared_transactions'"
+                        )
+                    )
+                except exc.OperationalError:
+                    return False
+                else:
+                    return num > 0
+
         return skip_if(
             [
                 no_support("firebird", "no SA implementation"),
@@ -670,6 +689,12 @@ class DefaultRequirements(SuiteRequirements):
                     "mysql",
                     "recent MySQL communiity editions have too many issues "
                     "(late 2016), disabling for now",
+                ),
+                NotPredicate(
+                    LambdaPredicate(
+                        pg_prepared_transaction,
+                        "max_prepared_transactions not available or zero",
+                    )
                 ),
             ]
         )

--- a/test/sql/test_compare.py
+++ b/test/sql/test_compare.py
@@ -59,6 +59,7 @@ from sqlalchemy.testing import is_false
 from sqlalchemy.testing import is_not_
 from sqlalchemy.testing import is_true
 from sqlalchemy.testing import ne_
+from sqlalchemy.testing.util import random_choices
 from sqlalchemy.util import class_hierarchy
 
 
@@ -392,13 +393,13 @@ class CoreFixtures(object):
         lambda: (
             # same number of params each time, so compare for IN
             # with legacy behavior of bind for each value works
-            column("x").in_(random.choices(range(10), k=3)),
+            column("x").in_(random_choices(range(10), k=3)),
             # expanding IN places the whole list into a single parameter
             # so it can be of arbitrary length as well
             column("x").in_(
                 bindparam(
                     "q",
-                    random.choices(range(10), k=random.randint(0, 7)),
+                    random_choices(range(10), k=random.randint(0, 7)),
                     expanding=True,
                 )
             ),

--- a/test/sql/test_compare.py
+++ b/test/sql/test_compare.py
@@ -391,18 +391,17 @@ class CoreFixtures(object):
 
     dont_compare_values_fixtures = [
         lambda: (
-            # same number of params each time, so compare for IN
-            # with legacy behavior of bind for each value works
+            # note the in_(...) all have different column names becuase
+            # otherwise all IN expressions would compare as equivalent
             column("x").in_(random_choices(range(10), k=3)),
-            # expanding IN places the whole list into a single parameter
-            # so it can be of arbitrary length as well
-            column("x").in_(
+            column("y").in_(
                 bindparam(
                     "q",
                     random_choices(range(10), k=random.randint(0, 7)),
                     expanding=True,
                 )
             ),
+            column("z").in_(random_choices(range(10), k=random.randint(0, 7))),
             column("x") == random.randint(1, 10),
         )
     ]

--- a/test/sql/test_cte.py
+++ b/test/sql/test_cte.py
@@ -903,6 +903,28 @@ class CTETest(fixtures.TestBase, AssertsCompiledSQL):
             'ON anon_1."order" = "order"."order"',
         )
 
+    def test_prefixes(self):
+        orders = table("order", column("order"))
+        s = select([orders.c.order]).cte("regional_sales")
+        s = s.prefix_with("NOT MATERIALIZED", dialect="postgresql")
+        stmt = select([orders]).where(orders.c.order > s.c.order)
+
+        self.assert_compile(
+            stmt,
+            'WITH regional_sales AS (SELECT "order"."order" AS "order" '
+            'FROM "order") SELECT "order"."order" FROM "order", '
+            'regional_sales WHERE "order"."order" > regional_sales."order"',
+        )
+
+        self.assert_compile(
+            stmt,
+            'WITH regional_sales AS NOT MATERIALIZED '
+            '(SELECT "order"."order" AS "order" '
+            'FROM "order") SELECT "order"."order" FROM "order", '
+            'regional_sales WHERE "order"."order" > regional_sales."order"',
+            dialect="postgresql"
+        )
+
     def test_suffixes(self):
         orders = table("order", column("order"))
         s = select([orders.c.order]).cte("regional_sales")

--- a/test/sql/test_external_traversal.py
+++ b/test/sql/test_external_traversal.py
@@ -102,8 +102,8 @@ class TraversalTest(fixtures.TestBase, AssertsExecutionResults):
                         return True
                 return False
 
-            def _copy_internals(self, clone=_clone):
-                self.items = [clone(i) for i in self.items]
+            def _copy_internals(self, clone=_clone, **kw):
+                self.items = [clone(i, **kw) for i in self.items]
 
             def get_children(self, **kwargs):
                 return self.items

--- a/test/sql/test_query.py
+++ b/test/sql/test_query.py
@@ -813,7 +813,7 @@ class QueryTest(fixtures.TestBase):
         users.insert().execute(user_id=8, user_name="fred")
         users.insert().execute(user_id=9, user_name=None)
 
-        u = bindparam("search_key")
+        u = bindparam("search_key", type_=String)
 
         s = users.select(not_(u.in_([])))
         r = s.execute(search_key="john").fetchall()
@@ -821,7 +821,6 @@ class QueryTest(fixtures.TestBase):
         r = s.execute(search_key=None).fetchall()
         assert len(r) == 3
 
-    @testing.emits_warning(".*empty sequence.*")
     def test_literal_in(self):
         """similar to test_bind_in but use a bind with a value."""
 
@@ -860,40 +859,6 @@ class QueryTest(fixtures.TestBase):
             s = users.select(users.c.user_name.in_([]) == None)  # noqa
             r = conn.execute(s).fetchall()
             assert len(r) == 0
-
-    @testing.requires.boolean_col_expressions
-    def test_empty_in_filtering_dynamic(self):
-        """test the behavior of the in_() function when
-        comparing against an empty collection, specifically
-        that a proper boolean value is generated.
-
-        """
-
-        engine = engines.testing_engine(
-            options={"empty_in_strategy": "dynamic"}
-        )
-
-        with engine.connect() as conn:
-            users.create(engine, checkfirst=True)
-
-            conn.execute(
-                users.insert(),
-                [
-                    {"user_id": 7, "user_name": "jack"},
-                    {"user_id": 8, "user_name": "ed"},
-                    {"user_id": 9, "user_name": None},
-                ],
-            )
-
-            s = users.select(users.c.user_name.in_([]) == True)  # noqa
-            r = conn.execute(s).fetchall()
-            assert len(r) == 0
-            s = users.select(users.c.user_name.in_([]) == False)  # noqa
-            r = conn.execute(s).fetchall()
-            assert len(r) == 2
-            s = users.select(users.c.user_name.in_([]) == None)  # noqa
-            r = conn.execute(s).fetchall()
-            assert len(r) == 1
 
 
 class RequiredBindTest(fixtures.TablesTest):

--- a/test/sql/test_selectable.py
+++ b/test/sql/test_selectable.py
@@ -2442,7 +2442,7 @@ class AnnotationsTest(fixtures.TestBase):
             (table1.c.col1 == 5, "table1.col1 = :col1_1"),
             (
                 table1.c.col1.in_([2, 3, 4]),
-                "table1.col1 IN (:col1_1, :col1_2, " ":col1_3)",
+                "table1.col1 IN ([POSTCOMPILE_col1_1])",
             ),
         ]:
             eq_(str(expr), expected)


### PR DESCRIPTION
Fixes: #5045

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
pyodbc requires that T-SQL DATETIMEOFFSET values be passed as strings, and we were formatting `datetime` objects as strings without the fractional seconds.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
