### PR TITLE
[#5599] Fix issue with str(SQLAlchemyError(<object>))

### DIFF
--- a/lib/sqlalchemy/exc.py
+++ b/lib/sqlalchemy/exc.py
@@ -56,10 +56,19 @@ class SQLAlchemyError(Exception):
         #
         if len(self.args) == 1:
             text = self.args[0]
+
             if as_unicode and isinstance(text, compat.binary_types):
-                return compat.decode_backslashreplace(text, "utf-8")
+                text = compat.decode_backslashreplace(text, "utf-8")
+
+            # This is for when the argument is not a string of any sort.
+            # Otherwise, converting this exception to string would fail for
+            # non-string arguments.
+            if compat.py3k or not as_unicode:
+                text = str(text)
             else:
-                return self.args[0]
+                text = compat.text_type(text)
+
+            return text
         else:
             # this is not a normal case within SQLAlchemy but is here for
             # compatibility with Exception.args - the str() comes out as

--- a/test/engine/test_execute.py
+++ b/test/engine/test_execute.py
@@ -58,6 +58,15 @@ class SomeException(Exception):
     pass
 
 
+class Foo(object):
+
+    def __str__(self):
+        return "foo"
+
+    def __unicode__(self):
+        return util.u("fóó")
+
+
 class ExecuteTest(fixtures.TablesTest):
     __backend__ = True
 
@@ -411,6 +420,13 @@ class ExecuteTest(fixtures.TablesTest):
             eq_(unicode(err), util.u("some message méil"))  # noqa
         else:
             eq_(str(err), util.u("some message méil"))
+
+    def test_stmt_exception_object_arg(self):
+        err = tsa.exc.SQLAlchemyError(Foo())
+        eq_(str(err), "foo")
+
+        if util.py2k:
+            eq_(unicode(err), util.u("fóó"))  # noqa
 
     def test_stmt_exception_str_multi_args(self):
         err = tsa.exc.SQLAlchemyError("some message", 206)


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Doing `str(SQLAlchemyError(value))` fails when value is not a str, bytes or unicode, because `SQLAlchemyError.__str__` returns the non-string argument verbatim (when there's only one). This is not the case with `Exception` - doing `str(Exception(value))` will work regardless of what the `value` is. My changes are restoring compatibility with `Exception` by converting the sole argument to the text type (str or unicode) if needed.

The issue was discovered when using `sqlalchemy-redshift` - it uses `NoSuchTableError(RelationKey(...))`.
Converting `RelationKey` to string actually results in the table name, so doing `str(NoSuchTableError(RelationKey("foo", "bar")))` should result in `bar.foo`, but it raises an error.

Example:
```py
>>> from sqlalchemy.exc import SQLAlchemyError
>>> class Foo(object):
...     pass
>>> str(SQLAlchemyError(Foo()))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __str__ returned non-string (type Foo)
```

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
