### PR TITLE
Fix anti-pattern to fit E711

### DIFF
--- a/test/ext/test_associationproxy.py
+++ b/test/ext/test_associationproxy.py
@@ -2230,11 +2230,11 @@ class ComparatorTest(fixtures.MappedTest, AssertsCompiledSQL):
         Singular = self.classes.Singular
 
         self._equivalent(
-            self.session.query(User).filter(User.singular_value == None),
+            self.session.query(User).filter(User.singular_value is None),
             self.session.query(User).filter(
                 or_(
-                    User.singular.has(Singular.value == None),
-                    User.singular == None,
+                    User.singular.has(Singular.value is None),
+                    User.singular is None,
                 )
             ),
         )


### PR DESCRIPTION
Modified '==' to 'is' to fit PEP8 E711.
https://www.flake8rules.com/rules/E711.html

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
