### PR TITLE
Implement `TypeEngine.as_generic`

### DIFF
--- a/doc/build/changelog/unreleased_14/5659.rst
+++ b/doc/build/changelog/unreleased_14/5659.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: datatypes, feature
+    :tickets: 5659
+
+    Added :meth:`_types.TypeEngine.as_generic` to map dialect-specific types,
+    e.g., ``INTEGER`` with the "best match" generic SQLAlchemy type,
+    e.g., ``Integer``. Pull request courtesy Andrew Hannigan.

--- a/lib/sqlalchemy/dialects/oracle/base.py
+++ b/lib/sqlalchemy/dialects/oracle/base.py
@@ -666,6 +666,13 @@ class INTERVAL(sqltypes.NativeForEmulated, sqltypes._AbstractInterval):
     def _type_affinity(self):
         return sqltypes.Interval
 
+    def as_generic(self):
+        return sqltypes.Interval(
+            native=True,
+            second_precision=self.second_precision,
+            day_precision=self.day_precision,
+        )
+
 
 class ROWID(sqltypes.TypeEngine):
     """Oracle ROWID type.

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1434,6 +1434,9 @@ class INTERVAL(sqltypes.NativeForEmulated, sqltypes._AbstractInterval):
     def _type_affinity(self):
         return sqltypes.Interval
 
+    def as_generic(self):
+        return sqltypes.Interval(native=True, second_precision=self.precision)
+
     @property
     def python_type(self):
         return dt.timedelta

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -1982,6 +1982,9 @@ class Interval(Emulated, _AbstractInterval, TypeDecorator):
         self.second_precision = second_precision
         self.day_precision = day_precision
 
+    def __repr__(self):
+        return util.generic_repr(self)
+
     @property
     def python_type(self):
         return dt.timedelta

--- a/lib/sqlalchemy/sql/type_api.py
+++ b/lib/sqlalchemy/sql/type_api.py
@@ -483,9 +483,9 @@ class TypeEngine(Traversible):
 
     def as_generic(self, allow_nulltype=False):
         """
-        Return an instance of the generic type corresponding to this type using
-        heuristic rule. The method may be overridden if this heuristic rule is not
-        sufficient.
+        Return an instance of the generic type corresponding to this type
+        using heuristic rule. The method may be overridden if this
+        heuristic rule is not sufficient.
 
         >>> from sqlalchemy.dialects.mysql import INTEGER
         >>> INTEGER(display_width=4).as_generic()

--- a/lib/sqlalchemy/sql/type_api.py
+++ b/lib/sqlalchemy/sql/type_api.py
@@ -470,13 +470,18 @@ class TypeEngine(Traversible):
                     "sqlalchemy.sql.sqltypes",
                     "sqlalchemy.sql.type_api",
                 )
-                and t._is_generic_type()
+                and hasattr(t, '_is_generic_type') and t._is_generic_type()
             ):
                 if t in (TypeEngine, UserDefinedType):
                     return NULLTYPE.__class__
                 return t
         else:
             return self.__class__
+
+    def as_generic(self):
+        """Return an instance of the generic type corresponding to this type"""
+
+        return util.constructor_copy(self, self._generic_type_affinity())
 
     def dialect_impl(self, dialect):
         """Return a dialect-specific implementation for this

--- a/lib/sqlalchemy/sql/type_api.py
+++ b/lib/sqlalchemy/sql/type_api.py
@@ -481,7 +481,19 @@ class TypeEngine(Traversible):
         return best_camelcase or best_uppercase or NULLTYPE.__class__
 
     def as_generic(self):
-        """Return an instance of the generic type corresponding to this type"""
+        """
+        Return an instance of the generic type corresponding to this type.
+
+        >>> from sqlalchemy.dialects.mysql import INTEGER
+        >>> INTEGER(display_width=4).as_generic()
+        Integer()
+
+        >>> from sqlalchemy.dialects.mysql import NVARCHAR
+        >>> NVARCHAR(length=100).as_generic()
+        Unicode(length=100)
+
+        .. versionadded:: 1.4.0b2
+        """
 
         return util.constructor_copy(self, self._generic_type_affinity())
 

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -383,6 +383,26 @@ class TypeAffinityTest(fixtures.TestBase):
         assert t1.dialect_impl(d)._type_affinity is postgresql.UUID
 
 
+class AsGenericTest(fixtures.TestBase):
+    @testing.combinations(
+        (String(), String()),
+        (VARCHAR(length=100), String(length=100)),
+        (NVARCHAR(length=100), Unicode(length=100)),
+        (DATE(), Date()),
+    )
+    def test_as_generic(self, t1, t2):
+        assert repr(t1.as_generic()) == repr(t2)
+
+    @testing.combinations(*[(t,) for t in _all_types(omit_special_types=True)])
+    def test_as_generic_all_types(self, type_):
+        if issubclass(type_, ARRAY):
+            t1 = type_(String)
+        else:
+            t1 = type_()
+
+        t1.as_generic()
+
+
 class PickleTypesTest(fixtures.TestBase):
     @testing.combinations(
         ("Boo", Boolean()),

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -6,6 +6,7 @@ import operator
 import os
 
 import sqlalchemy as sa
+import sqlalchemy.dialects.postgresql as pg
 from sqlalchemy import and_
 from sqlalchemy import ARRAY
 from sqlalchemy import BigInteger
@@ -389,6 +390,8 @@ class AsGenericTest(fixtures.TestBase):
         (VARCHAR(length=100), String(length=100)),
         (NVARCHAR(length=100), Unicode(length=100)),
         (DATE(), Date()),
+        (pg.JSON(), sa.JSON()),
+        (pg.ARRAY(sa.String), sa.ARRAY(sa.String)),
     )
     def test_as_generic(self, t1, t2):
         assert repr(t1.as_generic()) == repr(t2)

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -6,7 +6,6 @@ import operator
 import os
 
 import sqlalchemy as sa
-import sqlalchemy.dialects.postgresql as pg
 from sqlalchemy import and_
 from sqlalchemy import ARRAY
 from sqlalchemy import BigInteger
@@ -59,6 +58,7 @@ from sqlalchemy import types
 from sqlalchemy import Unicode
 from sqlalchemy import util
 from sqlalchemy import VARCHAR
+import sqlalchemy.dialects.postgresql as pg
 from sqlalchemy.engine import default
 from sqlalchemy.schema import AddConstraint
 from sqlalchemy.schema import CheckConstraint


### PR DESCRIPTION
### Description
Implements `TypeEngine.as_generic()` which returns a generic type object for a vendor-specific type.  This is intended to be used to replicate schemas as closely as possible between different database flavors.  Columns can be reflected from a source database, converted to generic, and then compiled to any database flavor from there.  

Fixes: #5659 

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
