### PR TITLE
Add support for SQL Server filtered indexes

### DIFF
--- a/doc/build/changelog/unreleased_14/4966.rst
+++ b/doc/build/changelog/unreleased_14/4966.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: mssql, usecase
+    :tickets: 4966
+
+    The :meth:`.Dialect.get_indexes` will now reflect the filter definitions
+    for Partial Indexes / Filtered Indexes on the PostgreSQL and MSSQL
+    dialects. Pull request courtesy Ramon Williams.

--- a/doc/build/changelog/unreleased_14/4966.rst
+++ b/doc/build/changelog/unreleased_14/4966.rst
@@ -1,5 +1,5 @@
 .. change::
-    :tags: mssql, usecase
+    :tags: mssql, usecase, postgresql
     :tickets: 4966
 
     The :meth:`.Dialect.get_indexes` will now reflect the filter definitions

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -2711,7 +2711,8 @@ class MSDialect(default.DefaultDialect):
 
         rp = connection.execution_options(future_result=True).execute(
             sql.text(
-                "select ind.index_id, ind.is_unique, ind.name "
+                "select ind.index_id, ind.is_unique, ind.name, "
+                "ind.filter_definition "
                 "from sys.indexes as ind join sys.tables as tab on "
                 "ind.object_id=tab.object_id "
                 "join sys.schemas as sch on sch.schema_id=tab.schema_id "
@@ -2731,6 +2732,7 @@ class MSDialect(default.DefaultDialect):
                 "name": row["name"],
                 "unique": row["is_unique"] == 1,
                 "column_names": [],
+                "dialect_options": {"mssql_where": row["filter_definition"]},
             }
         rp = connection.execution_options(future_result=True).execute(
             sql.text(

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -2732,8 +2732,13 @@ class MSDialect(default.DefaultDialect):
                 "name": row["name"],
                 "unique": row["is_unique"] == 1,
                 "column_names": [],
-                "dialect_options": {"mssql_where": row["filter_definition"]},
             }
+
+            if row["filter_definition"] is not None:
+                indexes[row["index_id"]].setdefault("dialect_options", {})[
+                    "mssql_where"
+                ] = row["filter_definition"]
+
         rp = connection.execution_options(future_result=True).execute(
             sql.text(
                 "select ind_col.index_id, ind_col.object_id, col.name "

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3402,6 +3402,7 @@ class PGDialect(default.DefaultDialect):
                   ix.indisunique, ix.indexprs, ix.indpred,
                   a.attname, a.attnum, c.conrelid, ix.indkey::varchar,
                   ix.indoption::varchar, i.reloptions, am.amname,
+                  pg_get_expr(ix.indpred, ix.indrelid),
                   %s as indnkeyatts
               FROM
                   pg_class t
@@ -3452,6 +3453,7 @@ class PGDialect(default.DefaultDialect):
                 idx_option,
                 options,
                 amname,
+                filter_definition,
                 indnkeyatts,
             ) = row
 
@@ -3526,6 +3528,9 @@ class PGDialect(default.DefaultDialect):
                 if amname and amname != "btree":
                     index["amname"] = amname
 
+                if filter_definition:
+                    index["postgresql_where"] = filter_definition
+
         result = []
         for name, idx in indexes.items():
             entry = {
@@ -3548,6 +3553,10 @@ class PGDialect(default.DefaultDialect):
                 entry.setdefault("dialect_options", {})[
                     "postgresql_using"
                 ] = idx["amname"]
+            if "postgresql_where" in idx:
+                entry.setdefault("dialect_options", {})[
+                    "postgresql_where"
+                ] = idx["postgresql_where"]
             result.append(entry)
         return result
 


### PR DESCRIPTION
A user requested that the filter definition for Filtered Indexes (MSSQL) are reflected. This change will reflect that. The presence of these filtered definitions will mean that the index is filtered. I have also made this change for PostgreSQL (where they are called Partial Indexes).

### Description
I have added a new column in the SELECT clause in Dialect.get_indexes() that will show the filter definition for the index if it exists. This will then be reflected under the dialect_options as postgresql_where or mssql_where depending on the dialect.

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
Fixes: #4966 