### PR TITLE
Test and fix return types for PostgreSQL custom range operators

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/ranges.py
+++ b/lib/sqlalchemy/dialects/postgresql/ranges.py
@@ -36,32 +36,32 @@ class RangeOperators(object):
                     other
                 )
             else:
-                return self.expr.op("<>")(other)
+                return self.expr.op("<>", is_comparison=True)(other)
 
         def contains(self, other, **kw):
             """Boolean expression. Returns true if the right hand operand,
             which can be an element or a range, is contained within the
             column.
             """
-            return self.expr.op("@>")(other)
+            return self.expr.op("@>", is_comparison=True)(other)
 
         def contained_by(self, other):
             """Boolean expression. Returns true if the column is contained
             within the right hand operand.
             """
-            return self.expr.op("<@")(other)
+            return self.expr.op("<@", is_comparison=True)(other)
 
         def overlaps(self, other):
             """Boolean expression. Returns true if the column overlaps
             (has points in common with) the right hand operand.
             """
-            return self.expr.op("&&")(other)
+            return self.expr.op("&&", is_comparison=True)(other)
 
         def strictly_left_of(self, other):
             """Boolean expression. Returns true if the column is strictly
             left of the right hand operand.
             """
-            return self.expr.op("<<")(other)
+            return self.expr.op("<<", is_comparison=True)(other)
 
         __lshift__ = strictly_left_of
 
@@ -69,7 +69,7 @@ class RangeOperators(object):
             """Boolean expression. Returns true if the column is strictly
             right of the right hand operand.
             """
-            return self.expr.op(">>")(other)
+            return self.expr.op(">>", is_comparison=True)(other)
 
         __rshift__ = strictly_right_of
 
@@ -77,19 +77,19 @@ class RangeOperators(object):
             """Boolean expression. Returns true if the range in the column
             does not extend right of the range in the operand.
             """
-            return self.expr.op("&<")(other)
+            return self.expr.op("&<", is_comparison=True)(other)
 
         def not_extend_left_of(self, other):
             """Boolean expression. Returns true if the range in the column
             does not extend left of the range in the operand.
             """
-            return self.expr.op("&>")(other)
+            return self.expr.op("&>", is_comparison=True)(other)
 
         def adjacent_to(self, other):
             """Boolean expression. Returns true if the range in the column
             is adjacent to the range in the operand.
             """
-            return self.expr.op("-|-")(other)
+            return self.expr.op("-|-", is_comparison=True)(other)
 
         def __add__(self, other):
             """Range expression. Returns the union of the two ranges.

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -2628,112 +2628,149 @@ class _RangeTypeCompilation(AssertsCompiledSQL, fixtures.TestBase):
         )
         cls.col = table.c.range
 
-    def _test_clause(self, colclause, expected):
+    def _test_clause(self, colclause, expected, type_):
         self.assert_compile(colclause, expected)
+        assert colclause.type is type_
 
     def test_where_equal(self):
         self._test_clause(
-            self.col == self._data_str, "data_table.range = %(range_1)s"
+            self.col == self._data_str,
+            "data_table.range = %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
 
     def test_where_not_equal(self):
         self._test_clause(
-            self.col != self._data_str, "data_table.range <> %(range_1)s"
+            self.col != self._data_str,
+            "data_table.range <> %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
 
     def test_where_is_null(self):
-        self._test_clause(self.col == None, "data_table.range IS NULL")
+        self._test_clause(
+            self.col == None, "data_table.range IS NULL", sqltypes.BOOLEANTYPE
+        )
 
     def test_where_is_not_null(self):
-        self._test_clause(self.col != None, "data_table.range IS NOT NULL")
+        self._test_clause(
+            self.col != None,
+            "data_table.range IS NOT NULL",
+            sqltypes.BOOLEANTYPE,
+        )
 
     def test_where_less_than(self):
         self._test_clause(
-            self.col < self._data_str, "data_table.range < %(range_1)s"
+            self.col < self._data_str,
+            "data_table.range < %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
 
     def test_where_greater_than(self):
         self._test_clause(
-            self.col > self._data_str, "data_table.range > %(range_1)s"
+            self.col > self._data_str,
+            "data_table.range > %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
 
     def test_where_less_than_or_equal(self):
         self._test_clause(
-            self.col <= self._data_str, "data_table.range <= %(range_1)s"
+            self.col <= self._data_str,
+            "data_table.range <= %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
 
     def test_where_greater_than_or_equal(self):
         self._test_clause(
-            self.col >= self._data_str, "data_table.range >= %(range_1)s"
+            self.col >= self._data_str,
+            "data_table.range >= %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
 
     def test_contains(self):
         self._test_clause(
             self.col.contains(self._data_str),
             "data_table.range @> %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
 
     def test_contained_by(self):
         self._test_clause(
             self.col.contained_by(self._data_str),
             "data_table.range <@ %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
 
     def test_overlaps(self):
         self._test_clause(
             self.col.overlaps(self._data_str),
             "data_table.range && %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
 
     def test_strictly_left_of(self):
         self._test_clause(
-            self.col << self._data_str, "data_table.range << %(range_1)s"
+            self.col << self._data_str,
+            "data_table.range << %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
         self._test_clause(
             self.col.strictly_left_of(self._data_str),
             "data_table.range << %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
 
     def test_strictly_right_of(self):
         self._test_clause(
-            self.col >> self._data_str, "data_table.range >> %(range_1)s"
+            self.col >> self._data_str,
+            "data_table.range >> %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
         self._test_clause(
             self.col.strictly_right_of(self._data_str),
             "data_table.range >> %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
 
     def test_not_extend_right_of(self):
         self._test_clause(
             self.col.not_extend_right_of(self._data_str),
             "data_table.range &< %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
 
     def test_not_extend_left_of(self):
         self._test_clause(
             self.col.not_extend_left_of(self._data_str),
             "data_table.range &> %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
 
     def test_adjacent_to(self):
         self._test_clause(
             self.col.adjacent_to(self._data_str),
             "data_table.range -|- %(range_1)s",
+            sqltypes.BOOLEANTYPE,
         )
 
     def test_union(self):
         self._test_clause(
-            self.col + self.col, "data_table.range + data_table.range"
+            self.col + self.col,
+            "data_table.range + data_table.range",
+            self.col.type,
         )
 
     def test_intersection(self):
         self._test_clause(
-            self.col * self.col, "data_table.range * data_table.range"
+            self.col * self.col,
+            "data_table.range * data_table.range",
+            self.col.type,
         )
 
     def test_different(self):
         self._test_clause(
-            self.col - self.col, "data_table.range - data_table.range"
+            self.col - self.col,
+            "data_table.range - data_table.range",
+            self.col.type,
         )
 
 


### PR DESCRIPTION
### Description
This adds a failing test and fix for the return types of PostgreSQL-specific range operators, which return booleans in the database but were exposed to SQLAlchemy as if they returned range objects.

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
- [x] A short code fix

  - Fix is just adding `is_comparison=True` to some custom operators.
  - This should fix #5476, though the tests are at a lower-level than the problem reported there, in order to involve just compilation rather than execution; the previous discrepancy with the [return types documented by PostgreSQL](https://www.postgresql.org/docs/12/functions-range.html) (and strongly implied by the operator names) is still pretty obvious.

- [ ] A new feature implementation

**Have a nice day!**
