### PR TITLE
Fix AsyncEngine connect() bug when pool is exhausted

### DIFF
--- a/lib/sqlalchemy/util/queue.py
+++ b/lib/sqlalchemy/util/queue.py
@@ -202,7 +202,7 @@ class Queue:
 
 
 class AsyncAdaptedQueue:
-    await_ = await_fallback
+    await_ = staticmethod(await_fallback)
 
     def __init__(self, maxsize=0, use_lifo=False):
         if use_lifo:

--- a/test/ext/asyncio/test_engine_py3k.py
+++ b/test/ext/asyncio/test_engine_py3k.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from sqlalchemy import Column
 from sqlalchemy import delete
 from sqlalchemy import exc
@@ -133,6 +135,16 @@ class AsyncEngineTest(EngineFixture):
                 "AsyncTransaction context has not been started "
                 "and object has not been awaited.",
                 trans.rollback(),
+            )
+
+    @async_test
+    async def test_pool_exhausted(self, async_engine):
+        engine = create_async_engine(
+            testing.db.url, pool_size=1, max_overflow=0, pool_timeout=0.1,
+        )
+        async with engine.connect():
+            await assert_raises_message_async(
+                asyncio.TimeoutError, "", engine.connect(),
             )
 
 


### PR DESCRIPTION
### Description

Decorating the referenced `await_fallback` with `staticmethod` would stop `AsyncAdaptedQueue.await_` from being treated as a bound method.

### Checklist

This pull request is:

- [x] A short code fix
    Fixes #5546

**Have a nice day!**
