### PR TITLE
switch to future.select() in engine/default.py to prevent warning

### DIFF
--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -26,6 +26,7 @@ from .. import pool
 from .. import processors
 from .. import types as sqltypes
 from .. import util
+from .. import future
 from ..sql import compiler
 from ..sql import expression
 from ..sql.elements import quoted_name
@@ -377,7 +378,7 @@ class DefaultDialect(interfaces.Dialect):
 
         def check_unicode(test):
             statement = cast_to(
-                expression.select([test]).compile(dialect=self)
+                future.select(test).compile(dialect=self)
             )
             try:
                 cursor = connection.connection.cursor()


### PR DESCRIPTION
Fixes #5295

### Description
Switch from old `expression.select()` to the new `future.select()` in SQLAlchemy own internal code to prevent the constant warnings coming from SQLAlchemy itself.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
