### PR TITLE
Fix QueryContext ref cycle on joinedload

### DIFF
--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -3911,7 +3911,7 @@ class Query(object):
 
         for rec in context.create_eager_joins:
             strategy = rec[0]
-            strategy(*rec[1:])
+            strategy(context, *rec[1:])
 
         if context.from_clause:
             # "load from explicit FROMs" mode,

--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -1707,7 +1707,6 @@ class JoinedLoader(AbstractRelationshipLoader):
         context.create_eager_joins.append(
             (
                 self._create_eager_join,
-                context,
                 entity,
                 path,
                 adapter,

--- a/test/aaa_profiling/test_memusage.py
+++ b/test/aaa_profiling/test_memusage.py
@@ -1208,6 +1208,21 @@ class CycleTest(_fixtures.FixtureTest):
 
         go()
 
+    def test_query_joinedload(self):
+        User, Address = self.classes("User", "Address")
+
+        s = Session()
+
+        def generate():
+            s.query(User).options(joinedload(User.addresses)).all()
+
+        # cycles here are due to ClauseElement._cloned_set and Load.context
+        @assert_cycles(28)
+        def go():
+            generate()
+
+        go()
+
     def test_plain_join(self):
         users, addresses = self.tables("users", "addresses")
 


### PR DESCRIPTION
Fix QueryContext ref cycle on joinedload

Fixes: #5071

### Description
Avoid storing a reference to itself when dealing with create_eager_joins. Also fix a cheating test.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
