### PR TITLE
support indexing expressions and functions for the MySQL dialect

### DIFF
--- a/doc/build/changelog/unreleased_13/5462.rst
+++ b/doc/build/changelog/unreleased_13/5462.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: mysql, usecase
+    :tickets: 5462
+
+    Adjusted the :meth:`MySQLDDLCompiler.visit_create_index` to implement
+    indexing with expressions and functions on the MySQL dialect.
+    Pull request courtesy Ramon Williams.

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1975,12 +1975,17 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
         self._verify_index_table(index)
         preparer = self.preparer
         table = preparer.format_table(index.table)
-        columns = [
-            self.sql_compiler.process(
+
+        columns = []
+        for expr in index.expressions:
+            key_part = self.sql_compiler.process(
                 expr, include_table=False, literal_binds=True
             )
-            for expr in index.expressions
-        ]
+            if not isinstance(expr, sa_schema.Column) and not isinstance(
+                expr, elements.UnaryExpression
+            ):
+                key_part = "(%s)" % key_part
+            columns.append(key_part)
 
         name = self._prepared_index_name(index)
 


### PR DESCRIPTION
Support indexing on expressions and functions for the MySQL dialect

### Description
A user noticed that creating an index where the "key part" was an expression or function would raise an error for MySQL because the key part was not parenthesized. The proposed change will check whether a key part is not a Column or Unary Expression  and parenthesize if the case is False.  

This fix also contains a minor fix to a test case that was previously incorrect (`def test_create_index_expr():`).


This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
Fixes: #5462 