### PR TITLE
Add opsclass to exclusion constraint

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2418,7 +2418,7 @@ class PGDDLCompiler(compiler.DDLCompiler):
         for expr, name, op in constraint._render_exprs:
             kw["include_table"] = False
             exclude_element = self.sql_compiler.process(expr, **kw) + (
-                (" " + constraint.ops[expr.key] + " ")
+                (" " + constraint.ops[expr.key])
                 if hasattr(expr, "key") and expr.key in constraint.ops
                 else ""
             )

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -781,6 +781,8 @@ using the ``postgresql_where`` keyword argument::
 
   Index('my_index', my_table.c.id, postgresql_where=my_table.c.value > 10)
 
+.. _postgresql_operator_classes:
+
 Operator Classes
 ^^^^^^^^^^^^^^^^
 

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2417,9 +2417,13 @@ class PGDDLCompiler(compiler.DDLCompiler):
         elements = []
         for expr, name, op in constraint._render_exprs:
             kw["include_table"] = False
-            elements.append(
-                "%s WITH %s" % (self.sql_compiler.process(expr, **kw), op)
+            exclude_element = self.sql_compiler.process(expr, **kw) + (
+                (" " + constraint.ops[expr.key] + " ")
+                if hasattr(expr, "key") and expr.key in constraint.ops
+                else ""
             )
+
+            elements.append("%s WITH %s" % (exclude_element, op))
         text += "EXCLUDE USING %s (%s)" % (
             self.preparer.validate_sql_phrase(
                 constraint.using, IDX_USING

--- a/lib/sqlalchemy/dialects/postgresql/ext.py
+++ b/lib/sqlalchemy/dialects/postgresql/ext.py
@@ -209,8 +209,7 @@ class ExcludeConstraint(ColumnCollectionConstraint):
         if where is not None:
             self.where = coercions.expect(roles.StatementOptionRole, where)
 
-        # TODO: add docs, name?
-        self.ops = kw.get("ops")
+        self.ops = kw.get("ops", {})
 
     def _set_parent(self, table, **kw):
         super(ExcludeConstraint, self)._set_parent(table)

--- a/lib/sqlalchemy/dialects/postgresql/ext.py
+++ b/lib/sqlalchemy/dialects/postgresql/ext.py
@@ -209,6 +209,9 @@ class ExcludeConstraint(ColumnCollectionConstraint):
         if where is not None:
             self.where = coercions.expect(roles.StatementOptionRole, where)
 
+        # TODO: add docs, name?
+        self.ops = kw.get("ops")
+
     def _set_parent(self, table, **kw):
         super(ExcludeConstraint, self)._set_parent(table)
 

--- a/lib/sqlalchemy/dialects/postgresql/ext.py
+++ b/lib/sqlalchemy/dialects/postgresql/ext.py
@@ -171,6 +171,11 @@ class ExcludeConstraint(ColumnCollectionConstraint):
           If set, emit WHERE <predicate> when issuing DDL
           for this constraint.
 
+        :param ops:
+          Optional dictionary.  Used to define operator classes for the
+          elements.
+          See :ref:`_postgresql_operator_classes`
+
         """
         columns = []
         render_exprs = []


### PR DESCRIPTION
Fix #5604 - add operation classes support to exclusion constraints.

### Description
Add an ops kw param to ExcludeConstraint, that behaves similarly to postgres-ops in an Index.

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

