### PR TITLE
Correct reflection for composite primary keys in MSSQL

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -3168,16 +3168,20 @@ class MSDialect(default.DefaultDialect):
         C = ischema.key_constraints.alias("C")
 
         # Primary key constraints
-        s = sql.select(
-            C.c.column_name, TC.c.constraint_type, C.c.constraint_name
-        ).where(
-            sql.and_(
-                TC.c.constraint_name == C.c.constraint_name,
-                TC.c.table_schema == C.c.table_schema,
-                C.c.table_name == tablename,
-                C.c.table_schema == owner,
-            ),
-        ).order_by(TC.c.constraint_name, C.c.ordinal_position)
+        s = (
+            sql.select(
+                C.c.column_name, TC.c.constraint_type, C.c.constraint_name
+            )
+            .where(
+                sql.and_(
+                    TC.c.constraint_name == C.c.constraint_name,
+                    TC.c.table_schema == C.c.table_schema,
+                    C.c.table_name == tablename,
+                    C.c.table_schema == owner,
+                ),
+            )
+            .order_by(TC.c.constraint_name, C.c.ordinal_position)
+        )
         c = connection.execution_options(future_result=True).execute(s)
         constraint_name = None
         for row in c.mappings():

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -3177,7 +3177,7 @@ class MSDialect(default.DefaultDialect):
                 C.c.table_name == tablename,
                 C.c.table_schema == owner,
             ),
-        )
+        ).order_by(TC.c.constraint_name, C.c.ordinal_position)
         c = connection.execution_options(future_result=True).execute(s)
         constraint_name = None
         for row in c.mappings():

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -1853,6 +1853,7 @@ class SQLiteDialect(default.DefaultDialect):
             constraint_name = result.group(1) if result else None
 
         cols = self.get_columns(connection, table_name, schema, **kw)
+        cols.sort(key=lambda col: col.get("primary_key"))
         pkeys = []
         for col in cols:
             if col["primary_key"]:

--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -1581,6 +1581,59 @@ class IdentityReflectionTest(fixtures.TablesTest):
                 )
 
 
+class CompositeKeyReflectionTest(fixtures.TablesTest):
+    __backend__ = True
+
+    @classmethod
+    def define_tables(cls, metadata):
+        tb1 = Table(
+            "tb1",
+            metadata,
+            Column("id", Integer),
+            Column("attr", Integer),
+            Column("name", sql_types.VARCHAR(20)),
+            sa.PrimaryKeyConstraint("name", "id", "attr", name="pk_tb1"),
+            schema=None,
+            test_needs_fk=True,
+        )
+        Table(
+            "tb2",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("pid", Integer),
+            Column("pattr", Integer),
+            Column("pname", sql_types.VARCHAR(20)),
+            sa.ForeignKeyConstraint(
+                ["pname", "pid", "pattr"],
+                [tb1.c.name, tb1.c.id, tb1.c.attr],
+                name="fk_tb1_name_id_attr",
+            ),
+            schema=None,
+            test_needs_fk=True,
+        )
+
+    @testing.requires.primary_key_constraint_reflection
+    @testing.provide_metadata
+    def test_pk_column_order(self):
+        # test for issue #5661
+        meta = self.metadata
+        insp = inspect(meta.bind)
+        primary_key = insp.get_pk_constraint(self.tables.tb1.name)
+        eq_(primary_key.get("constrained_columns"), ["name", "id", "attr"])
+
+    @testing.requires.foreign_key_constraint_reflection
+    @testing.provide_metadata
+    def test_fk_column_order(self):
+        # test for issue #5661
+        meta = self.metadata
+        insp = inspect(meta.bind)
+        foreign_keys = insp.get_foreign_keys(self.tables.tb2.name)
+        eq_(len(foreign_keys), 1)
+        fkey1 = foreign_keys[0]
+        eq_(fkey1.get("referred_columns"), ["name", "id", "attr"])
+        eq_(fkey1.get("constrained_columns"), ["pname", "pid", "pattr"])
+
+
 __all__ = (
     "ComponentReflectionTest",
     "QuotedNameArgumentTest",
@@ -1589,4 +1642,5 @@ __all__ = (
     "NormalizedNameTest",
     "ComputedReflectionTest",
     "IdentityReflectionTest",
+    "CompositeKeyReflectionTest",
 )

--- a/test/dialect/mssql/test_reflection.py
+++ b/test/dialect/mssql/test_reflection.py
@@ -7,7 +7,6 @@ from sqlalchemy import DDL
 from sqlalchemy import event
 from sqlalchemy import exc
 from sqlalchemy import ForeignKey
-from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy import Identity
 from sqlalchemy import Index
 from sqlalchemy import inspect
@@ -238,63 +237,6 @@ class ReflectionTest(fixtures.TestBase, ComparesTables, AssertsCompiledSQL):
                     "referred_schema": "test_schema",
                     "referred_table": "subject",
                     "referred_columns": ["id"],
-                }
-            ],
-        )
-
-    @testing.provide_metadata
-    def test_pk_fk_column_order(self):
-        # test for issue #5661
-        metadata = self.metadata
-
-        Table(
-            "primary",
-            metadata,
-            Column("id", Integer),
-            Column("attr", Integer),
-            Column("name", types.VARCHAR(20)),
-            PrimaryKeyConstraint("name", "id", "attr", name="primary_pk"),
-            schema=testing.config.test_schema,
-        )
-
-        Table(
-            "foreign",
-            metadata,
-            Column("id", Integer, primary_key=True),
-            Column("pid", Integer),
-            Column("pattr", Integer),
-            Column("pname", types.VARCHAR(20)),
-            ForeignKeyConstraint(
-                ["pname", "pid", "pattr"],
-                [
-                    "%s.primary.name" % testing.config.test_schema,
-                    "%s.primary.id" % testing.config.test_schema,
-                    "%s.primary.attr" % testing.config.test_schema
-                ],
-                name="fk_primary_name_id_attr",
-            ),
-            schema=testing.config.test_schema,
-        )
-
-        metadata.create_all()
-
-        insp = inspect(testing.db)
-        eq_(
-            insp.get_pk_constraint("primary", testing.config.test_schema),
-            {
-                "name": "primary_pk",
-                "constrained_columns": ["name", "id", "attr"],
-            },
-        )
-        eq_(
-            insp.get_foreign_keys("foreign", testing.config.test_schema),
-            [
-                {
-                    "name": "fk_primary_name_id_attr",
-                    "constrained_columns": ["pname", "pid", "pattr"],
-                    "referred_schema": "test_schema",
-                    "referred_table": "primary",
-                    "referred_columns": ["name", "id", "attr"],
                 }
             ],
         )


### PR DESCRIPTION
Correct reflection for composite primary keys in MSSQL

Fixes: #5661

### Description
Fixes reflection of composite primary keys to maintain the correct column order in the MSSQL dialect.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
