### PR TITLE
Support IF EXISTS/IF NOT EXISTS for DDL constructs

### DIFF
--- a/doc/build/changelog/unreleased_14/2843.rst
+++ b/doc/build/changelog/unreleased_14/2843.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: schema, usecase
+    :tickets: 2843
+
+    The create/drop clause constructs :class:`CreateTable`, :class:`DropTable`,
+    :class:`CreateIndex` and :class:`DropIndex` now support the EXISTS
+    operator. If a dialect does not support the EXISTS operator then EXISTS
+    will be ignored. Pull request courtesy Ramon Williams.

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -2590,6 +2590,9 @@ class MSDialect(default.DefaultDialect):
     # T-SQL's actual default is -9223372036854775808
     default_sequence_base = 1
 
+    supports_exists_table = False
+    supports_exists_index = False
+
     supports_native_boolean = False
     non_native_boolean_check_constraint = False
     supports_unicode_binds = True

--- a/lib/sqlalchemy/dialects/oracle/base.py
+++ b/lib/sqlalchemy/dialects/oracle/base.py
@@ -1397,6 +1397,8 @@ class OracleExecutionContext(default.DefaultExecutionContext):
 class OracleDialect(default.DefaultDialect):
     name = "oracle"
     supports_alter = True
+    supports_exist_table = False
+    supports_exists_index = False
     supports_unicode_statements = False
     supports_unicode_binds = False
     max_identifier_length = 128

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2262,6 +2262,9 @@ class PGDDLCompiler(compiler.DDLCompiler):
             if concurrently:
                 text += "CONCURRENTLY "
 
+        if create.if_not_exists and self.dialect.supports_exists_index:
+            text += "IF NOT EXISTS "
+
         text += "%s ON %s " % (
             self._prepared_index_name(index, include_schema=False),
             preparer.format_table(index.table),
@@ -2344,6 +2347,9 @@ class PGDDLCompiler(compiler.DDLCompiler):
             concurrently = index.dialect_options["postgresql"]["concurrently"]
             if concurrently:
                 text += "CONCURRENTLY "
+
+        if drop.if_exists and self.dialect.supports_exists_index:
+            text += "IF EXISTS "
 
         text += self._prepared_index_name(index, include_schema=True)
         return text
@@ -2758,6 +2764,9 @@ class PGDialect(default.DefaultDialect):
     supports_alter = True
     max_identifier_length = 63
     supports_sane_rowcount = True
+
+    supports_exists_table = True
+    supports_exists_index = True
 
     supports_native_enum = True
     supports_native_boolean = True

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -1239,7 +1239,13 @@ class SQLiteDDLCompiler(compiler.DDLCompiler):
         text = "CREATE "
         if index.unique:
             text += "UNIQUE "
-        text += "INDEX %s ON %s (%s)" % (
+
+        text += "INDEX "
+
+        if create.if_not_exists and self.dialect.supports_exists_index:
+            text += "IF NOT EXISTS "
+
+        text += "%s ON %s (%s)" % (
             self._prepared_index_name(index, include_schema=True),
             preparer.format_table(index.table, use_schema=False),
             ", ".join(
@@ -1447,6 +1453,8 @@ class SQLiteExecutionContext(default.DefaultExecutionContext):
 class SQLiteDialect(default.DefaultDialect):
     name = "sqlite"
     supports_alter = False
+    supports_exists_table = True
+    supports_exists_index = True
     supports_unicode_statements = True
     supports_unicode_binds = True
     supports_default_values = True

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -56,6 +56,9 @@ class DefaultDialect(interfaces.Dialect):
     supports_alter = True
     supports_comments = False
     inline_comments = False
+
+    supports_exists_table = False
+    supports_exists_index = False
     use_setinputsizes = False
 
     # the first value we'd get for an autoincrement


### PR DESCRIPTION
Support IF EXISTS/IF NOT EXISTS for DDL constructs 

### Description
Over time a few users have requested that support of the EXISTS operator is provided to the various create/drop DDL constructs. The proposed change implements the EXISTS operator for the DDL constructs CreateTable/CreateIndex/DropTable/DropIndex. In the event that SQLAlchemy recognizes that a dialect does not support the EXISTS operator on the create/drop constructs (i.e. `supports_exists_table=False` or `supports_exists_index="False`) the EXISTS operator will be ignored in the create/drop statement.


This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
Fixes: #2843 