### PR TITLE
Fix missing None handling of Table.prefixes

### DIFF
--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -659,7 +659,7 @@ class Table(DialectKWArgs, SchemaItem, TableClause):
             for evt, fn in listeners:
                 event.listen(self, evt, fn)
 
-        self._prefixes = kwargs.pop("prefixes", [])
+        self._prefixes = kwargs.pop("prefixes", []) or []
 
         self._extra_kwargs(**kwargs)
 

--- a/test/sql/test_metadata.py
+++ b/test/sql/test_metadata.py
@@ -5540,3 +5540,7 @@ class CopyDialectOptionsTest(fixtures.TestBase):
             m2 = MetaData()
             t2 = t1.to_metadata(m2)  # make a copy
             self.check_dialect_options_(t2)
+
+    def test_prefixes_set_to_none(self):
+        table = Table("foo", Column("bar", Integer), prefixes=None)
+        assert table._prefixes == []

--- a/test/sql/test_metadata.py
+++ b/test/sql/test_metadata.py
@@ -5542,5 +5542,5 @@ class CopyDialectOptionsTest(fixtures.TestBase):
             self.check_dialect_options_(t2)
 
     def test_prefixes_set_to_none(self):
-        table = Table("foo", Column("bar", Integer), prefixes=None)
+        table = Table("foo", MetaData(), Column("bar", Integer), prefixes=None)
         assert table._prefixes == []


### PR DESCRIPTION
Resolves https://github.com/sqlalchemy/alembic/issues/867

### Description
Table misses a None handling of prefixes

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
