### PR TITLE
Folds two identical exception handlers into a single one

### DIFF
--- a/lib/sqlalchemy/orm/base.py
+++ b/lib/sqlalchemy/orm/base.py
@@ -313,11 +313,7 @@ def object_state(instance):
 def _inspect_mapped_object(instance):
     try:
         return instance_state(instance)
-        # TODO: whats the py-2/3 syntax to catch two
-        # different kinds of exceptions at once ?
-    except exc.UnmappedClassError:
-        return None
-    except exc.NO_STATE:
+    except (exc.UnmappedClassError,) + exc.NO_STATE:
         return None
 
 

--- a/lib/sqlalchemy/orm/exc.py
+++ b/lib/sqlalchemy/orm/exc.py
@@ -196,9 +196,7 @@ def _safe_cls_name(cls):
 def _default_unmapped(base, cls):
     try:
         mappers = base.manager_of_class(cls).mappers
-    except NO_STATE:
-        mappers = {}
-    except TypeError:
+    except (TypeError,) + NO_STATE:
         mappers = {}
     name = _safe_cls_name(cls)
 


### PR DESCRIPTION
Fixes a `TODO` that searches for py2/3 compatible syntax to match multiple exception types.

### Description

Merges the two exception clauses using the syntax that exists for both Python 2 and 3 as per the exception handling tutorials ([Python 2](https://docs.python.org/2/tutorial/errors.html#handling-exceptions), [Python 3](https://docs.python.org/3/tutorial/errors.html#handling-exceptions))

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
