### PR TITLE
Use SingletonThreadPool for in-memory SQLite database created using filename uri

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/pysqlite.py
+++ b/lib/sqlalchemy/dialects/sqlite/pysqlite.py
@@ -474,7 +474,9 @@ class SQLiteDialect_pysqlite(SQLiteDialect):
 
     @classmethod
     def _is_url_file_db(cls, url):
-        if url.database and url.database != ":memory:":
+        if (url.database and url.database != ":memory:") and (
+            url.query.get("mode", None) != "memory"
+        ):
             return True
         else:
             return False

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -710,6 +710,11 @@ class DialectTest(
         e = create_engine("sqlite+pysqlite:///:memory:")
         assert e.pool.__class__ is pool.SingletonThreadPool
 
+        e = create_engine(
+            "sqlite+pysqlite:///file:foo.db?mode=memory&uri=true"
+        )
+        assert e.pool.__class__ is pool.SingletonThreadPool
+
         e = create_engine("sqlite+pysqlite:///foo.db")
         assert e.pool.__class__ is pool.NullPool
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
  Fix bug where NullPool is used for in-memory SQLite created using
  filename uri instead of ":memory:".

  Checks for in-memory SQLite database created using filename uri like
  "file:foo.db?mode=memory&uri=true" in addition to in-memory SQLite
  database created using the standard ":memory:".

  Fixes: #6379


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
