### PR TITLE
Support for multiple hosts in PostgreSQL connection string

### DIFF
--- a/doc/build/changelog/unreleased_13/4392.rst
+++ b/doc/build/changelog/unreleased_13/4392.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: engine, postgresql, usecase
+    :tickets: 4392
+
+    A :class:`.URL` connection now supports multiple hosts for PostgreSQL. Any
+    query that contains multiple hosts will now group the hosts as a string
+    instead of a tuple of strings. Pull request courtesy Ramon Williams.

--- a/lib/sqlalchemy/engine/url.py
+++ b/lib/sqlalchemy/engine/url.py
@@ -755,6 +755,13 @@ def _parse_rfc1738_args(name):
             query = None
         components["query"] = query
 
+        if components["query"]:
+            if "host" in components["query"]:
+                if not isinstance(components["query"]["host"], str):
+                    components["query"]["host"] = ",".join(
+                        components["query"]["host"]
+                    )
+
         if components["username"] is not None:
             components["username"] = _rfc_1738_unquote(components["username"])
 

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -158,6 +158,25 @@ class DialectTest(fixtures.TestBase):
         eq_(cargs, [])
         eq_(cparams, {"host": "somehost", "any_random_thing": "yes"})
 
+    def test_psycopg2_nonempty_connection_string_w_query_two(self):
+        dialect = psycopg2_dialect.dialect()
+        url_string = "postgresql://USER:PASS@/DB?host=hostA"
+        u = url.make_url(url_string)
+        cargs, cparams = dialect.create_connect_args(u)
+        eq_(cargs, [])
+        eq_(cparams["host"], "hostA")
+
+    def test_psycopg2_nonempty_connection_string_w_query_three(self):
+        dialect = psycopg2_dialect.dialect()
+        url_string = (
+            "postgresql://USER:PASS@/DB"
+            "?host=hostA:portA&host=hostB&host=hostC"
+        )
+        u = url.make_url(url_string)
+        cargs, cparams = dialect.create_connect_args(u)
+        eq_(cargs, [])
+        eq_(cparams["host"], "hostA:portA,hostB,hostC")
+
 
 class ExecuteManyMode(object):
     __only_on__ = "postgresql+psycopg2"


### PR DESCRIPTION
Provide support for multiple hosts in the PostgreSQL connection string.

### Description
A user requested for SQLAlchemy to support multiple hosts within a PostgreSQL URL string. The proposed fix allows this. In the event that the url contains multiple hosts the proposed code will convert the query["hosts"] tuple into a single string. This allows the hosts to then get converted into a valid dsn variable in the psycopg2 connect function.

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
Fixes: #4392 
