### PR TITLE
Bug fix for code example: append to addresses instead of User object

### DIFF
--- a/doc/build/orm/cascades.rst
+++ b/doc/build/orm/cascades.rst
@@ -89,7 +89,7 @@ object, ``address3`` to the ``user1.addresses`` collection, it
 becomes part of the state of that :class:`.Session`::
 
     >>> address3 = Address()
-    >>> user1.append(address3)
+    >>> user1.addresses.append(address3)
     >>> address3 in sess
     >>> True
 


### PR DESCRIPTION
Correct a mistake in a code example.