### PR TITLE
Fix incorrect module reference in migration docs

### DIFF
--- a/doc/build/changelog/migration_20.rst
+++ b/doc/build/changelog/migration_20.rst
@@ -268,7 +268,7 @@ the SQLAlchemy project itself, the approach taken is as follows:
             r".*DefaultGenerator.execute\(\)",
         ]:
           warnings.filterwarnings(
-              "error", message=msg, category=sa_exc.RemovedIn20Warning,
+              "error", message=msg, category=exc.RemovedIn20Warning,
           )
 
         # for all other warnings, just log


### PR DESCRIPTION
Fix incorrect module reference (`sa_exc` instead of `exc`) in migration docs.

Found in page: https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#migration-to-2-0-step-three-resolve-all-removedin20warnings

### Description
Fix incorrect module reference (`sa_exc` instead of `exc`) in migration docs.

Found in page: https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#migration-to-2-0-step-three-resolve-all-removedin20warnings

### Checklist

This pull request is:

- [X] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
