### PR TITLE
fixes #4212 raise an error if selectable and flat/aliased are sent to with_polymorphic simultaenously

### DIFF
--- a/doc/build/changelog/unreleased_14/4212.rst
+++ b/doc/build/changelog/unreleased_14/4212.rst
@@ -1,0 +1,9 @@
+.. change::
+    :tags: bug, easy, inheritance, orm
+    :tickets: 4212
+
+    An :class:`.ArgumentError` is now raised if both the selectable and flat
+    parameters are set to True in :func:`.orm.with_polymorphic`.
+    The selectable name is already aliased and applying flat=True
+    overrides the selectable name with an anonymous name that would've
+    previously caused the code to break. Pull request courtesy Ramon Williams.

--- a/lib/sqlalchemy/orm/util.py
+++ b/lib/sqlalchemy/orm/util.py
@@ -932,6 +932,13 @@ def with_polymorphic(
        only be specified if querying for one specific subtype only
     """
     primary_mapper = _class_to_mapper(base)
+
+    if selectable not in (None, False) and flat:
+        raise sa_exc.ArgumentError(
+            "the 'flat' and 'selectable' arguments cannot be passed "
+            "simultaneously to with_polymorphic()"
+        )
+
     if _existing_alias:
         assert _existing_alias.mapper is primary_mapper
         classes = util.to_set(classes)

--- a/test/orm/inheritance/test_with_poly.py
+++ b/test/orm/inheritance/test_with_poly.py
@@ -1,4 +1,5 @@
 from sqlalchemy import and_
+from sqlalchemy import exc
 from sqlalchemy import or_
 from sqlalchemy import testing
 from sqlalchemy.orm import create_session
@@ -14,6 +15,21 @@ from ._poly_fixtures import Boss
 from ._poly_fixtures import Engineer
 from ._poly_fixtures import Manager
 from ._poly_fixtures import Person
+
+
+class WithPolymorphicAPITest(_Polymorphic, _PolymorphicFixtureBase):
+    def test_no_use_flat_and_aliased(self):
+        sess = create_session()
+
+        subq = sess.query(Person).subquery()
+
+        testing.assert_raises_message(
+            exc.ArgumentError,
+            "the 'flat' and 'selectable' arguments cannot be passed "
+            "simultaneously to with_polymorphic()",
+            with_polymorphic, Person, [Engineer],
+            selectable=subq, flat=True
+        )
 
 
 class _WithPolymorphicBase(_PolymorphicFixtureBase):

--- a/test/orm/inheritance/test_with_poly.py
+++ b/test/orm/inheritance/test_with_poly.py
@@ -27,8 +27,11 @@ class WithPolymorphicAPITest(_Polymorphic, _PolymorphicFixtureBase):
             exc.ArgumentError,
             "the 'flat' and 'selectable' arguments cannot be passed "
             "simultaneously to with_polymorphic()",
-            with_polymorphic, Person, [Engineer],
-            selectable=subq, flat=True
+            with_polymorphic,
+            Person,
+            [Engineer],
+            selectable=subq,
+            flat=True,
         )
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
Hi, 
This is a proposed fix for Issue #4212 

When the selectable argument is passed to with_polymorphic it is already aliased. Therefore an argument error should be raised if flat is also True. I have added an if statement to the with_polymorphic function, that raises an Argument Error if selectable is none/False AND if flat=True. I have also included a test.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

Kind Regards,

Ramon
