### PR TITLE
fix typo in "Connecting to databases with access tokens"

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mssql/pyodbc.py
@@ -124,7 +124,7 @@ database using Azure credentials::
 
         # create token credential
         raw_token = azure_credentials.get_token(TOKEN_URL).token.encode("utf-16-le")
-        token_struct = struct.pack(f"<I{len(raw_token)}s", len(raw_token), token)
+        token_struct = struct.pack(f"<I{len(raw_token)}s", len(raw_token), raw_token)
 
         # apply it to keyword arguments
         cparams["attrs_before"] = {SQL_COPT_SS_ACCESS_TOKEN: token_struct}


### PR DESCRIPTION
There's small typo in "Connecting to databases with access tokens" in mssql/pyodbc.py.

### Description

It's just simple typo fix.


### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed


**Have a nice day!**
