### PR TITLE
Remove whitespace before colon

### DIFF
--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -848,7 +848,7 @@ class ArrayIndexOpTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         col2 = Column("y", Integer())
 
         self.assert_compile(
-            col[col2 : col2 + 5], "x[y:y + :y_1]", checkparams={"y_1": 5}
+            col[col2: col2 + 5], "x[y:y + :y_1]", checkparams={"y_1": 5}
         )
 
     def test_getindex_literal_zeroind(self):
@@ -884,7 +884,7 @@ class ArrayIndexOpTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         col2 = Column("y", Integer())
 
         self.assert_compile(
-            col[col2 : col2 + 5],
+            col[col2: col2 + 5],
             "x[y + :y_1:y + :y_2 + :param_1]",
             checkparams={"y_1": 1, "y_2": 5, "param_1": 1},
         )


### PR DESCRIPTION
Removed whitespace placed before the colons.
This was fixed in accordance with PEP8.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [X] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
