### PR TITLE
test_for_update to recognise skip_locked for MariaDB-10.6

### DIFF
--- a/test/dialect/mysql/test_for_update.py
+++ b/test/dialect/mysql/test_for_update.py
@@ -409,14 +409,14 @@ class SkipLockedTest(fixtures.TablesTest):
             Column("value", Integer),
         )
 
-    @testing.only_on("mysql>=8")
+    @testing.only_on(["mysql>=8", "mariadb>=10.6"])
     def test_skip_locked(self, connection):
         stuff = self.tables.stuff
         stmt = stuff.select().with_for_update(skip_locked=True)
 
         connection.execute(stmt).fetchall()
 
-    @testing.only_on(["mysql<8", "mariadb"])
+    @testing.only_on(["mysql<8", "mariadb<10.6"])
     def test_unsupported_skip_locked(self, connection):
         stuff = self.tables.stuff
         stmt = stuff.select().with_for_update(skip_locked=True)


### PR DESCRIPTION
### Description

Alters the test for skip_locked to recognize that `SKIP LOCKED` was added to the MariaDB syntax in 10.6.0 https://mariadb.com/kb/en/select/#skip-locked.

### Checklist

This pull request is:

- [X] A minor test case fix
- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**

:smile: You too :boat:

Note:

```
$ podman run  --rm  -d -e MARIADB_USER=scott -e MARIADB_PASSWORD=tiger -e MARIADB_DATABASE=test -e MARIADB_RANDOM_ROOT_PASSWORD=1  -P mariadb:10.6
7248491216e93320d7eff4c8c3a9f8c6b6c43cc84a7a65e721265616f8854f4d

$ podman port 7248491216e93320d7eff4c8c3a9f8c6b6c43cc84a7a65e721265616f8854f4d   3306
0.0.0.0:43809

$ pytest --db  mariadb  --dburi   mariadb://scott:tiger@127.0.0.1:43809/test  test/dialect/mysql/test_for_update.py
...
INTERNALERROR>   File "/home/dan/.py3/lib64/python3.9/site-packages/MySQLdb/connections.py", line 185, in __init__
INTERNALERROR>     super().__init__(*args, **kwargs2)
INTERNALERROR> sqlalchemy.exc.OperationalError: (MySQLdb._exceptions.OperationalError) (2002, "Can't connect to MySQL server on '127.0.0.1' (115)")
INTERNALERROR> (Background on this error at: https://sqlalche.me/e/14/e3q8)
```
Some queries where executed on the container instance however there's something in the test hard-coded to 3306 (observed in strace). And/or I'm doing something incorrectly.