### PR TITLE
Update result.all documentation

### DIFF
--- a/lib/sqlalchemy/ext/asyncio/result.py
+++ b/lib/sqlalchemy/ext/asyncio/result.py
@@ -152,6 +152,14 @@ class AsyncResult(AsyncCommon):
 
         :return: a list of :class:`.Row` objects.
 
+        .. warning::  As opposed to :meth:`_query.Query.all`,
+           this method **will not** deduplicate entries
+           based on primary key.
+
+        .. seealso::
+
+            :ref:``
+
         """
 
         return await greenlet_spawn(self._allrows)


### PR DESCRIPTION
Adding a warning that results.all() does not deduplicate, unlike query.all(). I raised this in #6711 

I *think* I got the method call right. I was not sure how to get the url right

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
