### PR TITLE
added semicolon (;) to improve warning message clarity

### DIFF
--- a/lib/sqlalchemy/sql/ddl.py
+++ b/lib/sqlalchemy/sql/ddl.py
@@ -804,7 +804,7 @@ class SchemaDropper(DDLBase):
                 util.warn(
                     "Can't sort tables for DROP; an "
                     "unresolvable foreign key "
-                    "dependency exists between tables: %s, and backend does "
+                    "dependency exists between tables: %s; and backend does "
                     "not support ALTER.  To restore at least a partial sort, "
                     "apply use_alter=True to ForeignKey and "
                     "ForeignKeyConstraint "


### PR DESCRIPTION
### Description

Added a semicolon to improve the clarity of warning message.  I actually had a table named `backend`, and thought it was involved!

While updating the code, I noticed no test that directly tests for this warning message. There are tests for the `Can't sort tables for DROP;` prefix of this message and the `exc.CircularDependencyError`; and some tests for the `exc.CircularDependencyError` message itself. I couldn't find any test for this particular message though.  (Just thought I'd bring that up)

No issue created, because this is minor.
