### PR TITLE
Improve cascade backrefs warning and add `code` to deprecation warnings

### DIFF
--- a/doc/build/changelog/migration_14.rst
+++ b/doc/build/changelog/migration_14.rst
@@ -2144,16 +2144,18 @@ The above behavior was an unintended side effect of backref behavior, in that
 since ``a1.user`` implies ``u1.addresses.append(a1)``, ``a1`` would get
 cascaded into the :class:`_orm.Session`.  This remains the default behavior
 throughout 1.4.     At some point, a new flag :paramref:`_orm.relationship.cascade_backrefs`
-was added to disable to above behavior, as it can be surprising and also gets in
-the way of some operations where the object would be placed in the :class:`_orm.Session`
-too early and get prematurely flushed.
+was added to disable to above behavior, along with :paramref:`_orm.backref.cascade_backrefs`
+to set this when the relationship is specified by ``relationship.backref``, as it can be
+surprising and also gets in the way of some operations where the object would be placed in
+the :class:`_orm.Session` too early and get prematurely flushed.
 
 In 2.0, the default behavior will be that "cascade_backrefs" is False, and
 additionally there will be no "True" behavior as this is not generally a desirable
 behavior.    When 2.0 deprecation warnings are enabled, a warning will be emitted
 when a "backref cascade" actually takes place.    To get the new behavior, either
-set :paramref:`_orm.relationship.cascade_backrefs` to ``False`` on the target
-relationship, as is already supported in 1.3 and earlier, or alternatively make
+set :paramref:`_orm.relationship.cascade_backrefs` and
+:paramref:`_orm.backref.cascade_backrefs` to ``False`` on any target
+relationships, as is already supported in 1.3 and earlier, or alternatively make
 use of the :paramref:`_orm.Session.future` flag to :term:`2.0-style` mode::
 
     Session = sessionmaker(engine, future=True)

--- a/doc/build/errors.rst
+++ b/doc/build/errors.rst
@@ -172,6 +172,24 @@ In SQLAlchemy 1.4, this :term:`2.0 style` behavior is enabled when the
 :paramref:`_orm.Session.future` flag is set on :class:`_orm.sessionmaker`
 or :class:`_orm.Session`.
 
+.. _error_s9r1:
+
+Object is being merged into a Session along the backref cascade
+---------------------------------------------------------------
+
+Backref cascades are being removed in SQLAlchemy 2.0. This is a behavior in
+which ORM relationships add objects to the session in a potentially
+surprising way.
+
+To get the 2.0 behavior, set the :paramref:`_orm.relationship.cascade_backrefs` and
+:paramref:`_orm.backref.cascade_backrefs` parameters.
+:paramref:`_orm.relationship.backref` values should be updated from strings, if
+used, to :func:`~.sqlalchemy.orm.backref` function calls.
+
+For more details on the backref cascade, see the section
+:ref:`backref_cascade`. You can also read more about the deprecation and its
+rationale in the section :ref:`change_5150`.
+
 Connections and Transactions
 ============================
 

--- a/doc/build/orm/cascades.rst
+++ b/doc/build/orm/cascades.rst
@@ -555,6 +555,8 @@ operation should be propagated down to referred objects.
 
 .. _backref_cascade:
 
+.. _error_s9r1:
+
 Controlling Cascade on Backrefs
 -------------------------------
 

--- a/doc/build/orm/cascades.rst
+++ b/doc/build/orm/cascades.rst
@@ -603,7 +603,18 @@ option may be helpful for situations where an object needs to be kept out of a
 session until it's construction is completed, but still needs to be given
 associations to objects which are already persistent in the target session.
 
+When relationships are created by the ``backref`` parameter to
+``relationship()``, ``cascade_backrefs=False`` can be set by using the
+``backref()`` function instead of a string. For example, the above relationship
+could be declared::
 
+    mapper_registry.map_imperatively(Order, order_table, properties={
+        'items' : relationship(
+            Item, backref=backref('order', cascade_backrefs=False), cascade_backrefs=False
+        )
+    })
+
+This sets the ``cascade_backrefs=False`` behavior on both relationships.
 
 .. _session_deleting_from_collections:
 

--- a/doc/build/orm/cascades.rst
+++ b/doc/build/orm/cascades.rst
@@ -555,8 +555,6 @@ operation should be propagated down to referred objects.
 
 .. _backref_cascade:
 
-.. _error_s9r1:
-
 Controlling Cascade on Backrefs
 -------------------------------
 
@@ -605,9 +603,10 @@ option may be helpful for situations where an object needs to be kept out of a
 session until it's construction is completed, but still needs to be given
 associations to objects which are already persistent in the target session.
 
-When relationships are created by the ``backref`` parameter to
-``relationship()``, ``cascade_backrefs=False`` can be set by using the
-``backref()`` function instead of a string. For example, the above relationship
+When relationships are created by the :paramref:`_orm.relationship.backref`
+parameter on :func:`_orm.relationship`, the :paramref:`_orm.cascade_backrefs`
+parameter may be set to ``False`` on the backref side by using the
+:func:`_orm.backref` function instead of a string. For example, the above relationship
 could be declared::
 
     mapper_registry.map_imperatively(Order, order_table, properties={

--- a/lib/sqlalchemy/exc.py
+++ b/lib/sqlalchemy/exc.py
@@ -19,7 +19,7 @@ from .util import compat
 _version_token = None
 
 
-class _CodeStrMixin(object):
+class HasDescriptionCode:
     """helper which adds 'code' as an attribute and '_code_str' as a method"""
 
     code = None
@@ -28,7 +28,7 @@ class _CodeStrMixin(object):
         code = kw.pop("code", None)
         if code is not None:
             self.code = code
-        super(_CodeStrMixin, self).__init__(*arg, **kw)
+        super(HasDescriptionCode, self).__init__(*arg, **kw)
 
     def _code_str(self):
         if not self.code:
@@ -44,7 +44,7 @@ class _CodeStrMixin(object):
             )
 
 
-class SQLAlchemyError(_CodeStrMixin, Exception):
+class SQLAlchemyError(HasDescriptionCode, Exception):
     """Generic error class."""
 
     def _message(self, as_unicode=compat.py3k):
@@ -654,7 +654,7 @@ class NotSupportedError(DatabaseError):
 # Warnings
 
 
-class SADeprecationWarning(_CodeStrMixin, DeprecationWarning):
+class SADeprecationWarning(HasDescriptionCode, DeprecationWarning):
     """Issued for usage of deprecated APIs."""
 
     deprecated_since = None

--- a/lib/sqlalchemy/exc.py
+++ b/lib/sqlalchemy/exc.py
@@ -681,6 +681,12 @@ class RemovedIn20Warning(SADeprecationWarning):
     deprecated_since = "1.4"
     "Indicates the version that started raising this deprecation warning"
 
+    def __str__(self):
+        return (
+            super(RemovedIn20Warning, self).__str__()
+            + " (Background on SQLAlchemy 2.0 at: http://sqlalche.me/e/b8d9)"
+        )
+
 
 class MovedIn20Warning(RemovedIn20Warning):
     """Subtype of RemovedIn20Warning to indicate an API that moved only."""

--- a/lib/sqlalchemy/exc.py
+++ b/lib/sqlalchemy/exc.py
@@ -19,7 +19,7 @@ from .util import compat
 _version_token = None
 
 
-class HasDescriptionCode:
+class HasDescriptionCode(object):
     """helper which adds 'code' as an attribute and '_code_str' as a method"""
 
     code = None

--- a/lib/sqlalchemy/orm/unitofwork.py
+++ b/lib/sqlalchemy/orm/unitofwork.py
@@ -26,7 +26,8 @@ def _warn_for_cascade_backrefs(state, prop):
         '"%s" object is being merged into a Session along the backref '
         'cascade path for relationship "%s"; in SQLAlchemy 2.0, this '
         "reverse cascade will not take place.  Set cascade_backrefs to "
-        "False for the 2.0 behavior; or to set globally for the whole "
+        "False in either the relationship() or backref() function for "
+        "the 2.0 behavior; or to set globally for the whole "
         "Session, set the future=True flag" % (state.class_.__name__, prop)
     )
 

--- a/lib/sqlalchemy/orm/unitofwork.py
+++ b/lib/sqlalchemy/orm/unitofwork.py
@@ -28,7 +28,8 @@ def _warn_for_cascade_backrefs(state, prop):
         "reverse cascade will not take place.  Set cascade_backrefs to "
         "False in either the relationship() or backref() function for "
         "the 2.0 behavior; or to set globally for the whole "
-        "Session, set the future=True flag" % (state.class_.__name__, prop)
+        "Session, set the future=True flag" % (state.class_.__name__, prop),
+        code="s9r1",
     )
 
 

--- a/lib/sqlalchemy/util/deprecations.py
+++ b/lib/sqlalchemy/util/deprecations.py
@@ -26,7 +26,7 @@ if os.getenv("SQLALCHEMY_WARN_20", "false").lower() in ("true", "yes", "1"):
     SQLALCHEMY_WARN_20 = True
 
 
-def _warn_with_version(msg, version, type_, stacklevel):
+def _warn_with_version(msg, version, type_, stacklevel, code=None):
     is_20 = issubclass(type_, exc.RemovedIn20Warning)
 
     if is_20 and not SQLALCHEMY_WARN_20:
@@ -35,33 +35,38 @@ def _warn_with_version(msg, version, type_, stacklevel):
     if is_20:
         msg += " (Background on SQLAlchemy 2.0 at: http://sqlalche.me/e/b8d9)"
 
-    warn = type_(msg)
+    warn = type_(msg, code=code)
     warn.deprecated_since = version
 
     warnings.warn(warn, stacklevel=stacklevel + 1)
 
 
-def warn_deprecated(msg, version, stacklevel=3):
-    _warn_with_version(msg, version, exc.SADeprecationWarning, stacklevel)
+def warn_deprecated(msg, version, stacklevel=3, code=None):
+    _warn_with_version(
+        msg, version, exc.SADeprecationWarning, stacklevel, code=code
+    )
 
 
-def warn_deprecated_limited(msg, args, version, stacklevel=3):
+def warn_deprecated_limited(msg, args, version, stacklevel=3, code=None):
     """Issue a deprecation warning with a parameterized string,
     limiting the number of registrations.
 
     """
     if args:
         msg = _hash_limit_string(msg, 10, args)
-    _warn_with_version(msg, version, exc.SADeprecationWarning, stacklevel)
+    _warn_with_version(
+        msg, version, exc.SADeprecationWarning, stacklevel, code=code
+    )
 
 
-def warn_deprecated_20(msg, stacklevel=3):
+def warn_deprecated_20(msg, stacklevel=3, code=None):
 
     _warn_with_version(
         msg,
         exc.RemovedIn20Warning.deprecated_since,
         exc.RemovedIn20Warning,
         stacklevel,
+        code=code,
     )
 
 

--- a/lib/sqlalchemy/util/deprecations.py
+++ b/lib/sqlalchemy/util/deprecations.py
@@ -27,13 +27,8 @@ if os.getenv("SQLALCHEMY_WARN_20", "false").lower() in ("true", "yes", "1"):
 
 
 def _warn_with_version(msg, version, type_, stacklevel, code=None):
-    is_20 = issubclass(type_, exc.RemovedIn20Warning)
-
-    if is_20 and not SQLALCHEMY_WARN_20:
+    if issubclass(type_, exc.RemovedIn20Warning) and not SQLALCHEMY_WARN_20:
         return
-
-    if is_20:
-        msg += " (Background on SQLAlchemy 2.0 at: http://sqlalche.me/e/b8d9)"
 
     warn = type_(msg, code=code)
     warn.deprecated_since = version

--- a/test/orm/test_cascade.py
+++ b/test/orm/test_cascade.py
@@ -1394,6 +1394,10 @@ class NoSaveCascadeFlushTest(_fixtures.FixtureTest):
             with testing.expect_deprecated(
                 '"Address" object is being merged into a Session along '
                 'the backref cascade path for relationship "User.addresses"'
+                # link added to this specific warning
+                r".*Background on this error at: http://sqlalche.me/e/14/s9r1"
+                # link added to all RemovedIn20Warnings
+                r".*Background on SQLAlchemy 2.0 at: http://sqlalche.me/e/b8d9"
             ):
                 a1.user = u1
             sess.add(a1)


### PR DESCRIPTION
Fixes #6148 

The goal is to get an improved warning for users about "backref cascades" in 1.4 when `SQLALCHEMY_WARN_20=1`.

Per @zzzeek's advice in that issue (again, huge thanks for helping onboard someone new into contributing!), I've
- updated the warning text
- updated the doc on ORM cascades to mention `backref.cascade_backrefs` in addition to `relationship.cascade_backrefs`
- added mention of `backref.cascade_backrefs` to the 1.4 migration docs
- added a `code` to deprecation warnings, so that the relevant warning links to doc on ORM cascades

Most of the work is done in separate commits to make review easy, but I can rebase and squash if we intend to keep the change history.

The resulting warning now looks like so:
```
sqlalchemy.exc.RemovedIn20Warning: "Address" object is being merged into a Session along the backref cascade path for relationship "User.addresses"; in SQLAlchemy 2.0, this reverse cascade will not take place.  Set cascade_backrefs to False in either the relationship() or backref() function for the 2.0 behavior; or to set globally for the whole Session, set the future=True flag (Background on SQLAlchemy 2.0 at: http://sqlalche.me/e/b8d9) (Background on this error at: http://sqlalche.me/e/14/s9r1)
```

---

There are three parts of this that I'm not certain about, and I'd like to ask for advice/help getting this into a merge-ready state.

1. Adding `code` to warning objects

I looked at the stdlib's `warnings` to see how warnings are printed. [This line puts warnings in a small wrapper](https://github.com/python/cpython/blob/0983e01837714524fb164e784a8e96a2bc4bdf94/Lib/warnings.py#L394) and [then typically this is how that wrapper gets string-formatted](https://github.com/python/cpython/blob/0983e01837714524fb164e784a8e96a2bc4bdf94/Lib/warnings.py#L36-L37).

So all that we need to adjust is how `RemovedIn20Warning.__str__` behaves. That could be done by modifying the warning text, or by adjusting `__str__` directly. I opted for the latter, so `SADeprecationWarning` now has a modified `__str__` method.

I chose to do this by pulling `code` and `_code_str` from `SQLAlchemyError` into a mixin and then sharing that between both `SQLAlchemyError` and `SADeprecationWarning`. I wasn't sure if this would be preferable, vs copying the `code` and `_code_str` components into `SADeprecationWarning` without using the mixin, or some other approach.

I'm also not certain that this is all wanted or not?
It's simpler to just modify the message if `code != None` in `sqlalchemy.util.deprecations`, but this puts plumbing in place for deprecations to have a `code` in general.

(Aside: If the warnings have custom `__str__` methods, maybe the special-case message text for `RemovedIn20Warning` should be handled there as well?)

2. Testing

This passes existing tests today (at least, those which run under `tox -e py39-sqlite`, but it probably doesn't damage anything else).

At a minimum, some new test should cover the `SADeprecationWarning.code` behavior.

I looked at the existing tests for the ORM cascade and for deprecations, and I was a bit overwhelmed. I would like to add a test that verifies that `http://sqlalche.me/e/{version}/s9r1` appears in the deprecation warnings now, but I don't know how to do so. Any guidance on how to test this change would be a big help.

3. Are the new docs good?

The goal of these additions is primarily to make it clear that `backref.cascade_backrefs` exists, and you can read up on it if necessary. Was that accomplished? Would more narrative doc be helpful?
As a user, I've only interacted with these features very minimally, so I'm not confident that I captured everything important or stated things well.