### PR TITLE
fix 1.4 migration notes about sqlite implementation of regexp_match()

### DIFF
--- a/doc/build/changelog/migration_14.rst
+++ b/doc/build/changelog/migration_14.rst
@@ -516,7 +516,7 @@ The regular expression syntaxes and flags are **not backend agnostic**.
 A future feature will allow multiple regular expression syntaxes to be
 specified at once to switch between different backends on the fly.
 
-For SQLite, Python's ``re.match()`` function with no additional arguments
+For SQLite, Python's ``re.search()`` function with no additional arguments
 is established as the implementation.
 
 .. seealso::


### PR DESCRIPTION
- follow-up ec264a5a2c810394ee4ebd7a78f83fc0ea785c1f

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.