### PR TITLE
Use type_ when creating literals in _LiteralRoundTripFixture

### DIFF
--- a/lib/sqlalchemy/testing/suite/test_types.py
+++ b/lib/sqlalchemy/testing/suite/test_types.py
@@ -63,7 +63,7 @@ class _LiteralRoundTripFixture(object):
             for value in input_:
                 ins = (
                     t.insert()
-                    .values(x=literal(value))
+                    .values(x=literal(value, type_))
                     .compile(
                         dialect=testing.db.dialect,
                         compile_kwargs=dict(literal_binds=True),


### PR DESCRIPTION
Fixes #6496 by passing the `type_` argument passed to `run` to `literal`.

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
