### PR TITLE
Test execution_options on Query object before compilation

### DIFF
--- a/test/orm/test_events.py
+++ b/test/orm/test_events.py
@@ -2602,6 +2602,25 @@ class QueryEventsTest(
             )
         )
 
+    def test_before_compile_execution_options(self):
+        User = self.classes.User
+
+        @event.listens_for(query.Query, "before_compile", retval=True)
+        def _before_compile(query):
+            return query.execution_options(my_option=True)
+
+        opts = {}
+
+        @event.listens_for(testing.db, "before_cursor_execute")
+        def _before_cursor_execute(
+            conn, cursor, statement, parameters, context, executemany
+        ):
+            opts.update(context.execution_options)
+
+        sess = create_session(bind=testing.db, autocommit=False)
+        sess.query(User).first()
+        eq_(opts["my_option"], True)
+
 
 class RefreshFlushInReturningTest(fixtures.MappedTest):
     """test [ticket:3427].

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -12,7 +12,6 @@ from sqlalchemy import collate
 from sqlalchemy import column
 from sqlalchemy import desc
 from sqlalchemy import distinct
-from sqlalchemy import event
 from sqlalchemy import exc as sa_exc
 from sqlalchemy import exists
 from sqlalchemy import ForeignKey
@@ -5820,25 +5819,6 @@ class ExecutionOptionsTest(QueryTest):
         )
         q1 = sess.query(User).execution_options(**execution_options)
         q1.all()
-
-    def test_options_before_compile(self):
-        User = self.classes.User
-
-        @event.listens_for(Query, "before_compile", retval=True)
-        def _before_compile(query):
-            return query.execution_options(my_option=True)
-
-        opts = {}
-
-        @event.listens_for(testing.db, "before_cursor_execute")
-        def _before_cursor_execute(
-            conn, cursor, statement, parameters, context, executemany
-        ):
-            opts.update(context.execution_options)
-
-        sess = create_session(bind=testing.db, autocommit=False)
-        sess.query(User).first()
-        eq_(opts["my_option"], True)
 
 
 class BooleanEvalTest(fixtures.TestBase, testing.AssertsCompiledSQL):

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -5822,6 +5822,8 @@ class ExecutionOptionsTest(QueryTest):
         q1.all()
 
     def test_options_before_compile(self):
+        User = self.classes.User
+
         @event.listens_for(Query, "before_compile", retval=True)
         def _before_compile(query):
             return query.execution_options(my_option=True)
@@ -5835,7 +5837,7 @@ class ExecutionOptionsTest(QueryTest):
             opts.update(context.execution_options)
 
         sess = create_session(bind=testing.db, autocommit=False)
-        sess.query(column("1")).all()
+        sess.query(User).first()
         eq_(opts["my_option"], True)
 
 


### PR DESCRIPTION
 A test that checks if the execution options are being set on the Query object before compilation

### Description
Since Issue #4670 has been open there have changes to the execution mechanics that resolved it. I have just created a test case that will enable the issue to be closed.

This pull request is:

- [ X] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
Fixes: #4670 