### PR TITLE
Explicit exception in context manager

### DIFF
--- a/doc/build/orm/session_basics.rst
+++ b/doc/build/orm/session_basics.rst
@@ -380,7 +380,7 @@ ntextlib.html#contextlib.contextmanager>`_::
         try:
             yield session
             session.commit()
-        except:
+        except BaseException:
             session.rollback()
             raise
         finally:


### PR DESCRIPTION
bare except statement are frowned upon
prefer explicit except BaseException


### Description
- session_scope context manager uses bare `except`
- This doesn't seems to be a good practice https://github.com/PyCQA/flake8-bugbear#list-of-warnings
- Instead of using `Exception` and changing the behavior prefer usage of `BaseException` 
- This should rollback the commits if `KeyboardInterrupt` or similar exceptions raise https://stackoverflow.com/questions/44655854/what-is-the-difference-between-except-and-except-baseexception/63169967#63169967

### Checklist


This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed

**Have a nice day!**
