### PR TITLE
Fixed compile for mssql dialect

### DIFF
--- a/doc/build/changelog/unreleased_13/5751.rst
+++ b/doc/build/changelog/unreleased_13/5751.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: bug, mssql
+    :tickets: 5751
+
+    Fixed bug where a CREATE INDEX statement was rendered incorrectly when
+    both ``mssql-include`` and ``mssql_where`` were specified. Pull request
+    courtesy @Adiorz.

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -2286,18 +2286,6 @@ class MSDDLCompiler(compiler.DDLCompiler):
             ),
         )
 
-        whereclause = index.dialect_options["mssql"]["where"]
-
-        if whereclause is not None:
-            whereclause = coercions.expect(
-                roles.DDLExpressionRole, whereclause
-            )
-
-            where_compiled = self.sql_compiler.process(
-                whereclause, include_table=False, literal_binds=True
-            )
-            text += " WHERE " + where_compiled
-
         # handle other included columns
         if index.dialect_options["mssql"]["include"]:
             inclusions = [
@@ -2310,6 +2298,18 @@ class MSDDLCompiler(compiler.DDLCompiler):
             text += " INCLUDE (%s)" % ", ".join(
                 [preparer.quote(c.name) for c in inclusions]
             )
+
+        whereclause = index.dialect_options["mssql"]["where"]
+
+        if whereclause is not None:
+            whereclause = coercions.expect(
+                roles.DDLExpressionRole, whereclause
+            )
+
+            where_compiled = self.sql_compiler.process(
+                whereclause, include_table=False, literal_binds=True
+            )
+            text += " WHERE " + where_compiled
 
         return text
 

--- a/test/dialect/mssql/test_compiler.py
+++ b/test/dialect/mssql/test_compiler.py
@@ -1281,6 +1281,29 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             schema.CreateIndex(idx), "CREATE INDEX foo ON test (x) INCLUDE (y)"
         )
 
+    def test_index_include_where(self):
+        metadata = MetaData()
+        tbl = Table(
+            "test",
+            metadata,
+            Column("x", Integer),
+            Column("y", Integer),
+            Column("z", Integer),
+        )
+        idx = Index("foo", tbl.c.x, mssql_include=[tbl.c.y],
+                    mssql_where=tbl.c.y > 1)
+        self.assert_compile(
+            schema.CreateIndex(idx),
+            "CREATE INDEX foo ON test (x) INCLUDE (y) WHERE y > 1"
+        )
+
+        idx = Index("foo", tbl.c.x, mssql_include=[tbl.c.y],
+                    mssql_where="y > 1")
+        self.assert_compile(
+            schema.CreateIndex(idx),
+            "CREATE INDEX foo ON test (x) INCLUDE (y) WHERE y > 1"
+        )
+
     def test_try_cast(self):
         metadata = MetaData()
         t1 = Table("t1", metadata, Column("id", Integer, primary_key=True))

--- a/test/dialect/mssql/test_compiler.py
+++ b/test/dialect/mssql/test_compiler.py
@@ -20,6 +20,7 @@ from sqlalchemy import sql
 from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy import testing
+from sqlalchemy import text
 from sqlalchemy import union
 from sqlalchemy import UniqueConstraint
 from sqlalchemy import update
@@ -1299,7 +1300,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         )
 
         idx = Index(
-            "foo", tbl.c.x, mssql_include=[tbl.c.y], mssql_where="y > 1"
+            "foo", tbl.c.x, mssql_include=[tbl.c.y], mssql_where=text("y > 1")
         )
         self.assert_compile(
             schema.CreateIndex(idx),

--- a/test/dialect/mssql/test_compiler.py
+++ b/test/dialect/mssql/test_compiler.py
@@ -1290,18 +1290,20 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             Column("y", Integer),
             Column("z", Integer),
         )
-        idx = Index("foo", tbl.c.x, mssql_include=[tbl.c.y],
-                    mssql_where=tbl.c.y > 1)
+        idx = Index(
+            "foo", tbl.c.x, mssql_include=[tbl.c.y], mssql_where=tbl.c.y > 1
+        )
         self.assert_compile(
             schema.CreateIndex(idx),
-            "CREATE INDEX foo ON test (x) INCLUDE (y) WHERE y > 1"
+            "CREATE INDEX foo ON test (x) INCLUDE (y) WHERE y > 1",
         )
 
-        idx = Index("foo", tbl.c.x, mssql_include=[tbl.c.y],
-                    mssql_where="y > 1")
+        idx = Index(
+            "foo", tbl.c.x, mssql_include=[tbl.c.y], mssql_where="y > 1"
+        )
         self.assert_compile(
             schema.CreateIndex(idx),
-            "CREATE INDEX foo ON test (x) INCLUDE (y) WHERE y > 1"
+            "CREATE INDEX foo ON test (x) INCLUDE (y) WHERE y > 1",
         )
 
     def test_try_cast(self):


### PR DESCRIPTION
Fixed string compilation when both mssql_include and mssql_where are used

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
This pull request is a short code fix.
Usage both of mssql_include and mssql_where dialect keywords renders wrong SQL string.

WHERE adn INCLUDE clauses are switched in comparison to working solution, e.g. following is rendered string using old approach:

```sql
CREATE INDEX idx_name_adult ON person (name) WHERE age > 18 INCLUDE (age)
```

The new approach produces following string:

```sql
CREATE INDEX idx_name_adult ON person (name) INCLUDE (age) WHERE age > 18
```
that is understandable by the engine.

**Have a nice day!**
