### PR TITLE
update pg8000 dialect is_disconnect method Fixes: #6099

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/pg8000.py
+++ b/lib/sqlalchemy/dialects/postgresql/pg8000.py
@@ -328,7 +328,12 @@ class PGDialect_pg8000(PGDialect):
         return ([], opts)
 
     def is_disconnect(self, e, connection, cursor):
-        return "connection is closed" in str(e)
+        if isinstance(e, self.dbapi.InterfaceError):
+            # pg8000 returns InterfaceError with message set to
+            # "network error on read", "network error on write", or
+            # "network error on flush" in case of connection issues.
+            return str(e).startswith("network error")
+        return False
 
     def set_isolation_level(self, connection, level):
         level = level.replace("_", " ")


### PR DESCRIPTION
### Description
With `pg8000` release `1.19.0`, now connection issues are raising `InterfaceError` with message `network error` in error.
Previous to this release, it was releasing either `struct.error` or `BrokenPipeError` this `is_disconnect` function was not functional.

I already opened issue #6099. I couldn't be sure about where to add tests, `test_reconnect.py` seemed the most relevant however tests mostly seemed like that they are tried for every dialect.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
