### PR TITLE
Add parens around unmarked clause

### DIFF
--- a/doc/build/orm/cascades.rst
+++ b/doc/build/orm/cascades.rst
@@ -93,12 +93,11 @@ becomes part of the state of that :class:`.Session`::
     >>> address3 in sess
     >>> True
 
-``save-update`` has the possibly surprising behavior which is that
-persistent objects which were *removed* from a collection
-(or in some cases a scalar attribute)
-may also be pulled into the :class:`.Session` of a parent object; this is
+A ``save-update`` cascade can exhibit surprising behavior when removing an item from
+a collection or de-associating an object from a scalar attribute. In some cases, the
+orphaned objects may still be pulled into the ex-parent's :class:`.Session`; this is
 so that the flush process may handle that related object appropriately.
-This case can usually only arise if an object is removed from one :class:`.Session`
+This case usually only arises if an object is removed from one :class:`.Session`
 and added to another::
 
     >>> user1 = sess1.query(User).filter_by(id=1).first()

--- a/doc/build/orm/cascades.rst
+++ b/doc/build/orm/cascades.rst
@@ -95,7 +95,7 @@ becomes part of the state of that :class:`.Session`::
 
 ``save-update`` has the possibly surprising behavior which is that
 persistent objects which were *removed* from a collection
-or in some cases a scalar attribute
+(or in some cases a scalar attribute)
 may also be pulled into the :class:`.Session` of a parent object; this is
 so that the flush process may handle that related object appropriately.
 This case can usually only arise if an object is removed from one :class:`.Session`


### PR DESCRIPTION

### Description
I'm not 100% sure what this sentence is saying, but I'm pretty sure it needs either commas or parentheses to break it up a little. I think parens make the most sense in this case (assuming I am reading it correctly). Here's the original sentence and the proposed edit in plaintext:

ORIG
 "...persistent objects which were removed from a collection or in some cases a scalar attribute may also be pulled into the Session of a parent object;..."

EDIT
 "...persistent objects which were removed from a collection (or in some cases a scalar attribute) may also be pulled into the Session of a parent object;..."


### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
