### PR TITLE
Fix covering index reflection

### DIFF
--- a/doc/build/changelog/unreleased_13/5205.rst
+++ b/doc/build/changelog/unreleased_13/5205.rst
@@ -1,5 +1,8 @@
 .. change::
-    :tags: usecase, postgresql
+    :tags: bug, postgresql
     :tickets: 5205
 
-    Fixed reflection of covering indexes. They were added in PostgreSQL 11.
+    Fixed issue where a "covering" index, e.g. those which have an 
+    INCLUDE clause, would be reflected including all the columns in INCLUDE
+    clause as regular columns.  Note that full support for "covering"
+    indexes is part of :ticket:`4458`.  Pull request courtesy Marat Sharafutdinov.

--- a/doc/build/changelog/unreleased_13/5205.rst
+++ b/doc/build/changelog/unreleased_13/5205.rst
@@ -1,0 +1,5 @@
+.. change::
+    :tags: usecase, postgresql
+    :tickets: 5205
+
+    Fixed reflection of covering indexes. They were added in PostgreSQL 11.

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3259,7 +3259,8 @@ class PGDialect(default.DefaultDialect):
                   i.relname as relname,
                   ix.indisunique, ix.indexprs, ix.indpred,
                   a.attname, a.attnum, NULL, ix.indkey%s,
-                  %s, %s, am.amname
+                  %s, %s, am.amname,
+                  NULL as indnkeyatts
               FROM
                   pg_class t
                         join pg_index ix on t.oid = ix.indrelid
@@ -3296,7 +3297,8 @@ class PGDialect(default.DefaultDialect):
                   i.relname as relname,
                   ix.indisunique, ix.indexprs, ix.indpred,
                   a.attname, a.attnum, c.conrelid, ix.indkey::varchar,
-                  ix.indoption::varchar, i.reloptions, am.amname
+                  ix.indoption::varchar, i.reloptions, am.amname,
+                  %s as indnkeyatts
               FROM
                   pg_class t
                         join pg_index ix on t.oid = ix.indrelid
@@ -3319,7 +3321,11 @@ class PGDialect(default.DefaultDialect):
               ORDER BY
                   t.relname,
                   i.relname
-            """
+            """ % (
+                "ix.indnkeyatts"
+                if self.server_version_info >= (11, 0)
+                else "NULL",
+            )
 
         t = sql.text(IDX_SQL).columns(
             relname=sqltypes.Unicode, attname=sqltypes.Unicode
@@ -3342,6 +3348,7 @@ class PGDialect(default.DefaultDialect):
                 idx_option,
                 options,
                 amname,
+                indnkeyatts,
             ) = row
 
             if expr:
@@ -3365,7 +3372,10 @@ class PGDialect(default.DefaultDialect):
             if col is not None:
                 index["cols"][col_num] = col
             if not has_idx:
-                index["key"] = [int(k.strip()) for k in idx_key.split()]
+                idx_keys = idx_key.split()
+                if indnkeyatts is not None:
+                    idx_keys = idx_keys[:indnkeyatts]
+                index["key"] = [int(k.strip()) for k in idx_keys]
 
                 # (new in pg 8.3)
                 # "pg_index.indoption" is list of ints, one per column/expr.

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -1077,7 +1077,7 @@ class ReflectionTest(fixtures.TestBase):
 
     @testing.provide_metadata
     def test_index_reflection_with_access_method(self):
-        """reflect indexes with storage options set"""
+        """reflect indexes with access method set"""
 
         metadata = self.metadata
 

--- a/test/orm/test_transaction.py
+++ b/test/orm/test_transaction.py
@@ -474,8 +474,8 @@ class SessionTransactionTest(fixtures.RemovesEvents, FixtureTest):
 
         x = [1]
 
-        @event.listens_for(sess, "after_commit")  # noqa
-        def add_another_user(session):
+        @event.listens_for(sess, "after_commit")
+        def add_another_user(session):  # noqa
             x[0] += 1
 
         sess.add(to_flush.pop())


### PR DESCRIPTION
Fixes: #5205 
Refs: #4458

### Description
Do not reflect included columns at PostgreSQL indexes as key columns.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
