### PR TITLE
Fix CockroachDB support via asyncpg

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3427,8 +3427,8 @@ class PGDialect(default.DefaultDialect):
     def _get_server_version_info(self, connection):
         v = connection.exec_driver_sql("select version()").scalar()
         m = re.match(
-            r".*(?:PostgreSQL|EnterpriseDB) "
-            r"(\d+)\.?(\d+)?(?:\.(\d+))?(?:\.\d+)?(?:devel|beta)?",
+            r".*(?:PostgreSQL|EnterpriseDB|CockroachDB CCL) "
+            r"v?(\d+)\.?(\d+)?(?:\.(\d+))?(?:\.\d+)?(?:devel|beta)?",
             v,
         )
         if not m:


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

Connecting to CockroachDB via asyncpg due to an assumption of the types the target database supports.

Also, I feel like there has to be a better way to get the DB name/version info to `_setup_type_codecs()` since there's a similar regex that picks out that information already, but I couldn't figure it out/wasn't sure how far that sort of change would have to reach.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- Issue: https://github.com/sqlalchemy/sqlalchemy/issues/6825
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
