### PR TITLE
Add "impl" parameter to PickleType

### DIFF
--- a/doc/build/changelog/unreleased_14/6646.rst
+++ b/doc/build/changelog/unreleased_14/6646.rst
@@ -1,5 +1,5 @@
 .. change::
-    :tags: usecase, type
+    :tags: usecase, sql
     :tickets: 6646
 
     Add a impl parameter to :class:`.PickleType` constructor, so the user

--- a/doc/build/changelog/unreleased_14/6646.rst
+++ b/doc/build/changelog/unreleased_14/6646.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: usecase, type
+    :tickets: 6646
+
+    Add a impl parameter to :class:`.PickleType` constructor, so the user
+    can customize the default implementation to avoid the issue that the
+    default LargeBinary impl might not be big enough to store the binary
+    object.

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -1783,7 +1783,11 @@ class PickleType(TypeDecorator):
     cache_ok = True
 
     def __init__(
-        self, protocol=pickle.HIGHEST_PROTOCOL, pickler=None, comparator=None
+        self,
+        protocol=pickle.HIGHEST_PROTOCOL,
+        pickler=None,
+        comparator=None,
+        impl=None,
     ):
         """
         Construct a PickleType.
@@ -1798,11 +1802,19 @@ class PickleType(TypeDecorator):
           to compare values of this type.  If left as ``None``,
           the Python "equals" operator is used to compare values.
 
+        :param impl: Any implementation class that support storing
+          binary object. (e.g. :class: `.mysql.LONGBLOB`).
+          If let as ``None``, the impl would use class's default impl
+          `:class:`.LargeBinary`
+
         """
         self.protocol = protocol
         self.pickler = pickler or pickle
         self.comparator = comparator
         super(PickleType, self).__init__()
+
+        if impl:
+            self.impl = to_instance(impl)
 
     def __reduce__(self):
         return PickleType, (self.protocol, None, self.comparator)

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -1803,9 +1803,10 @@ class PickleType(TypeDecorator):
           the Python "equals" operator is used to compare values.
 
         :param impl: Any implementation class that support storing
-          binary object. (e.g. :class: `.mysql.LONGBLOB`).
-          If let as ``None``, the impl would use class's default impl
+          binary object. (e.g. :class: `_mysql.LONGBLOB`).
+          If left as ``None``, the impl would use class's default impl
           `:class:`.LargeBinary`
+          .. versionadded:: 1.4.20
 
         """
         self.protocol = protocol

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -3809,6 +3809,11 @@ class PickleTest(fixtures.TestBase):
         ):
             assert p1.compare_values(p1.copy_value(obj), obj)
 
+    def test_customized_impl(self):
+        p1 = PickleType(impl=mysql.LONGBLOB)
+
+        assert isinstance(p1.impl, mysql.LONGBLOB)
+
 
 class CallableTest(fixtures.TestBase):
     @testing.provide_metadata

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -3810,8 +3810,10 @@ class PickleTest(fixtures.TestBase):
             assert p1.compare_values(p1.copy_value(obj), obj)
 
     def test_customized_impl(self):
-        p1 = PickleType(impl=mysql.LONGBLOB)
+        p1 = PickleType()
+        assert isinstance(p1.impl, LargeBinary)
 
+        p1 = PickleType(impl=mysql.LONGBLOB)
         assert isinstance(p1.impl, mysql.LONGBLOB)
 
 

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -3810,6 +3810,8 @@ class PickleTest(fixtures.TestBase):
             assert p1.compare_values(p1.copy_value(obj), obj)
 
     def test_customized_impl(self):
+        """test #6646"""
+
         p1 = PickleType()
         assert isinstance(p1.impl, LargeBinary)
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

Add "impl" parameter to PickleType

### Description
1. add a impl parameter in PickleType's constructor to allow user to customize the underlying column type's implementation