### PR TITLE
Fixes #6069

### DIFF
--- a/doc/build/changelog/unreleased_14/6069.rst
+++ b/doc/build/changelog/unreleased_14/6069.rst
@@ -1,0 +1,9 @@
+.. change::
+    :tags: bug, orm
+    :tickets: 6069
+
+    Fixed a bug where python 2.7.5 (default on CentOS 7) wasn't able to import
+    sqlalchemy, because on this version of Python ``exec "statement"`` and
+    ``exec("statement")`` do not behave the same way. Switching back to the
+    statement based ``exec`` solved ths.
+    

--- a/lib/sqlalchemy/sql/lambdas.py
+++ b/lib/sqlalchemy/sql/lambdas.py
@@ -25,6 +25,7 @@ from .. import exc
 from .. import inspection
 from .. import util
 from ..util import collections_abc
+from ..util import compat
 
 _closure_per_cache_key = util.LRUCache(1000)
 
@@ -1064,7 +1065,7 @@ class AnalyzedFunction(object):
         code += "        return %s\n" % ", ".join("i%d" % i for i in argrange)
         code += "    return closure.__closure__"
         vars_ = {"o%d" % i: cell_values[i] for i in argrange}
-        exec(code, vars_, vars_)
+        compat.exec_(code, vars_, vars_)
         closure = vars_["make_cells"]()
 
         func = type(f)(


### PR DESCRIPTION
This fixes an error on python 2.7.5 (the python version packaged in centos 7) which failed to import sqlalchemy with errors like this:

```
  File "/home/staging/virtualenv/lib/python2.7/site-packages/sqlalchemy/sql/lambdas.py", line 1067
    exec(code, vars_, vars_)
SyntaxError: unqualified exec is not allowed in function '_rewrite_code_obj' it contains a nested function with free variables
```

### Description
This switches out python bulletin exec() for util.compat.exec_ as that will use the statement based version of exec on python 2, which does not have the bug, while the function based version of `builtin.exec()` does.

### Checklist
This pull request is:

- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.

I'm not sure how to best provide a test for this, as it would require sqlalchemy to have a regular test executor on python 2.7.5 to be meaningful. Which I'm pretty sure will not happen anymore.
