### PR TITLE
updated historical terms with modern equivalents

### DIFF
--- a/doc/build/orm/persistence_techniques.rst
+++ b/doc/build/orm/persistence_techniques.rst
@@ -591,21 +591,21 @@ More comprehensive rule-based class-level partitioning can be built by
 overriding the :meth:`.Session.get_bind` method.   Below we illustrate
 a custom :class:`.Session` which delivers the following rules:
 
-1. Flush operations are delivered to the engine named ``master``.
+1. Flush operations are delivered to the engine named ``leader``.
 
 2. Operations on objects that subclass ``MyOtherClass`` all
    occur on the ``other`` engine.
 
 3. Read operations for all other classes occur on a random
-   choice of the ``slave1`` or ``slave2`` database.
+   choice of the ``follower1`` or ``follower2`` database.
 
 ::
 
     engines = {
-        'master':create_engine("sqlite:///master.db"),
+        'leader':create_engine("sqlite:///leader.db"),
         'other':create_engine("sqlite:///other.db"),
-        'slave1':create_engine("sqlite:///slave1.db"),
-        'slave2':create_engine("sqlite:///slave2.db"),
+        'follower1':create_engine("sqlite:///follower1.db"),
+        'follower2':create_engine("sqlite:///follower2.db"),
     }
 
     from sqlalchemy.orm import Session, sessionmaker
@@ -616,10 +616,10 @@ a custom :class:`.Session` which delivers the following rules:
             if mapper and issubclass(mapper.class_, MyOtherClass):
                 return engines['other']
             elif self._flushing:
-                return engines['master']
+                return engines['leader']
             else:
                 return engines[
-                    random.choice(['slave1','slave2'])
+                    random.choice(['follower1','follower2'])
                 ]
 
 The above :class:`.Session` class is plugged in using the ``class_``

--- a/test/orm/inheritance/test_productspec.py
+++ b/test/orm/inheritance/test_productspec.py
@@ -49,13 +49,13 @@ class InheritTest(fixtures.MappedTest):
                 test_needs_autoincrement=True,
             ),
             Column(
-                "master_id",
+                "leader_id",
                 Integer,
                 ForeignKey("products.product_id"),
                 nullable=True,
             ),
             Column(
-                "slave_id",
+                "follower_id",
                 Integer,
                 ForeignKey("products.product_id"),
                 nullable=True,
@@ -112,16 +112,16 @@ class InheritTest(fixtures.MappedTest):
                 )
 
         class SpecLine(object):
-            def __init__(self, master=None, slave=None, quantity=1):
-                self.master = master
-                self.slave = slave
+            def __init__(self, leader=None, follower=None, quantity=1):
+                self.leader = leader
+                self.follower = follower
                 self.quantity = quantity
 
             def __repr__(self):
                 return "<%s %.01f %s>" % (
                     self.__class__.__name__,
                     self.quantity or 0.0,
-                    repr(self.slave),
+                    repr(self.follower),
                 )
 
         class Document(object):
@@ -153,19 +153,19 @@ class InheritTest(fixtures.MappedTest):
             SpecLine,
             specification_table,
             properties=dict(
-                master=relationship(
+                leader=relationship(
                     Assembly,
-                    foreign_keys=[specification_table.c.master_id],
-                    primaryjoin=specification_table.c.master_id
+                    foreign_keys=[specification_table.c.leader_id],
+                    primaryjoin=specification_table.c.leader_id
                     == products_table.c.product_id,
                     lazy="select",
                     backref=backref("specification"),
                     uselist=False,
                 ),
-                slave=relationship(
+                follower=relationship(
                     Product,
-                    foreign_keys=[specification_table.c.slave_id],
-                    primaryjoin=specification_table.c.slave_id
+                    foreign_keys=[specification_table.c.follower_id],
+                    primaryjoin=specification_table.c.follower_id
                     == products_table.c.product_id,
                     lazy="select",
                     uselist=False,
@@ -179,10 +179,10 @@ class InheritTest(fixtures.MappedTest):
         a1 = Assembly(name="a1")
 
         p1 = Product(name="p1")
-        a1.specification.append(SpecLine(slave=p1))
+        a1.specification.append(SpecLine(follower=p1))
 
         d1 = Detail(name="d1")
-        a1.specification.append(SpecLine(slave=d1))
+        a1.specification.append(SpecLine(follower=d1))
 
         session.add(a1)
         orig = repr(a1)
@@ -212,10 +212,10 @@ class InheritTest(fixtures.MappedTest):
             SpecLine,
             specification_table,
             properties=dict(
-                slave=relationship(
+                follower=relationship(
                     Product,
-                    foreign_keys=[specification_table.c.slave_id],
-                    primaryjoin=specification_table.c.slave_id
+                    foreign_keys=[specification_table.c.follower_id],
+                    primaryjoin=specification_table.c.follower_id
                     == products_table.c.product_id,
                     lazy="select",
                     uselist=False,
@@ -225,8 +225,8 @@ class InheritTest(fixtures.MappedTest):
 
         session = create_session()
 
-        s = SpecLine(slave=Product(name="p1"))
-        s2 = SpecLine(slave=Detail(name="d1"))
+        s = SpecLine(follower=Product(name="p1"))
+        s2 = SpecLine(follower=Detail(name="d1"))
         session.add(s)
         session.add(s2)
         orig = repr([s, s2])
@@ -256,23 +256,23 @@ class InheritTest(fixtures.MappedTest):
             SpecLine,
             specification_table,
             properties=dict(
-                master=relationship(
+                leader=relationship(
                     Assembly,
                     lazy="joined",
                     uselist=False,
-                    foreign_keys=[specification_table.c.master_id],
-                    primaryjoin=specification_table.c.master_id
+                    foreign_keys=[specification_table.c.leader_id],
+                    primaryjoin=specification_table.c.leader_id
                     == products_table.c.product_id,
                     backref=backref(
                         "specification", cascade="all, delete-orphan"
                     ),
                 ),
-                slave=relationship(
+                follower=relationship(
                     Product,
                     lazy="joined",
                     uselist=False,
-                    foreign_keys=[specification_table.c.slave_id],
-                    primaryjoin=specification_table.c.slave_id
+                    foreign_keys=[specification_table.c.follower_id],
+                    primaryjoin=specification_table.c.follower_id
                     == products_table.c.product_id,
                 ),
                 quantity=specification_table.c.quantity,
@@ -303,7 +303,7 @@ class InheritTest(fixtures.MappedTest):
         session = create_session()
 
         a1 = Assembly(name="a1")
-        a1.specification.append(SpecLine(slave=Detail(name="d1")))
+        a1.specification.append(SpecLine(follower=Detail(name="d1")))
         a1.documents.append(Document("doc1"))
         a1.documents.append(RasterDocument("doc2"))
         session.add(a1)
@@ -391,21 +391,21 @@ class InheritTest(fixtures.MappedTest):
             SpecLine,
             specification_table,
             properties=dict(
-                master=relationship(
+                leader=relationship(
                     Assembly,
                     lazy="joined",
                     uselist=False,
-                    foreign_keys=[specification_table.c.master_id],
-                    primaryjoin=specification_table.c.master_id
+                    foreign_keys=[specification_table.c.leader_id],
+                    primaryjoin=specification_table.c.leader_id
                     == products_table.c.product_id,
                     backref=backref("specification"),
                 ),
-                slave=relationship(
+                follower=relationship(
                     Product,
                     lazy="joined",
                     uselist=False,
-                    foreign_keys=[specification_table.c.slave_id],
-                    primaryjoin=specification_table.c.slave_id
+                    foreign_keys=[specification_table.c.follower_id],
+                    primaryjoin=specification_table.c.follower_id
                     == products_table.c.product_id,
                 ),
                 quantity=specification_table.c.quantity,
@@ -451,7 +451,7 @@ class InheritTest(fixtures.MappedTest):
         session = create_session()
 
         a1 = Assembly(name="a1")
-        a1.specification.append(SpecLine(slave=Detail(name="d1")))
+        a1.specification.append(SpecLine(follower=Detail(name="d1")))
         a1.documents.append(Document("doc1"))
         a1.documents.append(RasterDocument("doc2"))
         session.add(a1)


### PR DESCRIPTION
### Description
There were a few remnant uses of master/slave in the code and docs. The project previously made a decision to move away from them to use modern and inclusive terminology.

This PR does not cover a bug or necessitate a documented entry into the changelog, so an issue ticket was not created.

### Checklist
This pull request is:

- [x] A documentation / typographical error fix
- [x] A short code fix
- [ ] A new feature implementation
