### PR TITLE
Pass legacy flag to `_create_entities_collection`

### DIFF
--- a/examples/dogpile_caching/caching_query.py
+++ b/examples/dogpile_caching/caching_query.py
@@ -42,7 +42,7 @@ class ORMCache(object):
         event.listen(session_factory, "do_orm_execute", self._do_orm_execute)
 
     def _do_orm_execute(self, orm_context):
-
+        
         for opt in orm_context.user_defined_options:
             if isinstance(opt, RelationshipCache):
                 opt = opt._process_orm_context(orm_context)

--- a/examples/dogpile_caching/caching_query.py
+++ b/examples/dogpile_caching/caching_query.py
@@ -42,7 +42,7 @@ class ORMCache(object):
         event.listen(session_factory, "do_orm_execute", self._do_orm_execute)
 
     def _do_orm_execute(self, orm_context):
-        
+
         for opt in orm_context.user_defined_options:
             if isinstance(opt, RelationshipCache):
                 opt = opt._process_orm_context(orm_context)

--- a/lib/sqlalchemy/orm/loading.py
+++ b/lib/sqlalchemy/orm/loading.py
@@ -201,7 +201,7 @@ def merge_frozen_result(session, statement, frozen_result, load=True):
         session._autoflush()
 
     ctx = querycontext.ORMSelectCompileState._create_entities_collection(
-        statement
+        statement, legacy=False
     )
 
     autoflush = session.autoflush
@@ -262,7 +262,7 @@ def merge_result(query, iterator, load=True):
         frozen_result = None
 
     ctx = querycontext.ORMSelectCompileState._create_entities_collection(
-        query, True
+        query, legacy=True
     )
 
     autoflush = session.autoflush


### PR DESCRIPTION
When implementing the the caching_query._do_orm_execute function from the provided examples it calls a function from the loading package called `loading.merge_frozen_result` that breaks when executing `ORMSelectCompileState._create_entities_collection`

### Description
Fixes #6211 

When calling  `loading.merge_frozen_result` from the `caching_query._do_orm_execute` function from the provided examples, pass missing legacy flag as False to  `ORMSelectCompileState._create_entities_collection`

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
