### PR TITLE
Provide primary key values for data in tests that aren't about primary keys.

### DIFF
--- a/lib/sqlalchemy/testing/suite/test_insert.py
+++ b/lib/sqlalchemy/testing/suite/test_insert.py
@@ -119,7 +119,7 @@ class InsertBehaviorTest(fixtures.TablesTest):
 
         with engine.begin() as conn:
             r = conn.execute(
-                self.tables.autoinc_pk.insert(), dict(data="some data")
+                self.tables.autoinc_pk.insert(), dict(id=1, data="some data")
             )
         assert r._soft_closed
         assert not r.closed

--- a/lib/sqlalchemy/testing/suite/test_rowcount.py
+++ b/lib/sqlalchemy/testing/suite/test_rowcount.py
@@ -49,7 +49,8 @@ class RowCountTest(fixtures.TablesTest):
         employees_table = cls.tables.employees
         connection.execute(
             employees_table.insert(),
-            [{"name": n, "department": d} for n, d in data],
+            [{"employee_id": i, "name": n, "department": d}
+             for i, (n, d) in enumerate(data)],
         )
 
     def test_basic(self, connection):

--- a/lib/sqlalchemy/testing/suite/test_types.py
+++ b/lib/sqlalchemy/testing/suite/test_types.py
@@ -116,7 +116,7 @@ class _UnicodeFixture(_LiteralRoundTripFixture, fixtures.TestBase):
     def test_round_trip(self, connection):
         unicode_table = self.tables.unicode_table
 
-        connection.execute(unicode_table.insert(), {"unicode_data": self.data})
+        connection.execute(unicode_table.insert(), {"id": 1, "unicode_data": self.data})
 
         row = connection.execute(select(unicode_table.c.unicode_data)).first()
 
@@ -128,7 +128,7 @@ class _UnicodeFixture(_LiteralRoundTripFixture, fixtures.TestBase):
 
         connection.execute(
             unicode_table.insert(),
-            [{"unicode_data": self.data} for i in range(3)],
+            [{"id": i, "unicode_data": self.data} for i in range(3)],
         )
 
         rows = connection.execute(
@@ -141,14 +141,14 @@ class _UnicodeFixture(_LiteralRoundTripFixture, fixtures.TestBase):
     def _test_null_strings(self, connection):
         unicode_table = self.tables.unicode_table
 
-        connection.execute(unicode_table.insert(), {"unicode_data": None})
+        connection.execute(unicode_table.insert(), {"id": 1, "unicode_data": None})
         row = connection.execute(select(unicode_table.c.unicode_data)).first()
         eq_(row, (None,))
 
     def _test_empty_strings(self, connection):
         unicode_table = self.tables.unicode_table
 
-        connection.execute(unicode_table.insert(), {"unicode_data": u("")})
+        connection.execute(unicode_table.insert(), {"id": 1, "unicode_data": u("")})
         row = connection.execute(select(unicode_table.c.unicode_data)).first()
         eq_(row, (u(""),))
 
@@ -211,7 +211,7 @@ class TextTest(_LiteralRoundTripFixture, fixtures.TablesTest):
     def test_text_roundtrip(self, connection):
         text_table = self.tables.text_table
 
-        connection.execute(text_table.insert(), {"text_data": "some text"})
+        connection.execute(text_table.insert(), {"id": 1, "text_data": "some text"})
         row = connection.execute(select(text_table.c.text_data)).first()
         eq_(row, ("some text",))
 
@@ -219,14 +219,14 @@ class TextTest(_LiteralRoundTripFixture, fixtures.TablesTest):
     def test_text_empty_strings(self, connection):
         text_table = self.tables.text_table
 
-        connection.execute(text_table.insert(), {"text_data": ""})
+        connection.execute(text_table.insert(), {"id": 1, "text_data": ""})
         row = connection.execute(select(text_table.c.text_data)).first()
         eq_(row, ("",))
 
     def test_text_null_strings(self, connection):
         text_table = self.tables.text_table
 
-        connection.execute(text_table.insert(), {"text_data": None})
+        connection.execute(text_table.insert(), {"id": 1, "text_data": None})
         row = connection.execute(select(text_table.c.text_data)).first()
         eq_(row, (None,))
 
@@ -303,7 +303,7 @@ class _DateFixture(_LiteralRoundTripFixture, fixtures.TestBase):
     def test_round_trip(self, connection):
         date_table = self.tables.date_table
 
-        connection.execute(date_table.insert(), {"date_data": self.data})
+        connection.execute(date_table.insert(), {"id": 1, "date_data": self.data})
 
         row = connection.execute(select(date_table.c.date_data)).first()
 
@@ -315,7 +315,7 @@ class _DateFixture(_LiteralRoundTripFixture, fixtures.TestBase):
         date_table = self.tables.date_table
 
         connection.execute(
-            date_table.insert(), {"decorated_date_data": self.data}
+            date_table.insert(), {"id": 1, "decorated_date_data": self.data}
         )
 
         row = connection.execute(
@@ -329,7 +329,7 @@ class _DateFixture(_LiteralRoundTripFixture, fixtures.TestBase):
     def test_null(self, connection):
         date_table = self.tables.date_table
 
-        connection.execute(date_table.insert(), {"date_data": None})
+        connection.execute(date_table.insert(), {"id": 1, "date_data": None})
 
         row = connection.execute(select(date_table.c.date_data)).first()
         eq_(row, (None,))
@@ -347,7 +347,7 @@ class _DateFixture(_LiteralRoundTripFixture, fixtures.TestBase):
         date_table = self.tables.date_table
         with config.db.begin() as conn:
             result = conn.execute(
-                date_table.insert(), {"date_data": self.data}
+                date_table.insert(), {"id": 1, "date_data": self.data}
             )
             id_ = result.inserted_primary_key[0]
             stmt = select(date_table.c.id).where(
@@ -457,7 +457,7 @@ class IntegerTest(_LiteralRoundTripFixture, fixtures.TestBase):
 
             metadata.create_all(config.db)
 
-            connection.execute(int_table.insert(), {"integer_data": data})
+            connection.execute(int_table.insert(), {"id": 1, "integer_data": data})
 
             row = connection.execute(select(int_table.c.integer_data)).first()
 
@@ -816,7 +816,7 @@ class JSONTest(_LiteralRoundTripFixture, fixtures.TablesTest):
         data_table = self.tables.data_table
 
         connection.execute(
-            data_table.insert(), {"name": "row1", "data": data_element}
+            data_table.insert(), {"id": 1, "name": "row1", "data": data_element}
         )
 
         row = connection.execute(select(data_table.c.data)).first()


### PR DESCRIPTION
This addresses #6469 for BigQuery.  That is, these changes allow the BigQuery dialect-compliance tests not to have to work around primary-key values not being provided. There might be other tests that BigQuery doesn't run that should get this treatment.

For many (maybe most or all) of these, a better fix might be to just get rid of the primary-key columns.

I'm not 100% that the primary key column and primary key generation isn't relevant to `test_autoclose_on_insert`, s I'm not 100% sure what it's doing. If this test is about primary keys, however, it should require one of the requirements about generating pk values.

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
