### PR TITLE
ORM tutorial: As of 1.1, there are five object states

### DIFF
--- a/doc/build/orm/tutorial.rst
+++ b/doc/build/orm/tutorial.rst
@@ -518,7 +518,7 @@ The level of reloading is configurable as is described in :doc:`/orm/session`.
 
    As our ``User`` object moved from being outside the :class:`.Session`, to
    inside the :class:`.Session` without a primary key, to actually being
-   inserted, it moved between three out of four
+   inserted, it moved between three out of five
    available "object states" - **transient**, **pending**, and **persistent**.
    Being aware of these states and what they mean is always a good idea -
    be sure to read :ref:`session_object_states` for a quick overview.


### PR DESCRIPTION
### Description
Update the ORM tutorial to refer to three of five rather than three of four object states. The ``deleted`` state was added in version 1.1.

### Checklist

This pull request is:

- A documentation / typographical error fix
