### PR TITLE
Implement upsert for SQLite

### DIFF
--- a/doc/build/changelog/unreleased_14/4010.rst
+++ b/doc/build/changelog/unreleased_14/4010.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: sqlite, usecase
+    :tickets: 4010
+
+    Implemented DO NOTHING and DO UPDATE SET (Upsert) for the
+    INSERT.. ON CONFLICT Clause as understood by the SQLite dialect.
+    Pull request courtesy Ramon Williams.

--- a/lib/sqlalchemy/dialects/sqlite/__init__.py
+++ b/lib/sqlalchemy/dialects/sqlite/__init__.py
@@ -24,7 +24,8 @@ from .base import TEXT
 from .base import TIME
 from .base import TIMESTAMP
 from .base import VARCHAR
-
+from .dml import Insert
+from .dml import insert
 
 # default dialect
 base.dialect = dialect = pysqlite.dialect
@@ -47,5 +48,7 @@ __all__ = (
     "TIMESTAMP",
     "VARCHAR",
     "REAL",
+    "Insert",
+    "insert",
     "dialect",
 )

--- a/lib/sqlalchemy/dialects/sqlite/dml.py
+++ b/lib/sqlalchemy/dialects/sqlite/dml.py
@@ -1,0 +1,231 @@
+# Copyright (C) 2005-2020 the SQLAlchemy authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of SQLAlchemy and is released under
+# the MIT License: http://www.opensource.org/licenses/mit-license.php
+
+from ... import util
+from ...sql import schema
+from ...sql.base import _generative
+from ...sql.dml import Insert as StandardInsert
+from ...sql.elements import ClauseElement
+from ...sql.expression import alias
+from ...util.langhelpers import public_factory
+
+
+__all__ = ("Insert", "insert")
+
+
+class Insert(StandardInsert):
+    """SQLite-specific implementation of INSERT.
+
+    Adds methods for SQLite-specific syntaxes such as ON CONFLICT.
+
+    The :class:`_sqlite.Insert` object is created using the
+    :func:`sqlalchemy.dialects.sqlite.insert` function.
+
+    .. versionadded:: 1.4
+
+    """
+
+    @util.memoized_property
+    def excluded(self):
+        """Provide the ``excluded`` namespace for an ON CONFLICT statement
+
+        SQLite's ON CONFLICT clause allows reference to the row that would
+        be inserted, known as ``excluded``.  This attribute provides
+        all columns in this row to be referenceable.
+
+        .. seealso::
+
+            :ref:`sqlite_insert_on_conflict` - example of how
+            to use :attr:`_expression.Insert.excluded`
+
+        """
+        return alias(self.table, name="excluded").columns
+
+    @_generative
+    def on_conflict_do_update(
+        self,
+        constraint=None,
+        index_elements=None,
+        index_where=None,
+        set_=None,
+        where=None,
+    ):
+        r"""
+        Specifies a DO UPDATE SET action for ON CONFLICT clause.
+
+        Either the ``constraint`` or ``index_elements`` argument is
+        required, but only one of these can be specified.
+
+        :param constraint:
+         The column name of a unique or primary key constraint on the table,
+         or the constraint object itself.
+
+        :param index_elements:
+         A sequence consisting of string column names, :class:`_schema.Column`
+         objects, or other column expression objects that will be used
+         to infer a target index.
+
+        :param index_where:
+         Additional WHERE criterion that can be used to infer a
+         conditional target index.
+
+        :param set\_:
+         Required argument. A dictionary or other mapping object
+         with column names as keys and expressions or literals as values,
+         specifying the ``SET`` actions to take.
+         If the target :class:`_schema.Column` specifies a ".
+         key" attribute distinct
+         from the column name, that key should be used.
+
+         .. warning:: This dictionary does **not** take into account
+            Python-specified default UPDATE values or generation functions,
+            e.g. those specified using :paramref:`_schema.Column.onupdate`.
+            These values will not be exercised for an ON CONFLICT style of
+            UPDATE, unless they are manually specified in the
+            :paramref:`.Insert.on_conflict_do_update.set_` dictionary.
+
+        :param where:
+         Optional argument. If present, can be a literal SQL
+         string or an acceptable expression for a ``WHERE`` clause
+         that restricts the rows affected by ``DO UPDATE SET``. Rows
+         not meeting the ``WHERE`` condition will not be updated
+         (effectively a ``DO NOTHING`` for those rows).
+
+         .. versionadded:: 1.4
+
+
+        .. seealso::
+
+            :ref:`sqlite_insert_on_conflict`
+
+        """
+        if isinstance(constraint, schema.UniqueConstraint) or isinstance(
+            constraint, schema.PrimaryKeyConstraint
+        ):
+            constraint = constraint.columns[0].name
+
+        self._post_values_clause = OnConflictDoUpdate(
+            constraint, index_elements, index_where, set_, where
+        )
+
+    @_generative
+    def on_conflict_do_nothing(
+        self, constraint=None, index_elements=None, index_where=None
+    ):
+        """
+        Specifies a DO NOTHING action for ON CONFLICT clause.
+
+        The ``constraint`` and ``index_elements`` arguments
+        are optional, but only one of these can be specified.
+
+        :param constraint:
+         The column name of a unique or primary key constraint on the table,
+         or the constraint object itself.
+
+        :param index_elements:
+         A sequence consisting of string column names, :class:`_schema.Column`
+         objects, or other column expression objects that will be used
+         to infer a target index.
+
+        :param index_where:
+         Additional WHERE criterion that can be used to infer a
+         conditional target index.
+
+         .. versionadded:: 1.4
+
+        .. seealso::
+
+            :ref:`sqlite_insert_on_conflict`
+
+        """
+
+        if isinstance(constraint, schema.UniqueConstraint) or isinstance(
+            constraint, schema.PrimaryKeyConstraint
+        ):
+            constraint = constraint.columns[0].name
+
+        self._post_values_clause = OnConflictDoNothing(
+            constraint, index_elements, index_where
+        )
+
+
+insert = public_factory(
+    Insert, ".dialects.sqlite.insert", ".dialects.sqlite.Insert"
+)
+
+
+class OnConflictClause(ClauseElement):
+    def __init__(self, constraint=None, index_elements=None, index_where=None):
+
+        if constraint is not None:
+            if not isinstance(constraint, util.string_types) and isinstance(
+                constraint, (schema.Index, schema.Constraint),
+            ):
+                constraint = getattr(constraint, "name") or constraint
+
+        if constraint is not None:
+            if index_elements is not None:
+                raise ValueError(
+                    "'constraint' and 'index_elements' are mutually exclusive"
+                )
+
+            if isinstance(constraint, util.string_types):
+                self.constraint_target = constraint
+                self.inferred_target_elements = None
+                self.inferred_target_whereclause = None
+            elif isinstance(constraint, schema.Index):
+                index_elements = constraint.expressions
+                index_where = constraint.dialect_options["sqlite"].get("where")
+            else:
+                index_elements = constraint.columns
+                index_where = constraint.dialect_options["sqlite"].get("where")
+
+        if index_elements is not None:
+            self.constraint_target = None
+            self.inferred_target_elements = index_elements
+            self.inferred_target_whereclause = index_where
+        elif constraint is None:
+            self.constraint_target = (
+                self.inferred_target_elements
+            ) = self.inferred_target_whereclause = None
+
+
+class OnConflictDoNothing(OnConflictClause):
+    __visit_name__ = "on_conflict_do_nothing"
+
+
+class OnConflictDoUpdate(OnConflictClause):
+    __visit_name__ = "on_conflict_do_update"
+
+    def __init__(
+        self,
+        constraint=None,
+        index_elements=None,
+        index_where=None,
+        set_=None,
+        where=None,
+    ):
+        super(OnConflictDoUpdate, self).__init__(
+            constraint=constraint,
+            index_elements=index_elements,
+            index_where=index_where,
+        )
+
+        if (
+            self.inferred_target_elements is None
+            and self.constraint_target is None
+        ):
+            raise ValueError(
+                "Either constraint or index_elements, "
+                "but not both, must be specified unless DO NOTHING"
+            )
+
+        if not isinstance(set_, dict) or not set_:
+            raise ValueError("set parameter must be a non-empty dictionary")
+        self.update_values_to_set = [
+            (key, value) for key, value in set_.items()
+        ]
+        self.update_whereclause = where

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -2688,7 +2688,7 @@ class RegexpTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
 class OnConflictTest(fixtures.TablesTest):
 
-    __only_on__ = "sqlite"
+    __only_on__ = ("sqlite >= 3.24.0",)
 
     @classmethod
     def define_tables(cls, metadata):

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -36,6 +36,7 @@ from sqlalchemy import types as sqltypes
 from sqlalchemy import UniqueConstraint
 from sqlalchemy import util
 from sqlalchemy.dialects.sqlite import base as sqlite
+from sqlalchemy.dialects.sqlite import insert
 from sqlalchemy.dialects.sqlite import pysqlite as pysqlite_dialect
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.schema import CreateTable
@@ -2683,3 +2684,542 @@ class RegexpTest(fixtures.TestBase, testing.AssertsCompiledSQL):
             self.table.c.myid.regexp_replace("pattern", "rep").compile,
             dialect=sqlite.dialect(),
         )
+
+
+class OnConflictTest(fixtures.TablesTest):
+
+    __only_on__ = "sqlite"
+
+    @classmethod
+    def define_tables(cls, metadata):
+        Table(
+            "users",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("name", String(50)),
+        )
+
+        class SpecialType(sqltypes.TypeDecorator):
+            impl = String
+
+            def process_bind_param(self, value, dialect):
+                return value + " processed"
+
+        Table(
+            "bind_targets",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("data", SpecialType()),
+        )
+
+        users_xtra = Table(
+            "users_xtra",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("name", String(50)),
+            Column("login_email", String(50)),
+            Column("lets_index_this", String(50)),
+        )
+        cls.unique_partial_index = schema.Index(
+            "idx_unique_partial_name",
+            users_xtra.c.name,
+            users_xtra.c.lets_index_this,
+            unique=True,
+            sqlite_where=users_xtra.c.lets_index_this == "unique_name",
+        )
+
+        cls.unique_constraint = schema.UniqueConstraint(
+            users_xtra.c.login_email, name="uq_login_email"
+        )
+        cls.bogus_index = schema.Index(
+            "idx_special_ops",
+            users_xtra.c.lets_index_this,
+            sqlite_where=users_xtra.c.lets_index_this > "m",
+        )
+
+    def test_bad_args(self):
+        assert_raises(
+            ValueError, insert(self.tables.users).on_conflict_do_update
+        )
+
+    def test_on_conflict_do_nothing(self):
+        users = self.tables.users
+
+        with testing.db.connect() as conn:
+            result = conn.execute(
+                insert(users).on_conflict_do_nothing(),
+                dict(id=1, name="name1"),
+            )
+            eq_(result.inserted_primary_key, (1,))
+
+            result = conn.execute(
+                insert(users).on_conflict_do_nothing(),
+                dict(id=1, name="name2"),
+            )
+            eq_(result.inserted_primary_key, (1,))
+
+            eq_(
+                conn.execute(users.select().where(users.c.id == 1)).fetchall(),
+                [(1, "name1")],
+            )
+
+    def test_on_conflict_do_nothing_connectionless(self, connection):
+        users = self.tables.users_xtra
+
+        result = connection.execute(
+            insert(users).on_conflict_do_nothing(constraint="login_email"),
+            dict(name="name1", login_email="email1"),
+        )
+        eq_(result.inserted_primary_key, (1,))
+
+        result = connection.execute(
+            insert(users).on_conflict_do_nothing(constraint="login_email"),
+            dict(name="name2", login_email="email1"),
+        )
+        eq_(result.inserted_primary_key, (1,))
+
+        eq_(
+            connection.execute(
+                users.select().where(users.c.id == 1)
+            ).fetchall(),
+            [(1, "name1", "email1", None)],
+        )
+
+    @testing.provide_metadata
+    def test_on_conflict_do_nothing_target(self):
+        users = self.tables.users
+
+        with testing.db.connect() as conn:
+            result = conn.execute(
+                insert(users).on_conflict_do_nothing(
+                    index_elements=users.primary_key.columns
+                ),
+                dict(id=1, name="name1"),
+            )
+            eq_(result.inserted_primary_key, (1,))
+
+            result = conn.execute(
+                insert(users).on_conflict_do_nothing(
+                    index_elements=users.primary_key.columns
+                ),
+                dict(id=1, name="name2"),
+            )
+            eq_(result.inserted_primary_key, (1,))
+
+            eq_(
+                conn.execute(users.select().where(users.c.id == 1)).fetchall(),
+                [(1, "name1")],
+            )
+
+    def test_on_conflict_do_update_one(self):
+        users = self.tables.users
+
+        with testing.db.connect() as conn:
+            conn.execute(users.insert(), dict(id=1, name="name1"))
+
+            i = insert(users)
+            i = i.on_conflict_do_update(
+                index_elements=[users.c.id], set_=dict(name=i.excluded.name)
+            )
+            result = conn.execute(i, dict(id=1, name="name1"))
+
+            eq_(result.inserted_primary_key, (1,))
+
+            eq_(
+                conn.execute(users.select().where(users.c.id == 1)).fetchall(),
+                [(1, "name1")],
+            )
+
+    def test_on_conflict_do_update_two(self):
+        users = self.tables.users
+
+        with testing.db.connect() as conn:
+            conn.execute(users.insert(), dict(id=1, name="name1"))
+
+            i = insert(users)
+            i = i.on_conflict_do_update(
+                index_elements=[users.c.id],
+                set_=dict(id=i.excluded.id, name=i.excluded.name),
+            )
+
+            result = conn.execute(i, dict(id=1, name="name2"))
+            eq_(result.inserted_primary_key, (1,))
+
+            eq_(
+                conn.execute(users.select().where(users.c.id == 1)).fetchall(),
+                [(1, "name2")],
+            )
+
+    def test_on_conflict_do_update_three(self):
+        users = self.tables.users
+
+        with testing.db.connect() as conn:
+            conn.execute(users.insert(), dict(id=1, name="name1"))
+
+            i = insert(users)
+            i = i.on_conflict_do_update(
+                index_elements=users.primary_key.columns,
+                set_=dict(name=i.excluded.name),
+            )
+            result = conn.execute(i, dict(id=1, name="name3"))
+            eq_(result.inserted_primary_key, (1,))
+
+            eq_(
+                conn.execute(users.select().where(users.c.id == 1)).fetchall(),
+                [(1, "name3")],
+            )
+
+    def test_on_conflict_do_update_four(self):
+        users = self.tables.users
+
+        with testing.db.connect() as conn:
+            conn.execute(users.insert(), dict(id=1, name="name1"))
+
+            i = insert(users)
+            i = i.on_conflict_do_update(
+                index_elements=users.primary_key.columns,
+                set_=dict(id=i.excluded.id, name=i.excluded.name),
+            ).values(id=1, name="name4")
+
+            result = conn.execute(i)
+            eq_(result.inserted_primary_key, (1,))
+
+            eq_(
+                conn.execute(users.select().where(users.c.id == 1)).fetchall(),
+                [(1, "name4")],
+            )
+
+    def test_on_conflict_do_update_five(self):
+        users = self.tables.users
+
+        with testing.db.connect() as conn:
+            conn.execute(users.insert(), dict(id=1, name="name1"))
+
+            i = insert(users)
+            i = i.on_conflict_do_update(
+                index_elements=users.primary_key.columns,
+                set_=dict(id=10, name="I'm a name"),
+            ).values(id=1, name="name4")
+
+            result = conn.execute(i)
+            eq_(result.inserted_primary_key, (1,))
+
+            eq_(
+                conn.execute(
+                    users.select().where(users.c.id == 10)
+                ).fetchall(),
+                [(10, "I'm a name")],
+            )
+
+    def test_on_conflict_do_update_multivalues(self):
+        users = self.tables.users
+
+        with testing.db.connect() as conn:
+            conn.execute(users.insert(), dict(id=1, name="name1"))
+            conn.execute(users.insert(), dict(id=2, name="name2"))
+
+            i = insert(users)
+            i = i.on_conflict_do_update(
+                index_elements=users.primary_key.columns,
+                set_=dict(name="updated"),
+                where=(i.excluded.name != "name12"),
+            ).values(
+                [
+                    dict(id=1, name="name11"),
+                    dict(id=2, name="name12"),
+                    dict(id=3, name="name13"),
+                    dict(id=4, name="name14"),
+                ]
+            )
+
+            result = conn.execute(i)
+            eq_(result.inserted_primary_key, (None,))
+
+            eq_(
+                conn.execute(users.select().order_by(users.c.id)).fetchall(),
+                [(1, "updated"), (2, "name2"), (3, "name13"), (4, "name14")],
+            )
+
+    def _exotic_targets_fixture(self, conn):
+        users = self.tables.users_xtra
+
+        conn.execute(
+            insert(users),
+            dict(
+                id=1,
+                name="name1",
+                login_email="name1@gmail.com",
+                lets_index_this="not",
+            ),
+        )
+        conn.execute(
+            users.insert(),
+            dict(
+                id=2,
+                name="name2",
+                login_email="name2@gmail.com",
+                lets_index_this="not",
+            ),
+        )
+
+        eq_(
+            conn.execute(users.select().where(users.c.id == 1)).fetchall(),
+            [(1, "name1", "name1@gmail.com", "not")],
+        )
+
+    def test_on_conflict_do_update_exotic_targets_two(self):
+        users = self.tables.users_xtra
+
+        with testing.db.connect() as conn:
+            self._exotic_targets_fixture(conn)
+            # try primary key constraint: cause an upsert on unique id column
+            i = insert(users)
+            i = i.on_conflict_do_update(
+                index_elements=users.primary_key.columns,
+                set_=dict(
+                    name=i.excluded.name, login_email=i.excluded.login_email
+                ),
+            )
+            result = conn.execute(
+                i,
+                dict(
+                    id=1,
+                    name="name2",
+                    login_email="name1@gmail.com",
+                    lets_index_this="not",
+                ),
+            )
+            eq_(result.inserted_primary_key, (1,))
+
+            eq_(
+                conn.execute(users.select().where(users.c.id == 1)).fetchall(),
+                [(1, "name2", "name1@gmail.com", "not")],
+            )
+
+    def test_on_conflict_do_update_exotic_targets_three(self):
+        users = self.tables.users_xtra
+
+        with testing.db.connect() as conn:
+            self._exotic_targets_fixture(conn)
+            # try unique constraint: cause an upsert on target
+            # login_email, not id
+            i = insert(users)
+            i = i.on_conflict_do_update(
+                constraint=self.unique_constraint,
+                set_=dict(
+                    id=i.excluded.id,
+                    name=i.excluded.name,
+                    login_email=i.excluded.login_email,
+                ),
+            )
+            # note: lets_index_this value totally ignored in SET clause.
+            result = conn.execute(
+                i,
+                dict(
+                    id=42,
+                    name="nameunique",
+                    login_email="name2@gmail.com",
+                    lets_index_this="unique",
+                ),
+            )
+            eq_(result.inserted_primary_key, (42,))
+
+            eq_(
+                conn.execute(
+                    users.select().where(
+                        users.c.login_email == "name2@gmail.com"
+                    )
+                ).fetchall(),
+                [(42, "nameunique", "name2@gmail.com", "not")],
+            )
+
+    def test_on_conflict_do_update_exotic_targets_four(self):
+        users = self.tables.users_xtra
+
+        with testing.db.connect() as conn:
+            self._exotic_targets_fixture(conn)
+            # try unique constraint by name: cause an
+            # upsert on target login_email, not id
+            i = insert(users)
+            i = i.on_conflict_do_update(
+                constraint="login_email",
+                set_=dict(
+                    id=i.excluded.id,
+                    name=i.excluded.name,
+                    login_email=i.excluded.login_email,
+                ),
+            )
+            # note: lets_index_this value totally ignored in SET clause.
+
+            result = conn.execute(
+                i,
+                dict(
+                    id=43,
+                    name="nameunique2",
+                    login_email="name2@gmail.com",
+                    lets_index_this="unique",
+                ),
+            )
+            eq_(result.inserted_primary_key, (43,))
+
+            eq_(
+                conn.execute(
+                    users.select().where(
+                        users.c.login_email == "name2@gmail.com"
+                    )
+                ).fetchall(),
+                [(43, "nameunique2", "name2@gmail.com", "not")],
+            )
+
+    def test_on_conflict_do_update_exotic_targets_four_no_pk(self):
+        users = self.tables.users_xtra
+
+        with testing.db.connect() as conn:
+            self._exotic_targets_fixture(conn)
+            # try unique constraint by name: cause an
+            # upsert on target login_email, not id
+            i = insert(users)
+            i = i.on_conflict_do_update(
+                index_elements=[users.c.login_email],
+                set_=dict(
+                    id=i.excluded.id,
+                    name=i.excluded.name,
+                    login_email=i.excluded.login_email,
+                ),
+            )
+
+            conn.execute(i, dict(name="name3", login_email="name1@gmail.com"))
+
+            eq_(
+                conn.execute(users.select().where(users.c.id == 1)).fetchall(),
+                [],
+            )
+
+            eq_(
+                conn.execute(users.select().order_by(users.c.id)).fetchall(),
+                [
+                    (2, "name2", "name2@gmail.com", "not"),
+                    (3, "name3", "name1@gmail.com", "not"),
+                ],
+            )
+
+    def test_on_conflict_do_update_exotic_targets_five(self):
+        users = self.tables.users_xtra
+
+        with testing.db.connect() as conn:
+            self._exotic_targets_fixture(conn)
+            # try bogus index
+            i = insert(users)
+
+            i = i.on_conflict_do_update(
+                index_elements=self.bogus_index.columns,
+                index_where=self.bogus_index.dialect_options["sqlite"][
+                    "where"
+                ],
+                set_=dict(
+                    name=i.excluded.name, login_email=i.excluded.login_email
+                ),
+            )
+
+            assert_raises(
+                exc.OperationalError,
+                conn.execute,
+                i,
+                dict(
+                    id=1,
+                    name="namebogus",
+                    login_email="bogus@gmail.com",
+                    lets_index_this="bogus",
+                ),
+            )
+
+    def test_on_conflict_do_update_exotic_targets_six(self):
+        users = self.tables.users_xtra
+
+        with testing.db.connect() as conn:
+            conn.execute(
+                insert(users),
+                dict(
+                    id=1,
+                    name="name1",
+                    login_email="mail1@gmail.com",
+                    lets_index_this="unique_name",
+                ),
+            )
+            i = insert(users)
+            i = i.on_conflict_do_update(
+                index_elements=self.unique_partial_index.columns,
+                index_where=self.unique_partial_index.dialect_options[
+                    "sqlite"
+                ]["where"],
+                set_=dict(
+                    name=i.excluded.name, login_email=i.excluded.login_email
+                ),
+            )
+
+            conn.execute(
+                i,
+                [
+                    dict(
+                        name="name1",
+                        login_email="mail2@gmail.com",
+                        lets_index_this="unique_name",
+                    )
+                ],
+            )
+
+            eq_(
+                conn.execute(users.select()).fetchall(),
+                [(1, "name1", "mail2@gmail.com", "unique_name")],
+            )
+
+    def test_on_conflict_do_update_no_row_actually_affected(self):
+        users = self.tables.users_xtra
+
+        with testing.db.connect() as conn:
+            self._exotic_targets_fixture(conn)
+            i = insert(users)
+            i = i.on_conflict_do_update(
+                index_elements=[users.c.login_email],
+                set_=dict(name="new_name"),
+                where=(i.excluded.name == "other_name"),
+            )
+            result = conn.execute(
+                i, dict(name="name2", login_email="name1@gmail.com")
+            )
+
+            # The last inserted primary key should be 2 here
+            # it is taking the result from the the exotic fixture
+            eq_(result.inserted_primary_key, (2,))
+
+            eq_(
+                conn.execute(users.select()).fetchall(),
+                [
+                    (1, "name1", "name1@gmail.com", "not"),
+                    (2, "name2", "name2@gmail.com", "not"),
+                ],
+            )
+
+    def test_on_conflict_do_update_special_types_in_set(self):
+        bind_targets = self.tables.bind_targets
+
+        with testing.db.connect() as conn:
+            i = insert(bind_targets)
+            conn.execute(i, {"id": 1, "data": "initial data"})
+
+            eq_(
+                conn.scalar(sql.select(bind_targets.c.data)),
+                "initial data processed",
+            )
+
+            i = insert(bind_targets)
+            i = i.on_conflict_do_update(
+                index_elements=[bind_targets.c.id],
+                set_=dict(data="new updated data"),
+            )
+            conn.execute(i, {"id": 1, "data": "new inserted data"})
+
+            eq_(
+                conn.scalar(sql.select(bind_targets.c.data)),
+                "new updated data processed",
+            )


### PR DESCRIPTION
Implement UPSERT for the SQLite Dialect

### Description
The proposed change implements the Upsert ( INSERT.. ON CONFLICT.. DO UPDATE SET | DO NOTHING) for the SQLite Dialect. The test cases provided are very similar to those on the existing PostgreSQL dialect and the implementation follows the existing code in place for the Upsert on PostgreSQL but takes into account the differences of SQLite i.e. inability to use constraint names directly as only column names are supported.

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
Fixes: #4010 