### PR TITLE
Improvements to test_computed_col_default_not_set

### DIFF
--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -1171,12 +1171,11 @@ class ComputedReflectionTest(fixtures.ComputedReflectionFixtureTest):
     def test_computed_col_default_not_set(self):
         insp = inspect(config.db)
 
-        cols = insp.get_columns("computed_column_table")
-        for col in cols:
-            if col["name"] == "with_default":
-                is_true("42" in col["default"])
-            elif not col["autoincrement"]:
-                is_(col["default"], None)
+        cols = insp.get_columns("computed_default_table")
+        col_data = {c["name"]: c for c in cols}
+        is_true("42" in col_data["with_default"]["default"])
+        is_(col_data["normal"]["default"], None)
+        is_(col_data["computed_col"]["default"], None)
 
     def test_get_column_returns_computed(self):
         insp = inspect(config.db)


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
- Update the test so it looks at computed_default_table instead of
  computed_column_table.
- Stop inspecting autoincrement; instead directly check for
  default/non-default values for the relevant columns.

Fixes: #5414 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
