### PR TITLE
New scalar option for query.all() method

### DIFF
--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -3152,10 +3152,13 @@ class Query(Generative):
         else:
             self._suffixes = suffixes
 
-    def all(self):
+    def all(self, scalar=False):
         """Return the results represented by this :class:`.Query` as a list.
 
         This results in an execution of the underlying SQL statement.
+
+        :param scalar: If True, return a list of scalar objects as a opposed to a list of tuples.
+        This is useful when selecting a single column.
 
         .. warning::  The :class:`.Query` object, when asked to return either
            a sequence or iterator that consists of full ORM-mapped entities,
@@ -3166,7 +3169,10 @@ class Query(Generative):
 
                 :ref:`faq_query_deduplicating`
         """
-        return list(self)
+        l = list(self)
+        if scalar:
+            l = [i[0] for i in l]
+        return l
 
     @_generative
     @_assertions(_no_clauseelement_condition)

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -965,6 +965,15 @@ class GetTest(QueryTest):
         assert u.addresses[0].email_address == "jack@bean.com"
         assert u.orders[1].items[2].description == "item 5"
 
+    def test_scalar_list_result(self):
+        User = self.classes.User
+
+        s = create_session()
+
+        usernames_tuple = s.query(User.name).all()
+        usernames = s.query(User.name).all(scalar=True)
+        assert usernames == [u[0] for u in usernames_tuple]
+
 
 class InvalidGenerationsTest(QueryTest, AssertsCompiledSQL):
     @testing.combinations(


### PR DESCRIPTION
I often find that I need to transform the results of single column SQLAlchemy queries from a a list of tuples to a list of whatever type the column is. Having an option in SQLA itself would avoid us having take care of this every time.

### Description
A very simple change: a new "scalar" argument in the Query.all() method that defaults to False so that it doesn't affect any existing code. If True, it transforms the result into a list of scalar values rather than returning the tuples as they are.

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x ] A new feature implementation
	Issue #5087

**Greetings from Kopernio :) Have a nice day!**
