### PR TITLE
Dispatch independent ctes on compound select

### DIFF
--- a/doc/build/changelog/unreleased_14/6752.rst
+++ b/doc/build/changelog/unreleased_14/6752.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: bug, sql
+    :tickets: 6752
+
+    Fix :class:`_sql.CTE` added with :meth:`_sql.HasCTE.add_cte` on
+    :func:`_sql.union`, :func:`_sql.union_all`, :func:`_sql.except`,
+    :func:`_sql.except_all`, :func:`_sql.intersect` or
+    :func:`_sql.intersect_all` constructs were not generated.

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -1787,6 +1787,8 @@ class SQLCompiler(Compiled):
         if toplevel and not self.compile_state:
             self.compile_state = compile_state
 
+        compound_stmt = compile_state.statement
+
         entry = self._default_stack_entry if toplevel else self.stack[-1]
         need_result_map = toplevel or (
             not compound_index
@@ -1806,6 +1808,10 @@ class SQLCompiler(Compiled):
                 "need_result_map_for_compound": need_result_map,
             }
         )
+
+        if compound_stmt._independent_ctes:
+            for cte in compound_stmt._independent_ctes:
+                cte._compiler_dispatch(self, **kwargs)
 
         keyword = self.compound_keywords.get(cs.keyword)
 

--- a/test/sql/test_cte.py
+++ b/test/sql/test_cte.py
@@ -1533,6 +1533,37 @@ class CTETest(fixtures.TestBase, AssertsCompiledSQL):
             checkparams={"param_1": 10, "price_1": 50, "price_2": 45},
         )
 
+    def test_compound_select_uses_independent_cte(self):
+        products = table("products", column("id"), column("price"))
+
+        upd_cte = (
+            products.update().values(price=10).where(products.c.price > 50)
+        ).cte()
+
+        stmt = (
+            products.select()
+            .where(products.c.price < 45)
+            .union(products.select().where(products.c.price > 90))
+            .add_cte(upd_cte)
+        )
+
+        self.assert_compile(
+            stmt,
+            "WITH anon_1 AS (UPDATE products SET price=:param_1 "
+            "WHERE products.price > :price_1) "
+            "SELECT products.id, products.price "
+            "FROM products WHERE products.price < :price_2 "
+            "UNION "
+            "SELECT products.id, products.price "
+            "FROM products WHERE products.price > :price_3",
+            checkparams={
+                "param_1": 10,
+                "price_1": 50,
+                "price_2": 45,
+                "price_3": 90,
+            },
+        )
+
     def test_insert_uses_independent_cte(self):
         products = table("products", column("id"), column("price"))
 


### PR DESCRIPTION
Oversight from: https://github.com/sqlalchemy/sqlalchemy/issues/6752#issuecomment-892687825

>     1. The fix does not include compound select (like `union`). Is it on purpose ?

> that's an oversight as the "add_cte()" method is part of what was added to CompoundSelect. If you can provide a short PR or open a new issue that would be helpful.