### PR TITLE
Fixed a typo in "Cascades" documentation

### DIFF
--- a/doc/build/orm/cascades.rst
+++ b/doc/build/orm/cascades.rst
@@ -98,7 +98,7 @@ becomes part of the state of that :class:`.Session`::
     >>> address3 = Address()
     >>> user1.addresses.append(address3)
     >>> address3 in sess
-    >>> True
+    True
 
 A ``save-update`` cascade can exhibit surprising behavior when removing an item from
 a collection or de-associating an object from a scalar attribute. In some cases, the


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Removed the interpreter prompt `>>>` at the wrong place, in front of a result.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed

**Have a nice day!** :)
