### PR TITLE
Fix small documentation error in declarative_mixins.rst

### DIFF
--- a/doc/build/orm/declarative_mixins.rst
+++ b/doc/build/orm/declarative_mixins.rst
@@ -352,7 +352,7 @@ attribute of each ``StringAttribute`` instance.
 argument ``strings``, a list of strings::
 
     ta = TypeA(strings=['foo', 'bar'])
-    tb = TypeA(strings=['bat', 'bar'])
+    tb = TypeB(strings=['bat', 'bar'])
 
 This list will generate a collection
 of ``StringAttribute`` objects, which are persisted into a table that's


### PR DESCRIPTION
Variables ta and tb should be instances of TypeA and TypeB respectively.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
It says: "TypeA or TypeB can be instantiated given the constructor argument strings, a list of strings:"
 
So it should be:
ta = TypeA(strings=['foo', 'bar'])
tb = TypeB(strings=['bat', 'bar'])

instead of: 
ta = TypeA(strings=['foo', 'bar'])
tb = TypeA(strings=['bat', 'bar'])

<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
