### PR TITLE
Fix query string escaping in engine URLs (Fixes #5341)

### DIFF
--- a/lib/sqlalchemy/engine/url.py
+++ b/lib/sqlalchemy/engine/url.py
@@ -96,7 +96,7 @@ class URL(object):
             keys = list(self.query)
             keys.sort()
             s += "?" + "&".join(
-                "%s=%s" % (k, element)
+                "%s=%s" % (util.quote_plus(k), util.quote_plus(element))
                 for k in keys
                 for element in util.to_list(self.query[k])
             )

--- a/test/engine/test_parseconnect.py
+++ b/test/engine/test_parseconnect.py
@@ -147,6 +147,11 @@ class URLTest(fixtures.TestBase):
             "dialect://user:pass@host/db?arg1=param1&arg2=param2&arg2=param3",
         )
 
+        test_url = "dialect://user:pass@host/db?arg1%3D=param1&arg2=param+2"
+        u = url.make_url(test_url)
+        eq_(u.query, {"arg1=": "param1", "arg2": "param 2"})
+        eq_(str(u), test_url)
+
     def test_comparison(self):
         components = (
             "drivername",


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
The `URL` class correctly processes escaped characters in the query string when parsing an input URL, but does not apply the escaping when returning this URL back.

Example with `sqlite:///db.sqlite?foo%3dbar=baz`

```
>>> from sqlalchemy.engine.url import make_url
>>> url = make_url('sqlite:///db.sqlite?foo%3dbar=+baz')
>>> url.query
{'foo=bar': ' baz'}
>>> str(url)
'sqlite:///db.sqlite?foo=bar= baz
```

The expected result for the last expression should be:

```
>>> str(url)
'sqlite:///db.sqlite?foo%3Dbar=+baz
```

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
