### PR TITLE
recreate the polymorphic attributes when reconstituting the entity. Fixes: #6680

### DIFF
--- a/lib/sqlalchemy/orm/util.py
+++ b/lib/sqlalchemy/orm/util.py
@@ -524,6 +524,17 @@ class AliasedClass(object):
         obj = cls.__new__(cls)
         obj.__name__ = "AliasedClass_%s" % aliased_insp.mapper.class_.__name__
         obj._aliased_insp = aliased_insp
+        for poly in aliased_insp.with_polymorphic_mappers:
+            if poly is not aliased_insp.mapper:
+                ent = AliasedClass(
+                    poly.class_,
+                    aliased_insp.local_table,
+                    base_alias=aliased_insp,
+                    adapt_on_names=aliased_insp._adapt_on_names,
+                    use_mapper_path=aliased_insp._use_mapper_path,
+                )
+
+                setattr(obj, poly.class_.__name__, ent)
         return obj
 
     def __getattr__(self, key):


### PR DESCRIPTION

### Description

Recreate the AliasedClass of polymorphic subclasses as attributes on the base AliasedInsp when reconstituting it.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix for #6680
- [ ] A new feature implementation

Test given as a file in #6680, not as a testcase.

