### PR TITLE
Limit AsyncAdaptedQueue to Python 3.7

### DIFF
--- a/lib/sqlalchemy/util/queue.py
+++ b/lib/sqlalchemy/util/queue.py
@@ -237,7 +237,7 @@ class AsyncAdaptedQueue:
     def put_nowait(self, item):
         try:
             return self._queue.put_nowait(item)
-        except asyncio.queues.QueueFull as err:
+        except asyncio.QueueFull as err:
             compat.raise_(
                 Full(),
                 replace_context=err,
@@ -254,10 +254,7 @@ class AsyncAdaptedQueue:
                 )
             else:
                 return self.await_(self._queue.put(item))
-        except (
-            asyncio.queues.QueueFull,
-            asyncio.exceptions.TimeoutError,
-        ) as err:
+        except (asyncio.QueueFull, asyncio.TimeoutError) as err:
             compat.raise_(
                 Full(),
                 replace_context=err,
@@ -266,7 +263,7 @@ class AsyncAdaptedQueue:
     def get_nowait(self):
         try:
             return self._queue.get_nowait()
-        except asyncio.queues.QueueEmpty as err:
+        except asyncio.QueueEmpty as err:
             compat.raise_(
                 Empty(),
                 replace_context=err,
@@ -283,10 +280,7 @@ class AsyncAdaptedQueue:
                 )
             else:
                 return self.await_(self._queue.get())
-        except (
-            asyncio.queues.QueueEmpty,
-            asyncio.exceptions.TimeoutError,
-        ) as err:
+        except (asyncio.QueueEmpty, asyncio.TimeoutError) as err:
             compat.raise_(
                 Empty(),
                 replace_context=err,

--- a/test/base/test_concurrency_py3k.py
+++ b/test/base/test_concurrency_py3k.py
@@ -161,6 +161,10 @@ class TestAsyncioCompat(fixtures.TestBase):
 
 
 class TestAsyncAdaptedQueue(fixtures.TestBase):
+    # uses asyncio.run() in alternate threads which is not available
+    # in Python 3.6
+    __requires__ = ("python37",)
+
     def test_lazy_init(self):
         run = [False]
 


### PR DESCRIPTION
Tests here are failing for python 3.6 due to the lack
of asyncio.run().   It seems to be non-trivial to vendor
a working version of this in Python 3.6 as the tests here
are running it in alternate threads.

Change-Id: I9398c9fb2aa87f3228ce2f59277de732091bd541

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
