### PR TITLE
self.columns containing None prevent from attaching an index

### DIFF
--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -2908,7 +2908,8 @@ class ColumnCollectionMixin(object):
 
             # issue #3411 - don't do the per-column auto-attach if some of the
             # columns are specified as strings.
-            has_string_cols = set(self._pending_colargs).difference(col_objs)
+            has_string_cols = set([colarg for colarg in self._pending_colargs
+                                   if colarg is not None]).difference(col_objs)
             if not has_string_cols:
 
                 def _col_attached(column, table):


### PR DESCRIPTION
if for instance this is declared
Index(__tablename__+'_ctry_distinct_on_idx', Country, Start, End, ScenarioType, desc('rsrc_created'))
the desc('rsrc_created') will generate a None in the self.columns which will result when evaluating difference for attaching an index
to {None} instead of set() in the _check_attach
has_string_cols = set(self._pending_colargs).difference(col_objs) 
has_string_cols = {None} will not trigger a _col_attached
Thank you

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
