### PR TITLE
Fix a mis-reference in create_async_engine().

### DIFF
--- a/lib/sqlalchemy/ext/asyncio/engine.py
+++ b/lib/sqlalchemy/ext/asyncio/engine.py
@@ -31,7 +31,7 @@ def create_async_engine(*arg, **kw):
     """
 
     if kw.get("server_side_cursors", False):
-        raise exc.AsyncMethodRequired(
+        raise async_exc.AsyncMethodRequired(
             "Can't set server_side_cursors for async engine globally; "
             "use the connection.stream() method for an async "
             "streaming result set"

--- a/test/ext/asyncio/test_engine_py3k.py
+++ b/test/ext/asyncio/test_engine_py3k.py
@@ -135,6 +135,16 @@ class AsyncEngineTest(EngineFixture):
                 trans.rollback(),
             )
 
+    @async_test
+    async def test_create_async_engine_server_side_cursor(self, async_engine):
+        testing.assert_raises_message(
+            asyncio_exc.AsyncMethodRequired,
+            "Can't set server_side_cursors for async engine globally",
+            create_async_engine,
+            testing.db.url,
+            server_side_cursors=True,
+        )
+
 
 class AsyncResultTest(EngineFixture):
     @testing.combinations(


### PR DESCRIPTION
### Description

`AsyncMethodRequired` is actually from `sqlalchemy.ext.asyncio.exc`, so here it should be referenced as `async_exc.AsyncMethodRequired`, instead of `exc.AsyncMethodRequired`.


### Checklist

This pull request is:

- [x] A short code fix
    Fixes #5529
    Was a part of #5531

**Have a nice day!**
