### PR TITLE
Add **kw support to DeclarativeMeta.__init__

### DIFF
--- a/lib/sqlalchemy/ext/declarative/api.py
+++ b/lib/sqlalchemy/ext/declarative/api.py
@@ -69,7 +69,7 @@ def has_inherited_table(cls):
 
 
 class DeclarativeMeta(type):
-    def __init__(cls, classname, bases, dict_):
+    def __init__(cls, classname, bases, dict_, **kw):
         if "_decl_class_registry" not in cls.__dict__:
             _as_declarative(cls, classname, cls.__dict__)
         type.__init__(cls, classname, bases, dict_)

--- a/test/ext/declarative/test_basic.py
+++ b/test/ext/declarative/test_basic.py
@@ -2131,6 +2131,20 @@ class DeclarativeTest(DeclarativeTestBase):
 
         assert not hasattr(Foo, "data_hybrid")
 
+    def test_kw_support_in_declarative_meta(self):
+        # This will not fail if DeclarativeMeta __init__ supports **kw
+
+        class BaseWithInitSubclass(Base):
+            __abstract__ = True
+
+            @classmethod
+            def __init_subclass__(cls, random_keyword_used_here=False, **kwargs):
+                pass
+
+        class User(BaseWithInitSubclass, random_keyword_used_here=True):
+            __tablename__ = "user"
+            id = Column(Integer, primary_key=True)
+
 
 def _produce_test(inline, stringbased):
     class ExplicitJoinTest(fixtures.MappedTest):

--- a/test/ext/declarative/test_basic.py
+++ b/test/ext/declarative/test_basic.py
@@ -2142,21 +2142,23 @@ class DeclarativeTest(DeclarativeTestBase):
                 super().__init_subclass__(**kw)
                 cls._set_random_keyword_used_here = random_keyword_used_here
 
-        # Including the kwarg in the class definition should work, i.e. not
-        # throw a TypeError
-        class User(BaseWithInitSubclass, random_keyword_used_here=True):
-            __tablename__ = "user"
-            id = Column(Integer, primary_key=True)
-
         # Omitting the kwarg in the class definition should work, i.e. not throw
         # a TypeError
         class AnotherUser(BaseWithInitSubclass):
             __tablename__ = "another_user"
             id = Column(Integer, primary_key=True)
-        
-        if util.py36:
-            eq_(User._set_random_keyword_used_here, True)
-            eq_(AnotherUser._set_random_keyword_used_here, False)
+
+        if util.py3k:
+            # Including the kwarg in the class definition should work, i.e. not
+            # throw a TypeError
+            class User(BaseWithInitSubclass, random_keyword_used_here=True):
+                __tablename__ = "user"
+                id = Column(Integer, primary_key=True)
+
+            # Check to see if __init_subclass__ works in supported versions
+            if util.py36:
+                eq_(User._set_random_keyword_used_here, True)
+                eq_(AnotherUser._set_random_keyword_used_here, False)
 
 
 def _produce_test(inline, stringbased):

--- a/test/ext/declarative/test_basic.py
+++ b/test/ext/declarative/test_basic.py
@@ -2131,6 +2131,7 @@ class DeclarativeTest(DeclarativeTestBase):
 
         assert not hasattr(Foo, "data_hybrid")
 
+    @testing.requires.python3
     def test_kw_support_in_declarative_meta_init(self):
         # This will not fail if DeclarativeMeta __init__ supports **kw
 
@@ -2142,23 +2143,22 @@ class DeclarativeTest(DeclarativeTestBase):
                 super().__init_subclass__(**kw)
                 cls._set_random_keyword_used_here = random_keyword_used_here
 
-        # Omitting the kwarg in the class definition should work, i.e. not throw
-        # a TypeError
+        # Omitting the kwarg in the class definition should work, i.e. not
+        # throw a TypeError
         class AnotherUser(BaseWithInitSubclass):
             __tablename__ = "another_user"
             id = Column(Integer, primary_key=True)
 
-        if util.py3k:
-            # Including the kwarg in the class definition should work, i.e. not
-            # throw a TypeError
-            class User(BaseWithInitSubclass, random_keyword_used_here=True):
-                __tablename__ = "user"
-                id = Column(Integer, primary_key=True)
+        # Including the kwarg in the class definition should work, i.e.
+        # not throw a TypeError
+        class User(BaseWithInitSubclass, random_keyword_used_here=True):
+            __tablename__ = "user"
+            id = Column(Integer, primary_key=True)
 
-            # Check to see if __init_subclass__ works in supported versions
-            if util.py36:
-                eq_(User._set_random_keyword_used_here, True)
-                eq_(AnotherUser._set_random_keyword_used_here, False)
+        # Check to see if __init_subclass__ works in supported versions
+        if util.py36:
+            eq_(User._set_random_keyword_used_here, True)
+            eq_(AnotherUser._set_random_keyword_used_here, False)
 
 
 def _produce_test(inline, stringbased):

--- a/test/ext/declarative/test_basic.py
+++ b/test/ext/declarative/test_basic.py
@@ -2141,8 +2141,8 @@ class DeclarativeTest(DeclarativeTestBase):
             def __init_subclass__(cls, random_keyword_used_here=False, **kw):
                 pass
 
-        # Omitting the kwarg in the class definition should work, i.e. not throw
-        # a TypeError
+        # Including the kwarg in the class definition should work, i.e. not
+        # throw a TypeError
         class User(BaseWithInitSubclass, random_keyword_used_here=True):
             __tablename__ = "user"
             id = Column(Integer, primary_key=True)

--- a/test/ext/declarative/test_basic.py
+++ b/test/ext/declarative/test_basic.py
@@ -2139,7 +2139,8 @@ class DeclarativeTest(DeclarativeTestBase):
 
             @classmethod
             def __init_subclass__(cls, random_keyword_used_here=False, **kw):
-                pass
+                super().__init_subclass__(**kw)
+                cls._set_random_keyword_used_here = random_keyword_used_here
 
         # Including the kwarg in the class definition should work, i.e. not
         # throw a TypeError
@@ -2152,6 +2153,10 @@ class DeclarativeTest(DeclarativeTestBase):
         class AnotherUser(BaseWithInitSubclass):
             __tablename__ = "another_user"
             id = Column(Integer, primary_key=True)
+        
+        if util.py36:
+            eq_(User._set_random_keyword_used_here, True)
+            eq_(AnotherUser._set_random_keyword_used_here, False)
 
 
 def _produce_test(inline, stringbased):

--- a/test/ext/declarative/test_basic.py
+++ b/test/ext/declarative/test_basic.py
@@ -2131,18 +2131,26 @@ class DeclarativeTest(DeclarativeTestBase):
 
         assert not hasattr(Foo, "data_hybrid")
 
-    def test_kw_support_in_declarative_meta(self):
+    def test_kw_support_in_declarative_meta_init(self):
         # This will not fail if DeclarativeMeta __init__ supports **kw
 
         class BaseWithInitSubclass(Base):
             __abstract__ = True
 
             @classmethod
-            def __init_subclass__(cls, random_keyword_used_here=False, **kwargs):
+            def __init_subclass__(cls, random_keyword_used_here=False, **kw):
                 pass
 
+        # Omitting the kwarg in the class definition should work, i.e. not throw
+        # a TypeError
         class User(BaseWithInitSubclass, random_keyword_used_here=True):
             __tablename__ = "user"
+            id = Column(Integer, primary_key=True)
+
+        # Omitting the kwarg in the class definition should work, i.e. not throw
+        # a TypeError
+        class AnotherUser(BaseWithInitSubclass):
+            __tablename__ = "another_user"
             id = Column(Integer, primary_key=True)
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

Add `**kw` to the signature of `DeclarativeMeta.__init__`.  This is inline with the metaclass `init()` specification in python 3.6+.  

A full discussion of this can be seen in #5357

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
