### PR TITLE
Added ssl_mode flag to mysqldb

### DIFF
--- a/doc/build/changelog/unreleased_13/5692.rst
+++ b/doc/build/changelog/unreleased_13/5692.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: mysql, usecase
+    :tickets: 5692
+
+    Added ``ssl_mode`` dialect keyword to MySQL dialect for use with mysqldb.
+    Pull request courtesy Teodor Moroz.

--- a/lib/sqlalchemy/dialects/mysql/mysqldb.py
+++ b/lib/sqlalchemy/dialects/mysql/mysqldb.py
@@ -189,6 +189,7 @@ class MySQLDialect_mysqldb(MySQLDialect):
         util.coerce_kw_type(opts, "write_timeout", int)
         util.coerce_kw_type(opts, "client_flag", int)
         util.coerce_kw_type(opts, "local_infile", int)
+        util.coerce_kw_type(opts, "ssl_mode", str)
         # Note: using either of the below will cause all strings to be
         # returned as Unicode, both in raw SQL operations and with column
         # types like String and MSString.

--- a/test/dialect/mysql/test_dialect.py
+++ b/test/dialect/mysql/test_dialect.py
@@ -141,6 +141,7 @@ class DialectTest(fixtures.TestBase):
             make_url(
                 "mysql://scott:tiger@localhost:3306/test"
                 "?ssl_ca=/ca.pem&ssl_cert=/cert.pem&ssl_key=/key.pem"
+                "&ssl_mode=REQUIRED"
             )
         )[1]
         # args that differ among mysqldb and oursql
@@ -156,6 +157,7 @@ class DialectTest(fixtures.TestBase):
                     "cert": "/cert.pem",
                     "key": "/key.pem",
                 },
+                "ssl_mode": "REQUIRED",
                 "host": "localhost",
                 "user": "scott",
                 "port": 3306,


### PR DESCRIPTION
ssl_mode flag is added to mysqldb

### Description
mysqldb driver supports "ssl_mode" flag, which can be one of following values:
"DISABLED", "PREFERRED", "REQUIRED", "VERIFY_CA", "VERIFY_IDENTITY".
Depending on these values MySQL will behave accordingly to them. 

So this flag has been added to the sqlaclhemy. So in case if TLS is not supported on the server, we can drop the connection right away.
Fixes: 
 #5692 Drop connection if ssl is not in use in sqlaclhemy