### PR TITLE
Provide a more detailed error message for Query.join()

### DIFF
--- a/doc/build/changelog/unreleased_14/4428.rst
+++ b/doc/build/changelog/unreleased_14/4428.rst
@@ -1,5 +1,5 @@
 .. change::
-    :tags: bug, fairly easy, orm
+    :tags: bug, orm
     :tickets: 4428
 
     An :class:`.ArgumentError` with more detail is now raised if the target

--- a/doc/build/changelog/unreleased_14/4428.rst
+++ b/doc/build/changelog/unreleased_14/4428.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: bug, fairly easy, orm
+    :tickets: 4428
+
+    An :class:`.ArgumentError` with more detail is now raised if the target
+    parameter for :meth:`_query.Query.join` is set to an unmapped object.
+    Prior to this change a less detailed ``AttributeError`` was raised.
+    Pull request courtesy Ramon Williams.

--- a/lib/sqlalchemy/orm/context.py
+++ b/lib/sqlalchemy/orm/context.py
@@ -1292,7 +1292,15 @@ class ORMSelectCompileState(ORMCompileState, SelectState):
                     if of_type:
                         right = of_type
                     else:
-                        right = onclause.property.entity
+                        right = onclause.property
+
+                        try:
+                            right = right.entity
+                        except AttributeError as err:
+                            raise sa_exc.ArgumentError(
+                                "Join target %s does not refer to a "
+                                "mapped entity" % right
+                            ) from err
 
                 left = onclause._parententity
 

--- a/lib/sqlalchemy/orm/context.py
+++ b/lib/sqlalchemy/orm/context.py
@@ -1297,10 +1297,13 @@ class ORMSelectCompileState(ORMCompileState, SelectState):
                         try:
                             right = right.entity
                         except AttributeError as err:
-                            raise sa_exc.ArgumentError(
-                                "Join target %s does not refer to a "
-                                "mapped entity" % right
-                            ) from err
+                            util.raise_(
+                                sa_exc.ArgumentError(
+                                    "Join target %s does not refer to a "
+                                    "mapped entity" % right
+                                ),
+                                replace_context=err,
+                            )
 
                 left = onclause._parententity
 

--- a/test/orm/test_joins.py
+++ b/test/orm/test_joins.py
@@ -2231,6 +2231,19 @@ class JoinTest(QueryTest, AssertsCompiledSQL):
             sess.query(User).join(User.id == Address.user_id)._compile_context,
         )
 
+    def test_on_clause_no_right_side_two(self):
+        User = self.classes.User
+        Address = self.classes.Address
+        sess = create_session()
+
+        right = Address.user_id
+
+        assert_raises_message(
+            sa_exc.ArgumentError,
+            "Join target %s does not refer to a mapped entity" % right,
+            sess.query(User).join(Address.user_id)._compile_context,
+        )
+
     def test_select_from(self):
         """Test that the left edge of the join can be set reliably with
         select_from()."""


### PR DESCRIPTION
A more detailed error message for Query.Join() on an unmapped object.
### Description
A more detailed exception was requested for Query.Join() when the target parameter is set to an unmapped object such a Column. Previously an attribute error was raised because this type of object's property element does not have an entity.

Sidenote:  I did come across an issue in the test where it failed because _"Exception %r was correctly raised but did not set a cause, within context %r as its cause."_ To solve this I just had to use the "as" keyword on the Attribute Error exception. The documentation was fine for this but I couldn't see the full message because my Console cut it off. If you want i can write this somewhere in case anyone else comes across it.

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
Fixes: #4428