### PR TITLE
Support legacy select(<iterable>) in addition to select(<list>) in v1.4

### DIFF
--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -39,6 +39,7 @@ from .base import Generative
 from .base import HasCompileState
 from .base import HasMemoized
 from .base import Immutable
+from .base import ImmutableColumnCollection
 from .base import prefix_anon_map
 from .coercions import _document_text_coercion
 from .elements import _anonymous_label
@@ -4871,9 +4872,7 @@ class Select(
 
         """
         if (
-            args
-            and hasattr(args[0], "__iter__")
-            and not hasattr(args[0], "strip")
+            args and isinstance(args[0], (list, ImmutableColumnCollection))
         ) or kw:
             return cls.create_legacy_select(*args, **kw)
         else:

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -4870,7 +4870,7 @@ class Select(
           constructs as given, as well as ORM-mapped classes.
 
         """
-        if (args and isinstance(args[0], list)) or kw:
+        if (args and hasattr(args[0], '__iter__')) or kw:
             return cls.create_legacy_select(*args, **kw)
         else:
             return cls._create_future_select(*args)

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -4870,7 +4870,11 @@ class Select(
           constructs as given, as well as ORM-mapped classes.
 
         """
-        if (args and hasattr(args[0], '__iter__')) or kw:
+        if (
+            args
+            and hasattr(args[0], "__iter__")
+            and not hasattr(args[0], "strip")
+        ) or kw:
             return cls.create_legacy_select(*args, **kw)
         else:
             return cls._create_future_select(*args)

--- a/test/sql/test_deprecations.py
+++ b/test/sql/test_deprecations.py
@@ -437,15 +437,6 @@ class SelectableTest(fixtures.TestBase, AssertsCompiledSQL):
             stmt = select([column("q")])
         self.assert_compile(stmt, "SELECT q")
 
-    def test_select_iterable_argument(self):
-
-        with testing.expect_deprecated_20(
-            r"The legacy calling style of select\(\) is deprecated "
-            "and will be removed in SQLAlchemy 2.0"
-        ):
-            stmt = select(iter([column("q")]))
-        self.assert_compile(stmt, "SELECT q")
-
     def test_select_immutable_column_collection_argument(self):
         t1 = table("t1", column("q"))
 

--- a/test/sql/test_deprecations.py
+++ b/test/sql/test_deprecations.py
@@ -446,6 +446,16 @@ class SelectableTest(fixtures.TestBase, AssertsCompiledSQL):
             stmt = select(iter([column("q")]))
         self.assert_compile(stmt, "SELECT q")
 
+    def test_select_immutable_column_collection_argument(self):
+        t1 = table("t1", column("q"))
+
+        with testing.expect_deprecated_20(
+            r"The legacy calling style of select\(\) is deprecated "
+            "and will be removed in SQLAlchemy 2.0"
+        ):
+            stmt = select(t1.c)
+        self.assert_compile(stmt, "SELECT t1.q FROM t1")
+
     def test_select_kw_argument(self):
 
         with testing.expect_deprecated_20(

--- a/test/sql/test_deprecations.py
+++ b/test/sql/test_deprecations.py
@@ -437,6 +437,15 @@ class SelectableTest(fixtures.TestBase, AssertsCompiledSQL):
             stmt = select([column("q")])
         self.assert_compile(stmt, "SELECT q")
 
+    def test_select_iterable_argument(self):
+
+        with testing.expect_deprecated_20(
+            r"The legacy calling style of select\(\) is deprecated "
+            "and will be removed in SQLAlchemy 2.0"
+        ):
+            stmt = select(iter([column("q")]))
+        self.assert_compile(stmt, "SELECT q")
+
     def test_select_kw_argument(self):
 
         with testing.expect_deprecated_20(


### PR DESCRIPTION
### Description
In v1.3 `sqlalchemy.select` supports an arbitrary iterable as the first argument. In v1.4 there was a minor regression that limits the first argument to a `list`. This change re-allows an iterable first argument

Resolves #5935

### Checklist
This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.