### PR TITLE
Fix test failures under Windows

### DIFF
--- a/test/ext/test_horizontal_shard.py
+++ b/test/ext/test_horizontal_shard.py
@@ -29,6 +29,7 @@ from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import provision
 from sqlalchemy.testing.engines import testing_engine
+from sqlalchemy.testing.engines import testing_reaper
 
 
 # TODO: ShardTest can be turned into a base for further subclasses
@@ -619,6 +620,8 @@ class LazyLoadIdentityKeyTest(fixtures.DeclarativeMappedTest):
     def teardown(self):
         for db in self.dbs:
             db.connect().invalidate()
+
+        testing_reaper.close_all()
         for i in range(1, 3):
             os.remove("shard%d_%s.db" % (i, provision.FOLLOWER_IDENT))
 


### PR DESCRIPTION
This aim at fixing the sqlalchemy tests on windows
Fix #4946 
### Description
Currently on sqlite there are these 3 tests that sometimes fail and sometimes do not
```
_____________________________ QueuePoolTest.test_connect_handler_not_called_for_recycled ______________________________
Traceback (most recent call last):
  File "C:\Users\Federico\Documents\GitHub\sqlalchemy\test\engine\test_pool.py", line 1312, in test_connect_handler_not_called_for_recycled
    assert_raises(Exception, p.connect)
  File "C:\Users\Federico\Documents\GitHub\sqlalchemy\test\..\lib\sqlalchemy\testing\assertions.py", line 307, in assert_raises
    assert success, "Callable did not raise an exception"
AssertionError: Callable did not raise an exception
assert False
____________________________________ QueuePoolTest.test_recycle_on_soft_invalidate ____________________________________
Traceback (most recent call last):
  File "C:\Users\Federico\Documents\GitHub\sqlalchemy\test\engine\test_pool.py", line 1227, in test_recycle_on_soft_invalidate
    is_not_(c3.connection, c_ref())
  File "C:\Users\Federico\Documents\GitHub\sqlalchemy\test\..\lib\sqlalchemy\testing\assertions.py", line 269, in is_not_
    assert a is not b, msg or "%r is %r" % (a, b)
AssertionError: <Mock id='1505749580168'> is <Mock id='1505749580168'>
assert <Mock id='1505749580168'> is not <Mock id='1505749580168'>
____________________________ QueuePoolTest.test_connect_checkout_handler_always_gets_info _____________________________
Traceback (most recent call last):
  File "C:\Users\Federico\Documents\GitHub\sqlalchemy\test\engine\test_pool.py", line 1359, in test_connect_checkout_handler_always_gets_info
    c = p.connect()
  File "C:\Users\Federico\Documents\GitHub\sqlalchemy\test\..\lib\sqlalchemy\pool\base.py", line 301, in connect
    return _ConnectionFairy._checkout(self)
  File "C:\Users\Federico\Documents\GitHub\sqlalchemy\test\..\lib\sqlalchemy\pool\base.py", line 725, in _checkout
    fairy.connection, fairy._connection_record, fairy
  File "C:\Users\Federico\Documents\GitHub\sqlalchemy\test\..\lib\sqlalchemy\event\attr.py", line 322, in __call__
    fn(*args, **kw)
  File "C:\Users\Federico\Documents\GitHub\sqlalchemy\test\engine\test_pool.py", line 1350, in checkout
    assert "x" in conn_rec.info
AssertionError: assert 'x' in {}
 +  where {} = <sqlalchemy.pool.base._ConnectionRecord object at 0x0000023667DB55C8>.info
```
### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
