### PR TITLE
Fix exception being thrown when using single table inheritance and having criteria

### DIFF
--- a/lib/sqlalchemy/orm/context.py
+++ b/lib/sqlalchemy/orm/context.py
@@ -585,7 +585,7 @@ class ORMSelectCompileState(ORMCompileState, SelectState):
 
         if query._having_criteria:
             self._having_criteria = tuple(
-                current_adapter(crit, True, True) if current_adapter else crit
+                current_adapter(crit, True) if current_adapter else crit
                 for crit in query._having_criteria
             )
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Removes an extra parameter. `current_adapter` comes from `self._get_current_adapter` which will either return `None` or a function taking in 2 arguments, from what I can see, `current_adapter` will never be a function taking in 3 non-self arguments.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
