### PR TITLE
Use pg_get_constraintdef for CHECK constraint reflection

### DIFF
--- a/doc/build/changelog/unreleased_12/4463.rst
+++ b/doc/build/changelog/unreleased_12/4463.rst
@@ -1,0 +1,8 @@
+.. change::
+   :tags: bug, postgresql
+   :tickets: 4463
+
+   Revised the query used when reflecting CHECK constraints to make use of the
+   ``pg_get_constraintdef`` function, as the ``consrc`` column is being
+   deprecated in PG 12.  Thanks to John A Stevenson for the tip.
+

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2940,7 +2940,7 @@ class PGDialect(default.DefaultDialect):
         CHECK_SQL = """
             SELECT
                 cons.conname as name,
-                cons.consrc as src
+                pg_get_constraintdef(cons.oid) as src
             FROM
                 pg_catalog.pg_constraint cons
             WHERE
@@ -2950,11 +2950,20 @@ class PGDialect(default.DefaultDialect):
 
         c = connection.execute(sql.text(CHECK_SQL), table_oid=table_oid)
 
+        # samples:
+        # "CHECK (((a > 1) AND (a < 5)))"
+        # "CHECK (((a = 1) OR ((a > 2) AND (a < 5))))"
+        def match_cons(src):
+            m = re.match(r"^CHECK *\(\((.+)\)\)$", src)
+            if not m:
+                util.warn("Could not parse CHECK constraint text: %r" % src)
+                return ""
+            return m.group(1)
+
         return [
-            {'name': name,
-             'sqltext': src[1:-1]}
+            {"name": name, "sqltext": match_cons(src)}
             for name, src in c.fetchall()
-            ]
+        ]
 
     def _load_enums(self, connection, schema=None):
         schema = schema or self.default_schema_name


### PR DESCRIPTION
Revised the query used when reflecting CHECK constraints to make use of the
``pg_get_constraintdef`` function, as the ``consrc`` column is being
deprecated in PG 12.  Thanks to John A Stevenson for the tip.

Fixes: #4463
Change-Id: Ie0ee9bdfddb0635db72b35c2e2e4b27f154162fd
(cherry picked from commit 377f12696bb1af17bb14f676a49ef21428d537d3)

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
