### PR TITLE
Literal compile DateTime objects for PG dialect

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1847,6 +1847,9 @@ colspecs = {
     sqltypes.Enum: ENUM,
     sqltypes.JSON.JSONPathType: _json.JSONPathType,
     sqltypes.JSON: _json.JSON,
+    sqltypes.DateTime: default._StrDateTime,
+    sqltypes.Date: default._StrDate,
+    sqltypes.Time: default._StrTime,
 }
 
 ischema_names = {


### PR DESCRIPTION
### Description
PG compiler can now literal compile datetime objects

<!-- Describe your changes in detail -->
This PR adds string handling for PG dialect. Continuation for #5052

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

Need to add test.


This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
