### PR TITLE
Fix 'email_address' being typoed as 'email_addres' in two places

### DIFF
--- a/lib/sqlalchemy/orm/strategy_options.py
+++ b/lib/sqlalchemy/orm/strategy_options.py
@@ -1155,7 +1155,7 @@ def load_only(loadopt, *attrs):
 
         session.query(User, Address).join(User.addresses).options(
                     Load(User).load_only("name", "fullname"),
-                    Load(Address).load_only("email_addres")
+                    Load(Address).load_only("email_address")
                 )
 
 

--- a/test/orm/test_mapper.py
+++ b/test/orm/test_mapper.py
@@ -277,7 +277,7 @@ class MapperTest(_fixtures.FixtureTest, AssertsCompiledSQL):
         eq_(a.user_id, 7)
         eq_(a.id, 1)
         # email address auto-defers
-        assert "email_addres" not in a.__dict__
+        assert "email_address" not in a.__dict__
         eq_(a.email_address, "jack@bean.com")
 
     def test_column_not_present(self):


### PR DESCRIPTION
### Description
Fixes a typo that coincidentally occurs in a couple of different places - once in the docs, and another time in a test, where it was presumably neutering one of the test's assertions by making it always pass.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
