### PR TITLE
Simplify; Python 2.5 no longer supported

### DIFF
--- a/lib/sqlalchemy/connectors/zxJDBC.py
+++ b/lib/sqlalchemy/connectors/zxJDBC.py
@@ -17,7 +17,7 @@ class ZxJDBCConnector(Connector):
     supports_sane_multi_rowcount = False
 
     supports_unicode_binds = True
-    supports_unicode_statements = sys.version > "2.5.0+"
+    supports_unicode_statements = True
     description_encoding = None
     default_paramstyle = "qmark"
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

Fixes: #5094

### Description
<!-- Describe your changes in detail -->

`./lib/sqlalchemy/connectors/zxJDBC.py`

```python
    supports_unicode_statements = sys.version > "2.5.0+"
```

It's best not to compare to `sys.version`, which is a string, as doing so can make assumptions that the major, minor or micro parts are single characters, which isn't guaranteed to be true. For example, Python 2.7.10 and 3.10.

It's probably safe in this case, but it Python 2.5 and 2.6 have long been dropped, and to prevent possible errors from copying and pasting, this line can be cleaned up to: 

```python
    supports_unicode_statements = True
```


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
