### PR TITLE
Fixes issue #5848

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/pysqlcipher.py
+++ b/lib/sqlalchemy/dialects/sqlite/pysqlcipher.py
@@ -18,6 +18,12 @@
     ``pysqlcipher3`` is a fork of ``pysqlcipher`` for Python 3. This dialect
     will attempt to import it if ``pysqlcipher`` is non-present.
 
+    ``sqlcipher3`` is an independent DB-API 2.0 interface which is up-to-date
+    since ``pysqlcipher3`` is no longer actively maintained and fails to install
+    on ``python3.9`` on some systems.
+
+    .. versionadded:: 1.3.22 - added fallback import of sqlcipher3
+
     .. versionadded:: 1.1.4 - added fallback import for pysqlcipher3
 
     .. versionadded:: 0.9.9 - added pysqlcipher dialect
@@ -96,9 +102,12 @@ class SQLiteDialect_pysqlcipher(SQLiteDialect_pysqlite):
             from pysqlcipher import dbapi2 as sqlcipher
         except ImportError as e:
             try:
-                from pysqlcipher3 import dbapi2 as sqlcipher
+                from sqlcipher3 import dbapi2 as sqlcipher
             except ImportError:
-                raise e
+                try:
+                    from pysqlcipher3 import dbapi2 as sqlcipher
+                except ImportError:
+                    raise e
 
         return sqlcipher
 


### PR DESCRIPTION
Repository https://github.com/rigglemania/pysqlcipher3 is not maintained anymore.
``sqlcipher3`` (https://github.com/coleifer/sqlcipher3) is a repository by ``coleifer`` (creator of peewee) for DB-API 2.0 bindings (same purpose which pysqlcipher3 served)
Also, pysqlcipher3 fails to install on some systems with python3.9

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Added another conditional import of ``sqlcipher`` in the file ``lib/sqlalchemy/dialects/sqlite/pysqlcipher.py``

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
