### PR TITLE
warn in case of dialect without driver

### DIFF
--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -655,16 +655,27 @@ class Numeric(_LookupExpressionAdapter, TypeEngine):
                 # we're a "numeric", DBAPI will give us Decimal directly
                 return None
             else:
-                util.warn(
-                    "Dialect %s+%s does *not* support Decimal "
-                    "objects natively, and SQLAlchemy must "
-                    "convert from floating point - rounding "
-                    "errors and other issues may occur. Please "
-                    "consider storing Decimal numbers as strings "
-                    "or integers on this platform for lossless "
-                    "storage." % (dialect.name, dialect.driver)
-                )
-
+                if hasattr(dialect, 'driver'):
+                    util.warn(
+                        "Dialect %s+%s does *not* support Decimal "
+                        "objects natively, and SQLAlchemy must "
+                        "convert from floating point - rounding "
+                        "errors and other issues may occur. Please "
+                        "consider storing Decimal numbers as strings "
+                        "or integers on this platform for lossless "
+                        "storage." % (dialect.name, dialect.driver)
+                    )
+                else:
+                    util.warn(
+                        "Dialect %s does *not* support Decimal "
+                        "objects natively, and SQLAlchemy must "
+                        "convert from floating point - rounding "
+                        "errors and other issues may occur. Please "
+                        "consider storing Decimal numbers as strings "
+                        "or integers on this platform for lossless "
+                        "storage." % dialect.name
+                    )
+                    
                 # we're a "numeric", DBAPI returns floats, convert.
                 return processors.to_decimal_processor_factory(
                     decimal.Decimal,


### PR DESCRIPTION
When using for example cratedb (http://crate.io) the dialect comes without driver, thus the util.warn-call which wants to print the dialect-driver-name fails. Which that change, in case of no driver, is just warns the way it was maybe planned.

<!-- Provide a general summary of your proposed changes in the Title field above -->
detection if driver available by if-clause 
### Description
<!-- Describe your changes in detail -->
if hassatr driver ==> use it in warning (the old way)
if not ==> just print the (old) warning but omitting the driver-name
### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #5322` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
