### PR TITLE
Implement `TypeEngine.as_generic()`

### DIFF
--- a/lib/sqlalchemy/sql/type_api.py
+++ b/lib/sqlalchemy/sql/type_api.py
@@ -470,13 +470,18 @@ class TypeEngine(Traversible):
                     "sqlalchemy.sql.sqltypes",
                     "sqlalchemy.sql.type_api",
                 )
-                and t._is_generic_type()
+                and hasattr(t, '_is_generic_type') and t._is_generic_type()
             ):
                 if t in (TypeEngine, UserDefinedType):
                     return NULLTYPE.__class__
                 return t
         else:
             return self.__class__
+
+    def as_generic(self):
+        """Return an instance of the generic type corresponding to this type"""
+
+        return util.constructor_copy(self, self._generic_type_affinity())
 
     def dialect_impl(self, dialect):
         """Return a dialect-specific implementation for this

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -383,6 +383,26 @@ class TypeAffinityTest(fixtures.TestBase):
         assert t1.dialect_impl(d)._type_affinity is postgresql.UUID
 
 
+class AsGenericTest(fixtures.TestBase):
+    @testing.combinations(
+        (String(), String()),
+        (VARCHAR(length=100), String(length=100)),
+        (NVARCHAR(length=100), Unicode(length=100)),
+        (DATE(), Date()),
+    )
+    def test_as_generic(self, t1, t2):
+        assert repr(t1.as_generic()) == repr(t2)
+
+    @testing.combinations(*[(t,) for t in _all_types(omit_special_types=True)])
+    def test_as_generic_all_types(self, type_):
+        if issubclass(type_, ARRAY):
+            t1 = type_(String)
+        else:
+            t1 = type_()
+
+        t1.as_generic()
+
+
 class PickleTypesTest(fixtures.TestBase):
     @testing.combinations(
         ("Boo", Boolean()),


### PR DESCRIPTION
### Description
Implements `TypeEngine.as_generic()` which returns a generic type object that corresponds to a given vendor-specific type.  This is intended for use when replicating a schema from database to another.  Reflected vendor-specific column types can be converted to generic types using `as_generic()`. From there the generic type can be compiled to any arbitrary database flavor.  

Fixes: #5659

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
