### PR TITLE
Add impl property to Postgres INTERVAL class

### DIFF
--- a/lib/sqlalchemy/dialects/oracle/base.py
+++ b/lib/sqlalchemy/dialects/oracle/base.py
@@ -702,6 +702,9 @@ class INTERVAL(sqltypes.NativeForEmulated, sqltypes._AbstractInterval):
             day_precision=self.day_precision,
         )
 
+    def coerce_compared_value(self, op, value):
+        return self
+
 
 class ROWID(sqltypes.TypeEngine):
     """Oracle ROWID type.

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1655,6 +1655,9 @@ class INTERVAL(sqltypes.NativeForEmulated, sqltypes._AbstractInterval):
     def python_type(self):
         return dt.timedelta
 
+    @property
+    def impl(self):
+        return self._type_affinity().impl
 
 PGInterval = INTERVAL
 

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1655,9 +1655,8 @@ class INTERVAL(sqltypes.NativeForEmulated, sqltypes._AbstractInterval):
     def python_type(self):
         return dt.timedelta
 
-    @property
-    def impl(self):
-        return self._type_affinity().impl
+    def coerce_compared_value(self, op, value):
+        return self
 
 PGInterval = INTERVAL
 

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1658,6 +1658,7 @@ class INTERVAL(sqltypes.NativeForEmulated, sqltypes._AbstractInterval):
     def coerce_compared_value(self, op, value):
         return self
 
+
 PGInterval = INTERVAL
 
 

--- a/test/dialect/oracle/test_types.py
+++ b/test/dialect/oracle/test_types.py
@@ -183,6 +183,10 @@ class DialectTypesTest(fixtures.TestBase, AssertsCompiledSQL):
     def test_interval(self, type_, expected):
         self.assert_compile(type_, expected)
 
+    def test_interval_coercion_literal(self):
+        expr = column("bar", oracle.INTERVAL) == datetime.timedelta(days=1)
+        eq_(expr.right.type._type_affinity, sqltypes.Interval)
+
 
 class TypesTest(fixtures.TestBase):
     __only_on__ = "oracle"

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -2427,6 +2427,10 @@ class TimestampTest(fixtures.TestBase, AssertsExecutionResults):
         eq_(expr.type._type_affinity, types.Interval)
         assert isinstance(expr.type, postgresql.INTERVAL)
 
+    def test_interval_coercion_literal(self):
+        expr = column("bar", postgresql.INTERVAL) == datetime.timedelta(days=1)
+        eq_(expr.right.type._type_affinity, types.Interval)
+
 
 class SpecialTypesCompileTest(fixtures.TestBase, AssertsCompiledSQL):
     __dialect__ = "postgresql"


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
The missing `.impl` attribute causes any kind of filtering on an `interval` column to fail.

`.impl` is called in `sql.sqltypes._AbstractInterval.coerce_compared_value`, and when the `ColumnElement` is `sql.sqltypes.Interval` this will point to `sql.sqltypes.DateTime`. However, `dialects.postgres.base.INTERVAL` lacks any `.impl` class attribute.

A `.impl` property on `dialects.postgres.base.INTERVAL` is used to create a path, using `_type_affinity()`, to `DateTime` so that `INTERVAL` can be used as a filter criterion.

The fix can be tested with the same procedure as in #6649.

An alternative implementation might be to make `.impl` an attribute of `_AbstractInterval`, assuming this would not create issues in other child classes.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
