### PR TITLE
Fixes: #4556 - Test that prevents passing a filter to Session.query when running an update

### DIFF
--- a/test/orm/test_update_delete.py
+++ b/test/orm/test_update_delete.py
@@ -607,6 +607,19 @@ class UpdateDeleteTest(fixtures.MappedTest):
         in_(jill, sess)
         not_in_(jane, sess)
 
+
+    def test_update_with_filter_statement(self):
+        """test for [ticket:4556] """
+
+        User = self.classes.User
+
+        sess = Session()
+        assert_raises(
+            exc.ArgumentError,
+            lambda: sess.query(User.name == 'filter').update({'name': 'update'})
+        )
+
+
     def test_update_without_load(self):
         User = self.classes.User
 


### PR DESCRIPTION
### Description
There was a bug in 1.3.8 that allowed passing a `BinaryExpression` to `Session().query`. I assume it was fixed in https://github.com/sqlalchemy/sqlalchemy/commit/3ab2364e78641c4f0e4b6456afc2cbed39b0d0e6 since now it raises: 
```
sqlalchemy.exc.ArgumentError: subject table for an INSERT, UPDATE or DELETE expected, got <sqlalchemy.sql.elements.BinaryExpression object at 0x7f3d90426370>.
```

I'm just adding a test that ensures the behavior. Fixes: [4556](https://github.com/sqlalchemy/sqlalchemy/issues/4556)

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
