### PR TITLE
Allow usage of cyfunction as validator

### DIFF
--- a/lib/sqlalchemy/orm/mapper.py
+++ b/lib/sqlalchemy/orm/mapper.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 
 from collections import deque
 from itertools import chain
+import inspect
 import sys
 import types
 import weakref
@@ -1262,7 +1263,7 @@ class Mapper(
                 method = method._sa_original_init
                 if isinstance(method, types.MethodType):
                     method = method.__func__
-            if isinstance(method, types.FunctionType):
+            if isinstance(method, types.FunctionType) or inspect._signature_is_functionlike(method):
                 if hasattr(method, "__sa_reconstructor__"):
                     self._reconstructor = method
                     event.listen(manager, "load", _event_on_load, raw=True)


### PR DESCRIPTION
Allow usage of cyfunction as a validator

### Description
Cython changes the base type of functions. Hence, they are no longer recognized as instances of `types.FunctionTypes`. This PR changes this behavior.
Below is the example output from the debugger
![image](https://user-images.githubusercontent.com/25174931/119652189-10833100-be26-11eb-9617-385a5e3af36b.png)

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
