### PR TITLE
Clean python UUID imports

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -992,6 +992,7 @@ E.g.::
 from collections import defaultdict
 import datetime as dt
 import re
+from uuid import UUID as _python_UUID
 
 from . import array as _array
 from . import hstore as _hstore
@@ -1021,12 +1022,6 @@ from ...types import REAL
 from ...types import SMALLINT
 from ...types import TEXT
 from ...types import VARCHAR
-
-
-try:
-    from uuid import UUID as _python_UUID  # noqa
-except ImportError:
-    _python_UUID = None
 
 
 IDX_USING = re.compile(r"^(?:btree|hash|gist|gin|[\w_]+)$", re.I)
@@ -1302,11 +1297,6 @@ class UUID(sqltypes.TypeEngine):
          DBAPI.
 
          """
-        if as_uuid and _python_UUID is None:
-            raise NotImplementedError(
-                "This version of Python does not support "
-                "the native UUID type."
-            )
         self.as_uuid = as_uuid
 
     def bind_processor(self, dialect):

--- a/lib/sqlalchemy/dialects/postgresql/pg8000.py
+++ b/lib/sqlalchemy/dialects/postgresql/pg8000.py
@@ -69,6 +69,7 @@ of the :ref:`psycopg2 <psycopg2_isolation_level>` dialect:
 """  # noqa
 import decimal
 import re
+from uuid import UUID as _python_UUID
 
 from .base import _DECIMAL_TYPES
 from .base import _FLOAT_TYPES
@@ -84,12 +85,6 @@ from ... import processors
 from ... import types as sqltypes
 from ... import util
 from ...sql.elements import quoted_name
-
-
-try:
-    from uuid import UUID as _python_UUID  # noqa
-except ImportError:
-    _python_UUID = None
 
 
 class _PGNumeric(sqltypes.Numeric):

--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -466,6 +466,7 @@ from __future__ import absolute_import
 import decimal
 import logging
 import re
+from uuid import UUID as _python_UUID
 
 from .base import _DECIMAL_TYPES
 from .base import _FLOAT_TYPES
@@ -485,11 +486,6 @@ from ... import types as sqltypes
 from ... import util
 from ...engine import cursor as _cursor
 from ...util import collections_abc
-
-try:
-    from uuid import UUID as _python_UUID  # noqa
-except ImportError:
-    _python_UUID = None
 
 
 logger = logging.getLogger("sqlalchemy.dialects.postgresql")

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -33,7 +33,6 @@ from sqlalchemy import Unicode
 from sqlalchemy import util
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import array
-from sqlalchemy.dialects.postgresql import base
 from sqlalchemy.dialects.postgresql import DATERANGE
 from sqlalchemy.dialects.postgresql import HSTORE
 from sqlalchemy.dialects.postgresql import hstore
@@ -2134,14 +2133,6 @@ class UUIDTest(fixtures.TestBase):
     @testing.fails_on("postgresql+pg8000", "No support for UUID with ARRAY")
     def test_uuid_array(self, datatype, value1, value2, connection):
         self.test_round_trip(datatype, value1, value2, connection)
-
-    def test_no_uuid_available(self):
-        uuid_type = base._python_UUID
-        base._python_UUID = None
-        try:
-            assert_raises(NotImplementedError, postgresql.UUID, as_uuid=True)
-        finally:
-            base._python_UUID = uuid_type
 
 
 class HStoreTest(AssertsCompiledSQL, fixtures.TestBase):


### PR DESCRIPTION
Fixes: #5482
All supported python versions provide 'uuid' module.