### PR TITLE
Fix WeakSequence circular reference

### DIFF
--- a/lib/sqlalchemy/util/_collections.py
+++ b/lib/sqlalchemy/util/_collections.py
@@ -676,15 +676,17 @@ class IdentitySet(object):
 
 class WeakSequence(object):
     def __init__(self, __elements=()):
+        def _remove(item, selfref=weakref.ref(self)):
+            self = selfref()
+            if self is not None:
+                self._storage.remove(item)
+        self._remove = _remove
         self._storage = [
-            weakref.ref(element, self._remove) for element in __elements
+            weakref.ref(element, _remove) for element in __elements
         ]
 
     def append(self, item):
         self._storage.append(weakref.ref(item, self._remove))
-
-    def _remove(self, ref):
-        self._storage.remove(ref)
 
     def __len__(self):
         return len(self._storage)

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -188,6 +188,19 @@ class WeakSequenceTest(fixtures.TestBase):
         eq_(len(w), 2)
         eq_(len(w._storage), 2)
 
+    @testing.requires.predictable_gc
+    def test_cleanout_container(self):
+        import weakref
+
+        class Foo(object):
+            pass
+
+        f = Foo()
+        w = WeakSequence([f])
+        w_wref = weakref.ref(w)
+        del w
+        eq_(w_wref(), None)
+
 
 class OrderedDictTest(fixtures.TestBase):
     def test_odict(self):


### PR DESCRIPTION
Fix WeakSequence circular reference

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
WeakSequence's  `_remove` instance method had `__self__` which caused a
circular reference. Use a weak selfref to break the cycle.

Fix #5050 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
