### PR TITLE
resolves #3757

### DIFF
--- a/lib/sqlalchemy/orm/strategy_options.py
+++ b/lib/sqlalchemy/orm/strategy_options.py
@@ -1077,6 +1077,9 @@ def load_only(loadopt, *attrs):
                     Load(Address).load_only("email_address")
                 )
 
+     .. note:: This method will still load a :class:`_schema.Column` even
+        if the column property is defined with ``deferred=True``
+        for the :func:`.column_property` function.
 
     .. versionadded:: 0.9.0
 


### PR DESCRIPTION
I have included an additional note for the [load_only()](https://github.com/sqlalchemy/sqlalchemy/blob/master/lib/sqlalchemy/orm/strategy_options.py#L1050) function

<!-- Describe your changes in detail -->
As per issue #3757 a bit more clarity was asked to be put into the documentation for the load_only() function.
If a column property is defined as deferred=True and then that same column's name attribute is used as a parameter in the load_only() function, the function will still load this column. This implies that this function will undefer (or override) Columns with the deferred=True property, so that the column can still be loaded as the user specified.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
