### PR TITLE
mysql reflection: Fix TiDB clustered PK comment compatibility

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/reflection.py
+++ b/lib/sqlalchemy/dialects/mysql/reflection.py
@@ -416,7 +416,7 @@ class MySQLTableDefinitionParser(object):
             r"(?: +KEY_BLOCK_SIZE *[ =]? *(?P<keyblock>\S+))?"
             r"(?: +WITH PARSER +(?P<parser>\S+))?"
             r"(?: +COMMENT +(?P<comment>(\x27\x27|\x27([^\x27])*?\x27)+))?"
-            r"(?: +/\*(?P<version_sql>.+)\*/ +)?"
+            r"(?: +/\*(?P<version_sql>.+)\*/ *)?"
             r",?$" % quotes
         )
 

--- a/test/dialect/mysql/test_reflection.py
+++ b/test/dialect/mysql/test_reflection.py
@@ -1148,6 +1148,10 @@ class RawReflectionTest(fixtures.TestBase):
         assert not regex.match(
             "  PRIMARY KEY (`id`) USING BTREE KEY_BLOCK_SIZE = = 16"
         )
+        # TiDB: https://github.com/sqlalchemy/sqlalchemy/issues/6659
+        assert regex.match(
+            "  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */"
+        )
         assert regex.match("  KEY (`id`) USING BTREE COMMENT 'comment'")
         # `SHOW CREATE TABLE` returns COMMENT '''comment'
         # after creating table with COMMENT '\'comment'
@@ -1163,6 +1167,10 @@ class RawReflectionTest(fixtures.TestBase):
             "  FULLTEXT KEY `ix_fulltext_oi_g_name` (`oi_g_name`) "
             "/*!50100 WITH PARSER `ngram` */ "
         )
+
+        m = regex.match("  PRIMARY KEY (`id`)")
+        eq_(m.group("type"), "PRIMARY")
+        eq_(m.group("columns"), "`id`")
 
     def test_key_reflection_columns(self):
         regex = self.parser._re_key


### PR DESCRIPTION
### Description

On TiDB there is a `clustered_index` feature. This adds a `CLUSTERED`
keyword to the PK definition. This is in a TiDB specific comment.

However as the comment isn't followed by a space (` `) the regex
used by SQL Alchemy fails to decode this line.

```
INFO:sqlalchemy.engine.Engine:SHOW CREATE TABLE `t`
INFO:sqlalchemy.engine.Engine:[raw sql] ()
DEBUG:sqlalchemy.engine.Engine:Col ('Table', 'Create Table')
DEBUG:sqlalchemy.engine.Engine:Row ('t', 'CREATE TABLE `t` (\n  `id` int(11) NOT NULL,\n  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin')
INFO:root:LINE:   PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */
/home/dvaneeden/dev/sqlalchemy_tidb/./sqlalchemy_tidb.py:26: SAWarning: Unknown schema content: '  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */'
  metadata.reflect(engine, only=['t'])
```

```
mysql> show create table t\G
*************************** 1. row ***************************
       Table: t
Create Table: CREATE TABLE `t` (
  `id` int(11) NOT NULL,
  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
1 row in set (0.00 sec)

mysql> select tidb_version()\G
*************************** 1. row ***************************
tidb_version(): Release Version: v5.2.0-alpha-88-ged52601e6
Edition: Community
Git Commit Hash: ed52601e6eb560138db8cdccdfa1b5e2d33a11f0
Git Branch: master
UTC Build Time: 2021-06-16 13:03:48
GoVersion: go1.16.4
Race Enabled: false
TiKV Min Version: v3.0.0-60965b006877ca7234adaced7890d7b029ed1306
Check Table Before Drop: false
1 row in set (0.00 sec)
```

<!-- Provide a general summary of your proposed changes in the Title field above -->


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

Fixes: #6659