### PR TITLE
update contains_eager docs to reflect common gotcha

### DIFF
--- a/doc/build/orm/loading_relationships.rst
+++ b/doc/build/orm/loading_relationships.rst
@@ -1135,20 +1135,20 @@ in fact associated with the collection.
     loaded.
 
     If we have a previous query in the session that has loaded the collection,
-    future queries will use the collection as is, it won't be reloaded
-    according to filter criteria. It may be necessary to expunge instances to
+    future queries will use the collection as is - it won't be reloaded
+    according to filter criteria. It may be necessary to use
+    :meth:`.Query.populate_existing` or :meth:`.Session.expunge` to
     get the desired behaviour::
 
         user = session.query(User)
         user.addresses
 
-        # if we don't include the following line, q.addresses will
-        # include all of the addresses - not just those we filter
-        session.expunge(user)
-
+        # if we don't include `.populate_existing()`, q.addresses will
+        # include all of the addresses, not just those we filter
         q = session.query(User).join(User.addresses).\
                     filter(Address.email.like('%ed%')).\
-                    options(contains_eager(User.addresses))
+                    options(contains_eager(User.addresses)).\
+                    populate_existing()
 
     In addition, the **collection will fully reload normally** once the
     object or attribute is expired.  This expiration occurs whenever the

--- a/doc/build/orm/loading_relationships.rst
+++ b/doc/build/orm/loading_relationships.rst
@@ -1134,6 +1134,22 @@ in fact associated with the collection.
     conflicting with entries that are already in the database but not locally
     loaded.
 
+    If we have a previous query in the session that has loaded the collection,
+    future queries will use the collection as is, it won't be reloaded
+    according to filter criteria. It may be necessary to expunge instances to
+    get the desired behaviour::
+
+        user = session.query(User)
+        user.addresses
+
+        # if we don't include the following line, q.addresses will
+        # include all of the addresses - not just those we filter
+        session.expunge(user)
+
+        q = session.query(User).join(User.addresses).\
+                    filter(Address.email.like('%ed%')).\
+                    options(contains_eager(User.addresses))
+
     In addition, the **collection will fully reload normally** once the
     object or attribute is expired.  This expiration occurs whenever the
     :meth:`.Session.commit`, :meth:`.Session.rollback` methods are used


### PR DESCRIPTION
### Description

`contains_eager` has behaviour that feels surprising to me - although I now see why the behaviour is as it is. Colleagues and "the internet" seemed to concur.

I hope the diff speaks for itself, this is an issue I've seen at least once in the github issues: https://github.com/sqlalchemy/sqlalchemy/issues/4021

And something I've reported [via stackoverflow](https://stackoverflow.com/questions/64823896/in-sqlalchemy-should-i-always-pair-contains-eager-with-expire-all).

### Checklist

This pull request is:

- [x] A documentation / typographical error fix

### Aside

It would be a big breaking change, but it feels like (due to the use of `contains_eager`) that `q.addresses` should return *a whole different list-like thing* to `user.addresses`. Probably one that highlights that it's not necessarily all of the `addresses` of the `user`, but just the ones from the query, and thus would eg. raise errors on `user.addresses.append(...)`.

