### PR TITLE
added docstring about expire_on_commit for #5243

### DIFF
--- a/doc/build/errors.rst
+++ b/doc/build/errors.rst
@@ -748,7 +748,7 @@ Mitigation of this error is via two general techniques:
     :ref:`loading_toplevel` - detailed documentation on eager loading and other
     relationship-oriented loading techniques
     :ref:`session_committing` - background on session commit
-    :ref:`session_expire` - background on attrifbute expiry
+    :ref:`session_expire` - background on attribute expiry
 
 
 .. _error_7s2a:

--- a/doc/build/errors.rst
+++ b/doc/build/errors.rst
@@ -734,6 +734,11 @@ Mitigation of this error is via two general techniques:
   special directives like the :func:`.raiseload` option can ensure that
   systems don't call upon lazy loading when its not expected.
 
+Please note: the default setting of :paramref:`_sa.orm.session.Session.expire_on_commit`
+is `True`, which means SQLAlchemy will expire the instance and all loaded
+attributes when a `commit` occurs. When this happens, SQLAlchemy will need to
+query the database to refresh the instance and attributes.
+  
   .. seealso::
 
     :ref:`loading_toplevel` - detailed documentation on eager loading and other

--- a/doc/build/errors.rst
+++ b/doc/build/errors.rst
@@ -734,15 +734,21 @@ Mitigation of this error is via two general techniques:
   special directives like the :func:`.raiseload` option can ensure that
   systems don't call upon lazy loading when its not expected.
 
-Please note: the default setting of :paramref:`_sa.orm.session.Session.expire_on_commit`
-is `True`, which means SQLAlchemy will expire the instance and all loaded
-attributes when a `commit` occurs. When this happens, SQLAlchemy will need to
-query the database to refresh the instance and attributes.
-  
+  .. note:
+
+    The default setting of :paramref:`_sa.orm.session.Session.expire_on_commit`
+    is ``True``, which means SQLAlchemy will expire the instance and all loaded
+    attributes when a ``commit`` occurs. When this happens, SQLAlchemy will need to
+    query the database to refresh the instance and attributes.
+
+    See the section :ref:`session_committing` for further background on this.
+
   .. seealso::
 
     :ref:`loading_toplevel` - detailed documentation on eager loading and other
     relationship-oriented loading techniques
+    :ref:`session_committing` - background on session commit
+    :ref:`session_expire` - background on attrifbute expiry
 
 
 .. _error_7s2a:


### PR DESCRIPTION
### Description
docstring

### Checklist
This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed

Instead of clarifying section 2 (as suggested in #5243), I added a new paragraph as this is related to both section 1 & 2.

I tried to keep this as generic as possible.

I can't get docs to build right, so I do have a concern about this link:

   :paramref:`_sa.orm.session.Session.expire_on_commit`

I think that is the correct formatting, but wanted to call attention to it.