### PR TITLE
Correct docs: pg8000 supports PostgreSQL UUID type

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1686,8 +1686,9 @@ class UUID(sqltypes.TypeEngine):
     data either as natively returned by the DBAPI
     or as Python uuid objects.
 
-    The UUID type may not be supported on all DBAPIs.
-    It is known to work on psycopg2 and not pg8000.
+    The UUID type is currently known to work within the prominent DBAPI
+    drivers supported by SQLAlchemy including psycopg2, pg8000 and
+    asyncpg. Support for other DBAPI drivers may be incomplete or non-present.
 
     """
 


### PR DESCRIPTION
### Description

Just a change to the docs to say that the pg8000 dialect supports the UUID type, whereas before it said it didn't. As a check that the pg8000 dialect really does work with UUIDs I did:

```
from uuid import UUID

from sqlalchemy import create_engine, text


engine = create_engine("postgresql+pg8000://postgres:cpsnow@localhost/test")
con = engine.connect()

ident = UUID("911460f2-1f43-fea2-3e2c-e01fd5b5069d")
result = con.execute(text("select :uuid"), uuid=ident).scalar_one()
assert result == ident
```

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a good day!**