### PR TITLE
Set upper bound to pg8000 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -192,7 +192,7 @@ def run_setup(with_cext):
             ],
             "postgresql": ["psycopg2"],
             "postgresql_psycopg2binary": ["psycopg2-binary"],
-            "postgresql_pg8000": ["pg8000"],
+            "postgresql_pg8000": ["pg8000<1.16.6"],
             "postgresql_psycopg2cffi": ["psycopg2cffi"],
             "oracle": ["cx_oracle"],
             "mssql_pyodbc": ["pyodbc"],


### PR DESCRIPTION
### Description
pg8000 1.16.6 introduced a change that broke compatibility with
sqlalchemy < 1.14.0.

Check #5645 for more details.

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.
