### PR TITLE
Added import of synonym in example code in Synonym portion of docs

### DIFF
--- a/doc/build/orm/mapped_attributes.rst
+++ b/doc/build/orm/mapped_attributes.rst
@@ -256,6 +256,8 @@ to "mirror" another attribute that is mapped.
 In the most basic sense, the synonym is an easy way to make a certain
 attribute available by an additional name::
 
+    from sqlalchemy.orm import synonym
+    
     class MyClass(Base):
         __tablename__ = 'my_table'
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [X] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

All the other sections show you how to import the topic in question at least once (usually when the first instance of example code is presented).  However, it appears that in the [Synonym section](https://docs.sqlalchemy.org/en/latest/orm/mapped_attributes.html#synonyms) there is never a code example which indicates how to import a `synonym`.  This just simple change to maintain the consistency of the documentation.  Thank you for taking my change into consideration!

**Have a nice day! 🙃**
