### PR TITLE
Fixed deprecated imports in orm/extensions docs

### DIFF
--- a/doc/build/orm/extensions/associationproxy.rst
+++ b/doc/build/orm/extensions/associationproxy.rst
@@ -24,8 +24,7 @@ Each ``User`` can have any number of ``Keyword`` objects, and vice-versa
 (the many-to-many pattern is described at :ref:`relationships_many_to_many`)::
 
     from sqlalchemy import Column, Integer, String, ForeignKey, Table
-    from sqlalchemy.orm import relationship
-    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.orm import declarative_base, relationship
 
     Base = declarative_base()
 
@@ -167,10 +166,8 @@ collection of ``User`` to the ``.keyword`` attribute present on each
 ``UserKeyword``::
 
     from sqlalchemy import Column, Integer, String, ForeignKey
-    from sqlalchemy.orm import relationship, backref
-
     from sqlalchemy.ext.associationproxy import association_proxy
-    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.orm import backref, declarative_base, relationship
 
     Base = declarative_base()
 
@@ -277,9 +274,8 @@ argument to the ``User.keywords`` proxy so that these values are assigned approp
 when new elements are added to the dictionary::
 
     from sqlalchemy import Column, Integer, String, ForeignKey
-    from sqlalchemy.orm import relationship, backref
     from sqlalchemy.ext.associationproxy import association_proxy
-    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.orm import backref, declarative_base, relationship    
     from sqlalchemy.orm.collections import attribute_mapped_collection
 
     Base = declarative_base()
@@ -353,10 +349,8 @@ an association proxy on ``User`` that refers to an association proxy
 present on ``UserKeyword``::
 
     from sqlalchemy import Column, Integer, String, ForeignKey
-    from sqlalchemy.orm import relationship, backref
-
     from sqlalchemy.ext.associationproxy import association_proxy
-    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.orm import backref, declarative_base, relationship 
     from sqlalchemy.orm.collections import attribute_mapped_collection
 
     Base = declarative_base()

--- a/doc/build/orm/extensions/asyncio.rst
+++ b/doc/build/orm/extensions/asyncio.rst
@@ -100,9 +100,9 @@ illustrates a complete example including mapper and session configuration::
     from sqlalchemy import Integer
     from sqlalchemy import String
     from sqlalchemy.ext.asyncio import AsyncSession
-    from sqlalchemy.ext.asyncio import create_async_engine
-    from sqlalchemy.ext.declarative import declarative_base
+    from sqlalchemy.ext.asyncio import create_async_engine    
     from sqlalchemy.future import select
+    from sqlalchemy.orm import declarative_base
     from sqlalchemy.orm import relationship
     from sqlalchemy.orm import selectinload
     from sqlalchemy.orm import sessionmaker


### PR DESCRIPTION
### Description
Fixed deprecated imports for `declarative_base` in `orm/extensions` documentation.

Pages:
https://docs.sqlalchemy.org/en/14/orm/extensions/asyncio.html
https://docs.sqlalchemy.org/en/14/orm/extensions/associationproxy.html

Since 1.4 `declarative_base` was moved to `sqlalchemy.orm` module.
Changelog: https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#migration-orm-configuration


### Checklist
This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
