### PR TITLE
GH-4757 Rename apply_labels to use_labels

### DIFF
--- a/lib/sqlalchemy/orm/loading.py
+++ b/lib/sqlalchemy/orm/loading.py
@@ -1396,7 +1396,7 @@ def load_scalar_attributes(mapper, state, attribute_names, passive):
 
         result = load_on_ident(
             session,
-            future.select(mapper).apply_labels(),
+            future.select(mapper).use_labels(),
             identity_key,
             refresh_state=state,
             only_load_props=attribute_names,

--- a/lib/sqlalchemy/orm/mapper.py
+++ b/lib/sqlalchemy/orm/mapper.py
@@ -3013,7 +3013,7 @@ class Mapper(
         cols = []
         for key in col_attribute_names:
             cols.extend(props[key].columns)
-        return sql.select(*cols).where(cond).apply_labels()
+        return sql.select(*cols).where(cond).use_labels()
 
     def _iterate_to_target_viawpoly(self, mapper):
         if self.isa(mapper):

--- a/lib/sqlalchemy/orm/persistence.py
+++ b/lib/sqlalchemy/orm/persistence.py
@@ -1508,7 +1508,7 @@ def _finalize_insert_update_commands(base_mapper, uowtransaction, states):
 
         if toload_now:
             state.key = base_mapper._identity_key_from_state(state)
-            stmt = future.select(mapper).apply_labels()
+            stmt = future.select(mapper).use_labels()
             loading.load_on_ident(
                 uowtransaction.session,
                 stmt,

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -2662,7 +2662,7 @@ class Session(_SessionClassMethods):
 
         if populate_existing:
             load_options += {"_populate_existing": populate_existing}
-        statement = sql.select(mapper).apply_labels()
+        statement = sql.select(mapper).use_labels()
         if with_for_update is not None:
             statement._for_update_arg = query.ForUpdateArg._from_argument(
                 with_for_update

--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -487,7 +487,7 @@ class DeferredColumnLoader(LoaderStrategy):
         if (
             loading.load_on_ident(
                 session,
-                sql.select(localparent).apply_labels(),
+                sql.select(localparent).use_labels(),
                 state.key,
                 only_load_props=group,
                 refresh_state=state,
@@ -890,7 +890,7 @@ class LazyLoader(AbstractRelationshipLoader, util.MemoizedSlots):
 
         stmt = sql.lambda_stmt(
             lambda: sql.select(self.entity)
-            .apply_labels()
+            .use_labels()
             ._set_compile_options(ORMCompileState.default_compile_options),
             global_track_bound_values=False,
             lambda_cache=self._query_cache,
@@ -2698,7 +2698,7 @@ class SelectInLoader(PostLoader, util.MemoizedSlots):
         q = sql.lambda_stmt(
             lambda: sql.select(
                 orm_util.Bundle("pk", *pk_cols), effective_entity
-            ).apply_labels(),
+            ).use_labels(),
             lambda_cache=self._query_cache,
             global_track_bound_values=False,
             track_on=(self, effective_entity) + tuple(pk_cols),


### PR DESCRIPTION
Rename all the apply_labels to use_labels 

### Description
As part of the process of moving to 2.0 apply_labels should be replaced with use_labels

