### PR TITLE
add 'schema' parameter to table(...)

### DIFF
--- a/doc/build/changelog/unreleased_13/5309.rst
+++ b/doc/build/changelog/unreleased_13/5309.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: usecase, sql
+    :tickets: 5309
+
+    Added a ".schema" parameter to the :func:`_expression.table` construct,
+    allowing ad-hoc table expressions to also include a schema name.
+    Pull request courtesy Dylan Modesitt.

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -1962,9 +1962,7 @@ class TableClause(Immutable, FromClause):
         if schema is not None:
             self.schema = schema
         if kw:
-            raise exc.ArgumentError(
-                "Unsupported argument(s): %s" % list(kw)
-            )
+            raise exc.ArgumentError("Unsupported argument(s): %s" % list(kw))
 
     def _refresh_for_new_column(self, column):
         pass

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -1945,7 +1945,8 @@ class TableClause(Immutable, FromClause):
 
         :param columns: A collection of :func:`_expression.column` constructs.
 
-        :param **kw: Additional keyword arguments where ``schema`` can be passed.
+        :param **kw: Additional keyword arguments where ``schema`` can be
+         passed.
 
         """
 
@@ -1962,7 +1963,7 @@ class TableClause(Immutable, FromClause):
             self.schema = schema
         if kw:
             raise exc.ArgumentError(
-                "Unsupported argument(s): %s" % ",".join(kw)
+                "Unsupported argument(s): %s" % list(kw)
             )
 
     def _refresh_for_new_column(self, column):

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -1878,9 +1878,9 @@ class FromGrouping(GroupedElement, FromClause):
 class TableClause(Immutable, FromClause):
     """Represents a minimal "table" construct.
 
-    This is a lightweight table object that has only a name and a
+    This is a lightweight table object that has only a name, a
     collection of columns, which are typically produced
-    by the :func:`_expression.column` function::
+    by the :func:`_expression.column` function, and a schema::
 
         from sqlalchemy import table, column
 
@@ -1925,7 +1925,7 @@ class TableClause(Immutable, FromClause):
     _autoincrement_column = None
     """No PK or default support so no autoincrement column."""
 
-    def __init__(self, name, *columns):
+    def __init__(self, name, *columns, **kw):
         """Produce a new :class:`_expression.TableClause`.
 
         The object returned is an instance of :class:`_expression.TableClause`
@@ -1938,9 +1938,14 @@ class TableClause(Immutable, FromClause):
            be imported from the plain ``sqlalchemy`` namespace like any
            other SQL element.
 
+        .. versionchanged:: 1.3.17 :func:`_expression.table` can now
+           accept a ``schema`` argument.
+
         :param name: Name of the table.
 
         :param columns: A collection of :func:`_expression.column` constructs.
+
+        :param **kw: Additional keyword arguments where ``schema`` can be passed.
 
         """
 
@@ -1951,6 +1956,14 @@ class TableClause(Immutable, FromClause):
         self.foreign_keys = set()
         for c in columns:
             self.append_column(c)
+
+        schema = kw.pop("schema", None)
+        if schema is not None:
+            self.schema = schema
+        if kw:
+            raise exc.ArgumentError(
+                "Unsupported argument(s): %s" % ",".join(kw)
+            )
 
     def _refresh_for_new_column(self, column):
         pass

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -4448,6 +4448,80 @@ class SchemaTest(fixtures.TestBase, AssertsCompiledSQL):
             "(:rem_id, :datatype_id, :value)",
         )
 
+    def test_schema_lowercase_select(self):
+        # test that "schema" works correctly when passed to table
+        t1 = table("foo", column("a"), column("b"), schema="bar")
+        self.assert_compile(
+            select([t1]).select_from(t1),
+            "SELECT bar.foo.a, bar.foo.b FROM bar.foo",
+        )
+
+    def test_schema_lowercase_select_alias(self):
+        # test alias behavior
+        t1 = table("foo", schema="bar")
+        self.assert_compile(
+            select(["*"]).select_from(t1.alias("t")),
+            "SELECT * FROM bar.foo AS t",
+        )
+
+    def test_schema_lowercase_select_labels(self):
+        # test "schema" with extended_labels
+        t1 = table(
+            "baz",
+            column("id", Integer),
+            column("name", String),
+            column("meta", String),
+            schema="here",
+        )
+
+        self.assert_compile(
+            select([t1]).select_from(t1).apply_labels(),
+            "SELECT here.baz.id AS here_baz_id, here.baz.name AS "
+            "here_baz_name, here.baz.meta AS here_baz_meta FROM here.baz",
+        )
+
+    def test_schema_lowercase_select_subquery(self):
+        # test schema plays well with subqueries
+        t1 = table(
+            "yetagain",
+            column("anotherid", Integer),
+            column("anothername", String),
+            schema="here",
+        )
+        s = (
+            text("select id, name from user")
+            .columns(id=Integer, name=String)
+            .subquery()
+        )
+        stmt = select([t1.c.anotherid]).select_from(
+            t1.join(s, t1.c.anotherid == s.c.id)
+        )
+        compiled = stmt.compile()
+        eq_(
+            compiled._create_result_map(),
+            {
+                "anotherid": (
+                    "anotherid",
+                    (
+                        t1.c.anotherid,
+                        "anotherid",
+                        "anotherid",
+                        "here_yetagain_anotherid",
+                    ),
+                    t1.c.anotherid.type,
+                )
+            },
+        )
+
+    def test_schema_lowercase_invalid(self):
+        assert_raises_message(
+            exc.ArgumentError,
+            r"Unsupported argument\(s\): \['not_a_schema'\]",
+            table,
+            "foo",
+            not_a_schema="bar",
+        )
+
 
 class CorrelateTest(fixtures.TestBase, AssertsCompiledSQL):
     __dialect__ = "default"

--- a/test/sql/test_text.py
+++ b/test/sql/test_text.py
@@ -40,13 +40,6 @@ table2 = table(
     "myothertable", column("otherid", Integer), column("othername", String)
 )
 
-table3 = table(
-    "yetagain",
-    column("anotherid", Integer),
-    column("anothername", String),
-    schema="here"
-)
-
 
 class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
     __dialect__ = "default"
@@ -194,28 +187,6 @@ class SelectCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
             ),
             "SELECT t.myid, t.name, t.description, foo.f FROM mytable AS t, "
             "(select f from bar where lala=heyhey) foo WHERE foo.f = t.id",
-        )
-
-    def test_select_composition_nine(self):
-        # test that "schema" works correctly when passed to table
-        t1 = table("foo", schema="bar")
-        self.assert_compile(
-            select([
-                    literal_column("column1 as foobar"),
-                    literal_column("column2 as hoho"),
-                ],
-                from_obj=t1
-            ),
-            "SELECT column1 as foobar, column2 as hoho FROM bar.foo"
-        )
-
-    def test_select_composition_ten(self):
-        # test that "schema" doesn't interfier with non schema tables
-        # or aliases.
-        t1 = table("foo", schema="bar")
-        self.assert_compile(
-            select(["*"]).select_from(t1.alias("t")),
-            "SELECT * FROM bar.foo AS t"
         )
 
     def test_select_bundle_columns(self):
@@ -537,32 +508,6 @@ class AsFromTest(fixtures.TestBase, AssertsCompiledSQL):
         eq_(t.selected_columns.b.type._type_affinity, Integer)
         eq_(t.selected_columns.c.type._type_affinity, String)
 
-    def test_schema_subquery(self):
-        # schema plays well with subqueries
-        t = (
-            text("select id, name from user")
-            .columns(id=Integer, name=String)
-            .subquery()
-        )
-        stmt = select([table3.c.anotherid]).select_from(
-            table3.join(t, table3.c.anotherid == t.c.id)
-        )
-        compiled = stmt.compile()
-        eq_(
-            compiled._create_result_map(), {
-                "anotherid": (
-                    "anotherid",
-                    (
-                        table3.c.anotherid,
-                        "anotherid",
-                        "anotherid",
-                        "here_yetagain_anotherid"
-                    ),
-                    table3.c.anotherid.type
-                )
-            }
-        )
-
     def _xy_table_fixture(self):
         m = MetaData()
         t = Table("t", m, Column("x", Integer), Column("y", Integer))
@@ -727,15 +672,6 @@ class TextErrorsTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def test_from(self):
         self._test(select([table1.c.myid]).select_from, "mytable", "mytable")
-
-    def test_table_kw(self):
-        assert_raises_message(
-            exc.ArgumentError,
-            r"Unsupported argument\(s\): \['not_a_schema'\]",
-            table,
-            "foo",
-            not_a_schema="bar"
-        )
 
 
 class OrderByLabelResolutionTest(fixtures.TestBase, AssertsCompiledSQL):

--- a/test/sql/test_text.py
+++ b/test/sql/test_text.py
@@ -200,11 +200,11 @@ class SelectCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
         # test that "schema" works correctly when passed to table
         t1 = table("foo", schema="bar")
         self.assert_compile(
-                select([
+            select([
                     literal_column("column1 as foobar"),
                     literal_column("column2 as hoho"),
                 ],
-                from_obj=t1,
+                from_obj=t1
             ),
             "SELECT column1 as foobar, column2 as hoho FROM bar.foo"
         )
@@ -215,7 +215,7 @@ class SelectCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
         t1 = table("foo", schema="bar")
         self.assert_compile(
             select(["*"]).select_from(t1.alias("t")),
-           "SELECT * FROM bar.foo AS t"
+            "SELECT * FROM bar.foo AS t"
         )
 
     def test_select_bundle_columns(self):
@@ -731,7 +731,7 @@ class TextErrorsTest(fixtures.TestBase, AssertsCompiledSQL):
     def test_table_kw(self):
         assert_raises_message(
             exc.ArgumentError,
-            r"Unsupported argument\(s\): not_a_schema",
+            r"Unsupported argument\(s\): \['not_a_schema'\]",
             table,
             "foo",
             not_a_schema="bar"

--- a/test/sql/test_text.py
+++ b/test/sql/test_text.py
@@ -200,7 +200,8 @@ class SelectCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
         # test that "schema" works correctly when passed to table
         t1 = table("foo", schema="bar")
         self.assert_compile(
-            select([
+            select(
+                [
                     literal_column("column1 as foobar"),
                     literal_column("column2 as hoho"),
                 ],

--- a/test/sql/test_text.py
+++ b/test/sql/test_text.py
@@ -189,29 +189,6 @@ class SelectCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
             "(select f from bar where lala=heyhey) foo WHERE foo.f = t.id",
         )
 
-    def test_select_composition_nine(self):
-        # test that "schema" works correctly when passed to table
-        t1 = table("foo", schema="bar")
-        self.assert_compile(
-            select(
-                [
-                    literal_column("column1 as foobar"),
-                    literal_column("column2 as hoho"),
-                ],
-                from_obj=t1
-            ),
-            "SELECT column1 as foobar, column2 as hoho FROM bar.foo"
-        )
-
-    def test_select_composition_ten(self):
-        # test that "schema" doesn't interfier with non schema tables
-        # or aliases.
-        t1 = table("foo", schema="bar")
-        self.assert_compile(
-            select(["*"]).select_from(t1.alias("t")),
-            "SELECT * FROM bar.foo AS t"
-        )
-
     def test_select_bundle_columns(self):
         self.assert_compile(
             select(


### PR DESCRIPTION
A first pass at #5309 

### Description
Adds `**kw` to `TableClause` to support `schema` being passed to `table`, and tests these changes.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**

___

I am new to this project - Please let me know if I should add more or different tests or change the implementation (like assert that `schema` is an instance of `utils.text_type`) - or anything bigger. I plan on seeing this PR through if possible - thanks!
