### PR TITLE
QueuePool: support subsecond timeout

### DIFF
--- a/lib/sqlalchemy/engine/create.py
+++ b/lib/sqlalchemy/engine/create.py
@@ -440,9 +440,11 @@ def create_engine(url, **kwargs):
 
             :paramref:`_pool.Pool.reset_on_return`
 
-    :param pool_timeout=30: number of seconds to wait before giving
+    :param pool_timeout=30.0: number of seconds to wait before giving
         up on getting a connection from the pool. This is only used
-        with :class:`~sqlalchemy.pool.QueuePool`.
+        with :class:`~sqlalchemy.pool.QueuePool`. This can be a float but is
+        subject to the limitations of Python time functions which may not be
+        reliable in the tens of milliseconds.
 
     :param pool_use_lifo=False: use LIFO (last-in-first-out) when retrieving
         connections from :class:`.QueuePool` instead of FIFO

--- a/lib/sqlalchemy/pool/impl.py
+++ b/lib/sqlalchemy/pool/impl.py
@@ -40,7 +40,7 @@ class QueuePool(Pool):
         creator,
         pool_size=5,
         max_overflow=10,
-        timeout=30,
+        timeout=30.0,
         use_lifo=False,
         **kw
     ):
@@ -73,7 +73,9 @@ class QueuePool(Pool):
           connections. Defaults to 10.
 
         :param timeout: The number of seconds to wait before giving up
-          on returning a connection. Defaults to 30.
+          on returning a connection. Defaults to 30.0. This can be a float
+          but is subject to the limitations of Python time functions which
+          may not be reliable in the tens of milliseconds.
 
         :param use_lifo: use LIFO (last-in-first-out) when retrieving
           connections instead of FIFO (first-in-first-out). Using LIFO, a
@@ -129,7 +131,7 @@ class QueuePool(Pool):
             else:
                 raise exc.TimeoutError(
                     "QueuePool limit of size %d overflow %d reached, "
-                    "connection timed out, timeout %d"
+                    "connection timed out, timeout %0.2f"
                     % (self.size(), self.overflow(), self._timeout),
                     code="3o7r",
                 )


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Make it explicit in the documentation and in the default value for the 'timeout'
parameter that `timeout` can be a float. Because Python timing is not
very accurate, warn about the precision.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
