### PR TITLE
add --notimingintensive; block from github jobs

### DIFF
--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -94,7 +94,7 @@ jobs:
         # the mock reconnect test seems to fail on the ci in windows
         run: |
           pip install pytest pytest-xdist ${{ matrix.extra-requires }}
-          pytest -n2 -q test -k 'not MockReconnectTest' --nomemory
+          pytest -n2 -q test --nomemory --notimingintensive
 
       - name: Get wheel name
         id: wheel-name
@@ -223,7 +223,7 @@ jobs:
             pip install -f dist --no-index sqlalchemy
             python -c 'from sqlalchemy import cprocessors, cresultproxy, cutils'
             pip install pytest pytest-xdist ${{ matrix.extra-requires }}
-            pytest -n2 -q test -k 'not MockReconnectTest' --nomemory
+            pytest -n2 -q test --nomemory --notimingintensive
           else
             echo Not compatible. Skipping install.
           fi
@@ -361,7 +361,7 @@ jobs:
             pip install -f dist --no-index sqlalchemy &&
             python -c 'from sqlalchemy import cprocessors, cresultproxy, cutils' &&
             pip install pytest pytest-xdist ${{ matrix.extra-requires }} &&
-            pytest -n2 -q test -k 'not MockReconnectTest' --nomemory"
+            pytest -n2 -q test --nomemory --notimingintensive"
 
       - name: Get wheel names
         id: wheel-name

--- a/.github/workflows/run-on-pr.yaml
+++ b/.github/workflows/run-on-pr.yaml
@@ -50,7 +50,7 @@ jobs:
           pip list
 
       - name: Run tests
-        run: tox -e github-${{ matrix.build-type }} -- -q --nomemory ${{ matrix.pytest-args }}
+        run: tox -e github-${{ matrix.build-type }} -- -q --nomemory --notimingintensive ${{ matrix.pytest-args }}
 
   # Arm emulation is quite slow (~20min) so for now just run it when merging to master
   # run-test-arm64:
@@ -81,4 +81,4 @@ jobs:
   #               python -m pip install --upgrade pip &&
   #               pip install --upgrade tox setuptools &&
   #               pip list &&
-  #               tox -e github-${{ matrix.build-type }} -- -q --nomemory ${{ matrix.pytest-args }}"
+  #               tox -e github-${{ matrix.build-type }} -- -q --nomemory --notimingintensive ${{ matrix.pytest-args }}"

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -42,16 +42,6 @@ jobs:
           - x86
 
         include:
-          # the mock reconnect test seems to fail on the ci in windows
-          - os: "windows-latest"
-            pytest-args: "-k 'not MockReconnectTest'"
-          # python 2.7 or 3.5 on windows seem to fail also test_hanging_connect_within_overflow
-          - os: "windows-latest"
-            python-version: "3.5"
-            pytest-args: "-k 'not MockReconnectTest and not test_hanging_connect_within_overflow'"
-          - os: "windows-latest"
-            python-version: "2.7"
-            pytest-args: "-k 'not MockReconnectTest and not test_hanging_connect_within_overflow'"
           # autocommit tests fail on the ci for some reason
           - python-version: "pypy3"
             pytest-args: "-k 'not test_autocommit_on and not test_turn_autocommit_off_via_default_iso_level and not test_autocommit_isolation_level'"
@@ -96,7 +86,7 @@ jobs:
           pip list
 
       - name: Run tests
-        run: tox -e github-${{ matrix.build-type }} -- -q --nomemory ${{ matrix.pytest-args }}
+        run: tox -e github-${{ matrix.build-type }} -- -q --nomemory --notimingintensive ${{ matrix.pytest-args }}
 
   run-test-arm64:
     name: ${{ matrix.python-version }}-${{ matrix.build-type }}-arm64-ubuntu-latest
@@ -132,5 +122,5 @@ jobs:
             python -m pip install --upgrade pip &&
             pip install --upgrade tox setuptools &&
             pip list &&
-            tox -e github-${{ matrix.build-type }} -- -q --nomemory ${{ matrix.pytest-args }}
+            tox -e github-${{ matrix.build-type }} -- -q --nomemory --notimingintensive ${{ matrix.pytest-args }}
             "

--- a/lib/sqlalchemy/testing/plugin/plugin_base.py
+++ b/lib/sqlalchemy/testing/plugin/plugin_base.py
@@ -122,6 +122,12 @@ def setup_options(make_option):
         help="Don't run memory profiling tests",
     )
     make_option(
+        "--notimingintensive",
+        action="store_true",
+        dest="notimingintensive",
+        help="Don't run timing intensive tests",
+    )
+    make_option(
         "--profile-sort",
         type="string",
         default="cumulative",
@@ -344,6 +350,12 @@ def _setup_options(opt, file_config):
 def _set_nomemory(opt, file_config):
     if opt.nomemory:
         exclude_tags.add("memory_intensive")
+
+
+@pre
+def _set_notimingintensive(opt, file_config):
+    if opt.notimingintensive:
+        exclude_tags.add("timing_intensive")
 
 
 @pre

--- a/test/engine/test_pool.py
+++ b/test/engine/test_pool.py
@@ -955,7 +955,6 @@ class QueuePoolTest(PoolTestBase):
         dbapi = Mock()
 
         def failing_dbapi():
-            time.sleep(2)
             raise Exception("connection failed")
 
         creator = dbapi.connect
@@ -1890,7 +1889,7 @@ class SingletonThreadPoolTest(PoolTestBase):
                 assert c
                 c.cursor()
                 c.close()
-                time.sleep(0.1)
+                time.sleep(0.01)
 
         threads = []
         for i in range(10):


### PR DESCRIPTION
this provides a front-end option to disable tests marked
as timing_intensive, all of which are in test_pool, which are more
fragile and aren't consistent on the
github runners.   also remove /reduce unnecessary time.sleep()
from two other pool tests that are not timing intensive.

note that this removes test_hanging_connect_within_overflow
from the github runs via the timing_intensive requirement.

I've also removed MockReconnectTest from exclusions as those are
really important tests and they use mocks so should not have
platform dependent issues.   Need to see what the
windows failures are.

Change-Id: Icb3d284a2a952e2495d80fa91e22e0b32a54340f

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
