### PR TITLE
orm/session.py - comment grammar fix

### DIFF
--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -1693,7 +1693,7 @@ class Session(_SessionClassMethods):
 
         This clears all items and ends any transaction in progress.
 
-        If this session were created with ``autocommit=False``, a new
+        If this Session was created with ``autocommit=False``, a new
         transaction will be begun when the :class:`.Session` is next asked
         to procure a database connection.
 


### PR DESCRIPTION
A minor grammar fix in the comment

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed