### PR TITLE
While parsing for check constraints, ignore newline characters in the check condition

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3491,13 +3491,15 @@ class PGDialect(default.DefaultDialect):
             # "CHECK (((a\n < 1)\n OR\n (a\n >= 5))\n)"
 
             m = re.match(
-                r"^CHECK *\((.+)\)( NOT VALID)?$", src, flags=re.DOTALL)
+                r"^CHECK *\((.+)\)( NOT VALID)?$", src, flags=re.DOTALL
+            )
             if not m:
                 util.warn("Could not parse CHECK constraint text: %r" % src)
                 sqltext = ""
             else:
-                match_without_newlines = ' '.join(
-                    m.group(1).splitlines()).strip()
+                match_without_newlines = " ".join(
+                    m.group(1).splitlines()
+                ).strip()
                 sqltext = re.sub(r"^\((.+)\)$", r"\1", match_without_newlines)
             entry = {"name": name, "sqltext": sqltext}
             if m and m.group(2):

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3495,7 +3495,7 @@ class PGDialect(default.DefaultDialect):
                 util.warn("Could not parse CHECK constraint text: %r" % src)
                 sqltext = ""
             else:
-                match_without_newlines = ''.join(m.group(1).splitlines())
+                match_without_newlines = ' '.join(m.group(1).splitlines()).strip()
                 sqltext = re.sub(r"^\((.+)\)$", r"\1", match_without_newlines)
             entry = {"name": name, "sqltext": sqltext}
             if m and m.group(2):

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3490,12 +3490,14 @@ class PGDialect(default.DefaultDialect):
             # "CHECK (some_boolean_function(a))"
             # "CHECK (((a\n < 1)\n OR\n (a\n >= 5))\n)"
 
-            m = re.match(r"^CHECK *\((.+)\)( NOT VALID)?$", src, flags=re.DOTALL)
+            m = re.match(
+                r"^CHECK *\((.+)\)( NOT VALID)?$", src, flags=re.DOTALL)
             if not m:
                 util.warn("Could not parse CHECK constraint text: %r" % src)
                 sqltext = ""
             else:
-                match_without_newlines = ' '.join(m.group(1).splitlines()).strip()
+                match_without_newlines = ' '.join(
+                    m.group(1).splitlines()).strip()
                 sqltext = re.sub(r"^\((.+)\)$", r"\1", match_without_newlines)
             entry = {"name": name, "sqltext": sqltext}
             if m and m.group(2):

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -1602,18 +1602,9 @@ class ReflectionTest(fixtures.TestBase):
             eq_(
                 check_constraints,
                 [
-                    {
-                        "name": "some name",
-                        "sqltext": "a  IS  NOT   NULL ",
-                    },
-                    {
-                        "name": "some other name",
-                        "sqltext": "b IS NOT NULL",
-                    },
-                    {
-                        "name": "some CRLF name",
-                        "sqltext": "c  IS NOT NULL",
-                    }
+                    {"name": "some name", "sqltext": "a  IS  NOT   NULL ",},
+                    {"name": "some other name", "sqltext": "b IS NOT NULL",},
+                    {"name": "some CRLF name", "sqltext": "c  IS NOT NULL",},
                 ],
             )
 

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -1583,7 +1583,11 @@ class ReflectionTest(fixtures.TestBase):
                 testing.db.dialect.get_check_constraints(conn, "foo")
 
     def test_reflect_extra_newlines(self):
-        rows = [("some name", "CHECK (\n(a \nIS\n NOT\n\n NULL\n)\n)")]
+        rows = [
+            ("some name", "CHECK (\n(a \nIS\n NOT\n\n NULL\n)\n)"),
+            ("some other name", "CHECK ((b\nIS\nNOT\nNULL))"),
+            ("some CRLF name", "CHECK ((c\r\n\r\nIS\r\nNOT\r\nNULL))"),
+        ]
         conn = mock.Mock(
             execute=lambda *arg, **kw: mock.MagicMock(
                 fetchall=lambda: rows, __iter__=lambda self: iter(rows)
@@ -1600,7 +1604,15 @@ class ReflectionTest(fixtures.TestBase):
                 [
                     {
                         "name": "some name",
-                        "sqltext": "a IS NOT NULL",
+                        "sqltext": "a  IS  NOT   NULL ",
+                    },
+                    {
+                        "name": "some other name",
+                        "sqltext": "b IS NOT NULL",
+                    },
+                    {
+                        "name": "some CRLF name",
+                        "sqltext": "c  IS NOT NULL",
                     }
                 ],
             )


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Fixes https://github.com/sqlalchemy/sqlalchemy/issues/5170

Sets the flag `re.DOTALL` when matching a check constraint, in order to support newlines/other whitespace in the condition of the check constraint.

In addition to adding a test case, I took the minimal steps to reproduce from the linked issue, and verified that the issue is corrected by the changes in this PR.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
