### PR TITLE
Make discriminator column used by ConcreteBase configurable

### DIFF
--- a/lib/sqlalchemy/ext/declarative/api.py
+++ b/lib/sqlalchemy/ext/declarative/api.py
@@ -445,7 +445,8 @@ class ConcreteBase(object):
         By default the name of the discriminator column used in the
         :func:`.polymorphic_union` will be ``type``. This name might clash with
         a column in one of your mapped tables. For that reason, the name of
-        the discriminator can be configured by setting the ``_concrete_discriminator_name`` attribute.
+        the discriminator can be configured by setting the
+        ``_concrete_discriminator_name`` attribute.
 
         Example::
 
@@ -478,7 +479,10 @@ class ConcreteBase(object):
         if m.with_polymorphic:
             return
 
-        discriminator_name = _get_immediate_cls_attr(cls, "_concrete_discriminator_name") or "type"
+        discriminator_name = (
+            _get_immediate_cls_attr(cls, "_concrete_discriminator_name")
+            or "type"
+        )
 
         mappers = list(m.self_and_descendants)
         pjoin = cls._create_polymorphic_union(mappers, discriminator_name)
@@ -627,7 +631,10 @@ class AbstractConcreteBase(ConcreteBase):
             if mn is not None:
                 mappers.append(mn)
 
-        discriminator_name = _get_immediate_cls_attr(cls, "_concrete_discriminator_name") or "type"
+        discriminator_name = (
+            _get_immediate_cls_attr(cls, "_concrete_discriminator_name")
+            or "type"
+        )
         pjoin = cls._create_polymorphic_union(mappers, discriminator_name)
 
         # For columns that were declared on the class, these
@@ -647,7 +654,7 @@ class AbstractConcreteBase(ConcreteBase):
 
         def mapper_args():
             args = m_args()
-            args["polymorphic_on"] = pjoin.c[discriminator_name]            
+            args["polymorphic_on"] = pjoin.c[discriminator_name]
             return args
 
         to_map.mapper_args_fn = mapper_args

--- a/lib/sqlalchemy/ext/declarative/api.py
+++ b/lib/sqlalchemy/ext/declarative/api.py
@@ -15,6 +15,7 @@ from .base import _as_declarative
 from .base import _declarative_constructor
 from .base import _DeferredMapperConfig
 from .base import _del_attribute
+from .base import _get_immediate_cls_attr
 from .clsregistry import _class_resolver
 from ... import exc
 from ... import inspection
@@ -438,6 +439,20 @@ class ConcreteBase(object):
                             'polymorphic_identity':'manager',
                             'concrete':True}
 
+
+    .. note::
+
+        By default the name of the discriminator column used in the
+        :func:`.polymorphic_union` will be ``type``. This name might clash with
+        a column in one of your mapped tables. For that reason, the name of
+        the discriminator can be configured by setting the ``_concrete_discriminator_name`` attribute.
+
+        Example::
+
+            class Employee(ConcreteBase, Base):
+                _concrete_discriminator_name = '_concrete_discriminator'
+
+
     .. seealso::
 
         :class:`.AbstractConcreteBase`
@@ -448,12 +463,12 @@ class ConcreteBase(object):
     """
 
     @classmethod
-    def _create_polymorphic_union(cls, mappers):
+    def _create_polymorphic_union(cls, mappers, discriminator_name):
         return polymorphic_union(
             OrderedDict(
                 (mp.polymorphic_identity, mp.local_table) for mp in mappers
             ),
-            "type",
+            discriminator_name,
             "pjoin",
         )
 
@@ -463,10 +478,12 @@ class ConcreteBase(object):
         if m.with_polymorphic:
             return
 
+        discriminator_name = _get_immediate_cls_attr(cls, "_concrete_discriminator_name") or "type"
+
         mappers = list(m.self_and_descendants)
-        pjoin = cls._create_polymorphic_union(mappers)
+        pjoin = cls._create_polymorphic_union(mappers, discriminator_name)
         m._set_with_polymorphic(("*", pjoin))
-        m._set_polymorphic_on(pjoin.c.type)
+        m._set_polymorphic_on(pjoin.c[discriminator_name])
 
 
 class AbstractConcreteBase(ConcreteBase):
@@ -609,7 +626,9 @@ class AbstractConcreteBase(ConcreteBase):
             mn = _mapper_or_none(klass)
             if mn is not None:
                 mappers.append(mn)
-        pjoin = cls._create_polymorphic_union(mappers)
+
+        discriminator_name = _get_immediate_cls_attr(cls, "_concrete_discriminator_name") or "type"
+        pjoin = cls._create_polymorphic_union(mappers, discriminator_name)
 
         # For columns that were declared on the class, these
         # are normally ignored with the "__no_table__" mapping,
@@ -628,7 +647,7 @@ class AbstractConcreteBase(ConcreteBase):
 
         def mapper_args():
             args = m_args()
-            args["polymorphic_on"] = pjoin.c.type
+            args["polymorphic_on"] = pjoin.c[discriminator_name]            
             return args
 
         to_map.mapper_args_fn = mapper_args

--- a/test/ext/declarative/test_inheritance.py
+++ b/test/ext/declarative/test_inheritance.py
@@ -2043,9 +2043,7 @@ class ConcreteExtensionConfigTest(
         """test #5513"""
 
         class Employee(AbstractConcreteBase, Base):
-            _concrete_discriminator_name = (
-                "_alternative_concrete_discriminator"
-            )
+            _concrete_discriminator_name = "_alt_discriminator"
             employee_id = Column(Integer, primary_key=True)
 
         class Manager(Employee):
@@ -2068,10 +2066,10 @@ class ConcreteExtensionConfigTest(
         self.assert_compile(
             Session().query(Employee),
             "SELECT pjoin.employee_id AS pjoin_employee_id, "
-            "pjoin._alternative_concrete_discriminator AS pjoin__alternative_concrete_discriminator "
+            "pjoin._alt_discriminator AS pjoin__alt_discriminator "
             "FROM (SELECT engineer.employee_id AS employee_id, "
-            "'engineer' AS _alternative_concrete_discriminator "
-            "FROM engineer UNION ALL SELECT manager.employee_id AS employee_id, "
-            "'manager' AS _alternative_concrete_discriminator "
+            "'engineer' AS _alt_discriminator FROM engineer "
+            "UNION ALL SELECT manager.employee_id AS employee_id, "
+            "'manager' AS _alt_discriminator "
             "FROM manager) AS pjoin",
         )


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Allow using `_concrete_discriminator_name` attribute on `ConcreteBase` to configure the name of the discriminator column used when querying polymorphically.

I am not familiar with the codebase, so I'm not sure how to test this.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
