### PR TITLE
Make AsyncConnection._sync_connection() async for flexiblility

### DIFF
--- a/test/ext/asyncio/test_engine_py3k.py
+++ b/test/ext/asyncio/test_engine_py3k.py
@@ -69,11 +69,11 @@ class AsyncEngineTest(EngineFixture):
     async def test_connection_not_started(self, async_engine):
 
         conn = async_engine.connect()
-        testing.assert_raises_message(
+        await assert_raises_message_async(
             asyncio_exc.AsyncContextNotStarted,
             "AsyncConnection context has not been started and "
             "object has not been awaited.",
-            conn.begin,
+            conn.begin(),
         )
 
     @async_test


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

This PR makes `AsyncConnection._sync_connection()` async, even though itself in SQLAlchemy doesn't have to be async, but this allows subclasses to be able to easily blend in async code before the actual database interactions.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
- [x] A short code fix
    * Fixes #5530
- [ ] A new feature implementation

**Have a nice day!**
