### PR TITLE
Fixes: #5395 Add 'exists' to SQLite's reserved keywords

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -1334,6 +1334,7 @@ class SQLiteIdentifierPreparer(compiler.IdentifierPreparer):
             "escape",
             "except",
             "exclusive",
+            "exists",
             "explain",
             "false",
             "fail",

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -639,6 +639,7 @@ class DialectTest(
             Column("true", Integer),
             Column("false", Integer),
             Column("column", Integer),
+            Column("exists", Integer),
         )
         try:
             meta.create_all()


### PR DESCRIPTION
Fixes: https://github.com/sqlalchemy/sqlalchemy/issues/5395


**Have a nice day!**
