### PR TITLE
Add Optional type modifier to fields with default value of None 

### DIFF
--- a/doc/build/orm/mapping_styles.rst
+++ b/doc/build/orm/mapping_styles.rst
@@ -230,6 +230,7 @@ An example of a mapping using ``@dataclass`` is as follows::
     from dataclasses import dataclass
     from dataclasses import field
     from typing import List
+    from typing import Optional
 
     from sqlalchemy import Column
     from sqlalchemy import ForeignKey
@@ -254,9 +255,9 @@ An example of a mapping using ``@dataclass`` is as follows::
             Column("nickname", String(12)),
         )
         id: int = field(init=False)
-        name: str = None
-        fullname: str = None
-        nickname: str = None
+        name: Optional[str] = None
+        fullname: Optional[str] = None
+        nickname: Optional[str] = None
         addresses: List[Address] = field(default_factory=list)
 
         __mapper_args__ = {
@@ -277,7 +278,7 @@ An example of a mapping using ``@dataclass`` is as follows::
         )
         id: int = field(init=False)
         user_id: int = field(init=False)
-        email_address: str = None
+        email_address: Optional[str] = None
 
 In the above example, the ``User.id``, ``Address.id``, and ``Address.user_id``
 attributes are defined as ``field(init=False)``. This means that parameters for


### PR DESCRIPTION
Dataclass fields with a default value of `None` should use `typing.Optional` hints.

### Description
<!-- Describe your changes in detail -->

This fixes MyPy/PEP 484 complaints from the dataclass example in the docs.
```
main.py:30: error: Incompatible types in assignment (expression has type "None", variable has type "str")
main.py:31: error: Incompatible types in assignment (expression has type "None", variable has type "str")
main.py:32: error: Incompatible types in assignment (expression has type "None", variable has type "str")
main.py:50: error: Incompatible types in assignment (expression has type "None", variable has type "str")
```

References: #5027

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
