### PR TITLE
Added netezza in external dialects in documentation

### DIFF
--- a/doc/build/dialects/index.rst
+++ b/doc/build/dialects/index.rst
@@ -88,7 +88,10 @@ Currently maintained external dialect projects for SQLAlchemy include:
 +---------------------------------------+---------------------------------------+
 | Teradata Vantage                      | teradatasqlalchemy_                   |
 +---------------------------------------+---------------------------------------+
+| IBM Netezza Performance Server        | nzalchemy_                            |
++---------------------------------------+---------------------------------------+
 
+.. _nzalchemy: https://pypi.org/project/nzalchemy/
 .. _ibm-db-sa: https://pypi.org/project/ibm-db-sa/
 .. _PyHive: https://github.com/dropbox/PyHive#sqlalchemy
 .. _teradatasqlalchemy: https://pypi.org/project/teradatasqlalchemy/

--- a/doc/build/dialects/index.rst
+++ b/doc/build/dialects/index.rst
@@ -72,6 +72,8 @@ Currently maintained external dialect projects for SQLAlchemy include:
 +---------------------------------------+---------------------------------------+
 | IBM DB2 and Informix                  | ibm-db-sa_                            |
 +---------------------------------------+---------------------------------------+
+| IBM Netezza Performance Server        | nzalchemy_                            |
++---------------------------------------+---------------------------------------+
 | Microsoft Access (via pyodbc)         | sqlalchemy-access_                    |
 +---------------------------------------+---------------------------------------+
 | Microsoft SQL Server (via python-tds) | sqlalchemy-tds_                       |
@@ -87,8 +89,6 @@ Currently maintained external dialect projects for SQLAlchemy include:
 | Snowflake                             | snowflake-sqlalchemy_                 |
 +---------------------------------------+---------------------------------------+
 | Teradata Vantage                      | teradatasqlalchemy_                   |
-+---------------------------------------+---------------------------------------+
-| IBM Netezza Performance Server        | nzalchemy_                            |
 +---------------------------------------+---------------------------------------+
 
 .. _nzalchemy: https://pypi.org/project/nzalchemy/


### PR DESCRIPTION
### Description
IBM Netezza Performance Server (aka Netezza, NPS) now has fully function SQLAlchemy dialect. Need to add it in SQLAlchemy 1.3 documentation.
This PR fixes https://github.com/sqlalchemy/sqlalchemy/issues/6609

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
