### PR TITLE
Added loader options to session.merge, asyncsession.merge

### DIFF
--- a/lib/sqlalchemy/ext/asyncio/session.py
+++ b/lib/sqlalchemy/ext/asyncio/session.py
@@ -242,13 +242,13 @@ class AsyncSession(ReversibleProxy):
         """
         return await greenlet_spawn(self.sync_session.delete, instance)
 
-    async def merge(self, instance, load=True):
+    async def merge(self, instance, load=True, options=None):
         """Copy the state of a given instance into a corresponding instance
         within this :class:`_asyncio.AsyncSession`.
 
         """
         return await greenlet_spawn(
-            self.sync_session.merge, instance, load=load
+            self.sync_session.merge, instance, load=load, options=options
         )
 
     async def flush(self, objects=None):

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -2843,7 +2843,7 @@ class Session(_SessionClassMethods):
             load_options=load_options,
         )
 
-    def merge(self, instance, load=True):
+    def merge(self, instance, load=True, options=None):
         """Copy the state of a given instance into a corresponding instance
         within this :class:`.Session`.
 
@@ -2889,6 +2889,8 @@ class Session(_SessionClassMethods):
          produced as "clean", so it is only appropriate that the given objects
          should be "clean" as well, else this suggests a mis-use of the
          method.
+        :param options: optional sequence of loader options which will be
+         applied to the query, if the instance is not found locally.
 
 
         .. seealso::
@@ -2916,6 +2918,7 @@ class Session(_SessionClassMethods):
                 attributes.instance_state(instance),
                 attributes.instance_dict(instance),
                 load=load,
+                options=options,
                 _recursive=_recursive,
                 _resolve_conflict_map=_resolve_conflict_map,
             )
@@ -2927,6 +2930,7 @@ class Session(_SessionClassMethods):
         state,
         state_dict,
         load=True,
+        options=None,
         _recursive=None,
         _resolve_conflict_map=None,
     ):
@@ -2990,7 +2994,12 @@ class Session(_SessionClassMethods):
                 new_instance = True
 
             elif key_is_persistent:
-                merged = self.get(mapper.class_, key[1], identity_token=key[2])
+                merged = self.get(
+                    mapper.class_,
+                    key[1],
+                    identity_token=key[2],
+                    options=options,
+                )
 
         if merged is None:
             merged = mapper.class_manager.new_instance()

--- a/test/ext/asyncio/test_session_py3k.py
+++ b/test/ext/asyncio/test_session_py3k.py
@@ -113,7 +113,7 @@ class AsyncSessionQueryTest(AsyncFixture):
         )
 
         eq_(u.name, "jack")
-        eq_(len(u.addresses), 1)
+        eq_(len(u.__dict__["addresses"]), 1)
 
     @async_test
     @testing.requires.independent_cursors
@@ -364,7 +364,7 @@ class AsyncSessionTransactionTest(AsyncFixture):
             )
 
             eq_(new_u_merged.name, "new u1")
-            eq_(len(new_u_merged.addresses), 1)
+            eq_(len(new_u_merged.__dict__["addresses"]), 1)
 
     @async_test
     async def test_join_to_external_transaction(self, async_engine):


### PR DESCRIPTION
As discussed in #6955 and associated discussion, `.merge` currently has no way of adding loader options to the underlying `.get`. This can be an issue when lazy loading is not possible, such as when using `AsyncSession`.

### Description
This PR introduces a simple passthrough of options from `Session.merge()`, `AsyncSession.merge()` to the `.get()` call.

Testing:

* Added test to `MergeTest` that is very similar to `GetTest`
* Added test for `AsyncSession.get` with loader options
* Added test for `AsyncSession.merge` with loader options

I was wondering if this change would also benefit here:
 https://github.com/sqlalchemy/sqlalchemy/blob/6930dfc032c3f9f474e71ab4e021c0ef8384930e/lib/sqlalchemy/orm/loading.py#L141

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.


