### PR TITLE
fix: typos in doc/build/changelog and doc/build/faq

### DIFF
--- a/doc/build/changelog/changelog_01.rst
+++ b/doc/build/changelog/changelog_01.rst
@@ -421,7 +421,7 @@
         :tags: 
         :tickets: 
 
-      added \*args, \**kwargs pass-thru to engine.transaction(func) allowing easier
+      added \*args, \**kwargs pass-through to engine.transaction(func) allowing easier
       creation of transactionalizing decorator functions
 
     .. change::

--- a/doc/build/changelog/changelog_03.rst
+++ b/doc/build/changelog/changelog_03.rst
@@ -1191,7 +1191,7 @@
         :tags: sql
         :tickets: 
 
-      exists() becomes useable as a standalone selectable, not just in a
+      exists() becomes usable as a standalone selectable, not just in a
       WHERE clause, i.e. exists([columns], criterion).select()
 
     .. change::
@@ -1693,7 +1693,7 @@
         :tags: mssql
         :tickets: 
 
-      added query_timeout to db-url query parms. currently works only for
+      added query_timeout to db-url query params. currently works only for
       pymssql
 
     .. change::
@@ -1885,7 +1885,7 @@
         :tags: sql
         :tickets: 
 
-      added support for column "key" attribute to be useable in
+      added support for column "key" attribute to be usable in
       row[<key>]/row.<key>
 
     .. change::

--- a/doc/build/changelog/changelog_04.rst
+++ b/doc/build/changelog/changelog_04.rst
@@ -3742,7 +3742,7 @@
         :tickets: 
 
       New scoped_session() function replaces SessionContext and assignmapper.
-      Builds onto "sessionmaker()" concept to produce a class whos Session()
+      Builds onto "sessionmaker()" concept to produce a class whose Session()
       construction returns the thread-local session.  Or, call all Session
       methods as class methods, i.e. Session.save(foo); Session.commit().
       just like the old "objectstore" days.

--- a/doc/build/changelog/changelog_05.rst
+++ b/doc/build/changelog/changelog_05.rst
@@ -2533,7 +2533,7 @@
         :tickets: 536
 
       Removed FIRST_ROWS() optimize flag when using LIMIT/OFFSET,
-      can be reenabled with optimize_limits=True create_engine()
+      can be re-enabled with optimize_limits=True create_engine()
       flag.
 
     .. change::

--- a/doc/build/changelog/changelog_09.rst
+++ b/doc/build/changelog/changelog_09.rst
@@ -1341,7 +1341,7 @@
         :versions: 1.0.0b1
 
         Fixes to the newly enhanced boolean coercion in :ticket:`2804` where
-        the new rules for "where" and "having" woudn't take effect for the
+        the new rules for "where" and "having" wouldn't take effect for the
         "whereclause" and "having" kw arguments of the :func:`_expression.select` construct,
         which is also what :class:`_query.Query` uses so wasn't working in the
         ORM either.

--- a/doc/build/changelog/changelog_10.rst
+++ b/doc/build/changelog/changelog_10.rst
@@ -508,7 +508,7 @@
 
         Fixed a small issue in the Jython Oracle compiler involving the
         rendering of "RETURNING" which allows this currently
-        unsupported/untested dialect to work rudimentally with the 1.0 series.
+        unsupported/untested dialect to work rudimentarily with the 1.0 series.
         Pull request courtesy Carlos Rivas.
 
     .. change::
@@ -1460,7 +1460,7 @@
         where the check for query state on :meth:`_query.Query.update` or
         :meth:`_query.Query.delete` compared the empty tuple to itself using ``is``,
         which fails on PyPy to produce ``True`` in this case; this would
-        erronously emit a warning in 0.9 and raise an exception in 1.0.
+        erroneously emit a warning in 0.9 and raise an exception in 1.0.
 
     .. change::
         :tags: feature, engine

--- a/doc/build/changelog/changelog_13.rst
+++ b/doc/build/changelog/changelog_13.rst
@@ -244,7 +244,7 @@
         :tags: bug, oracle
         :tickets: 5812
 
-        Fixed bug in Oracle dialect where retriving a CLOB/BLOB column via
+        Fixed bug in Oracle dialect where retrieving a CLOB/BLOB column via
         :meth:`_dml.Insert.returning` would fail as the LOB value would need to be
         read when returned; additionally, repaired support for retrieval of Unicode
         values via RETURNING under Python 2.
@@ -280,7 +280,7 @@
         :tickets: 5784
         :versions: 1.4.0b2
 
-        Fixed regression which occured due to :ticket:`5755` which implemented
+        Fixed regression which occurred due to :ticket:`5755` which implemented
         isolation level support for Oracle.   It has been reported that many Oracle
         accounts don't actually have permission to query the ``v$transaction``
         view so this feature has been altered to gracefully fallback when it fails
@@ -323,7 +323,7 @@
         :tags: bug, sql
         :tickets: 5691
 
-        A warning is emmitted if a returning() method such as
+        A warning is emitted if a returning() method such as
         :meth:`_sql.Insert.returning` is called multiple times, as this does not
         yet support additive operation.  Version 1.4 will support additive
         operation for this.  Additionally, any combination of the
@@ -804,7 +804,7 @@
 
         Fixed an issue where the ``is_disconnect`` function in the SQL Server
         pyodbc dialect was incorrectly reporting the disconnect state when the
-        exception messsage had a substring that matched a SQL Server ODBC error
+        exception message had a substring that matched a SQL Server ODBC error
         code.
 
     .. change::
@@ -2339,7 +2339,7 @@
         appeared as of mysqlclient 1.4.4 based on changes in how this DBAPI creates
         a connection.  As the presence of this directive impacts three separate
         MySQL charset settings which each have intricate effects based on their
-        presense,  SQLAlchemy will now emit the directive on new connections to
+        presence,  SQLAlchemy will now emit the directive on new connections to
         ensure correct behavior.
 
     .. change::
@@ -3126,7 +3126,7 @@
 
        A SQL expression can now be assigned to a primary key attribute for an ORM
        flush in the same manner as ordinary attributes as described in
-       :ref:`flush_embedded_sql_expressions` where the expression will be evaulated
+       :ref:`flush_embedded_sql_expressions` where the expression will be evaluated
        and then returned to the ORM using RETURNING, or in the case of pysqlite,
        works using the cursor.lastrowid attribute.Requires either a database that
        supports RETURNING (e.g. Postgresql, Oracle, SQL Server) or pysqlite.

--- a/doc/build/changelog/changelog_14.rst
+++ b/doc/build/changelog/changelog_14.rst
@@ -490,7 +490,7 @@ This document details individual issue-level changes made throughout
         :tickets: 6646
 
         Add a impl parameter to :class:`_types.PickleType` constructor, allowing
-        any arbitary type to be used in place of the default implementation of
+        any arbitrary type to be used in place of the default implementation of
         :class:`_types.LargeBinary`. Pull request courtesy jason3gb.
 
     .. change::
@@ -3117,7 +3117,7 @@ This document details individual issue-level changes made throughout
           disabled for the case of ORM "refresh" operations, including loads
           of deferred or expired column attributes as well as for explicit
           operations like :meth:`_orm.Session.refresh`.  These loads are necessarily
-          based on primary key identity where addiional WHERE criteria is
+          based on primary key identity where additional WHERE criteria is
           never appropriate.  [ticket:5762]
 
         * Added new attribute :attr:`_orm.ORMExecuteState.is_column_load` to indicate
@@ -5004,7 +5004,7 @@ This document details individual issue-level changes made throughout
         :tickets: 5653
 
         Improved support for column names that contain percent signs in the string,
-        including repaired issues involving anoymous labels that also embedded a
+        including repaired issues involving anonymous labels that also embedded a
         column name with a percent sign in it, as well as re-established support
         for bound parameter names with percent signs embedded on the psycopg2
         dialect, using a late-escaping process similar to that used by the
@@ -5075,7 +5075,7 @@ This document details individual issue-level changes made throughout
         :tickets: 5649
 
         Reworked the "setinputsizes()" set of dialect hooks to be correctly
-        extensible for any arbirary DBAPI, by allowing dialects individual hooks
+        extensible for any arbitrary DBAPI, by allowing dialects individual hooks
         that may invoke cursor.setinputsizes() in the appropriate style for that
         DBAPI.   In particular this is intended to support pyodbc's style of usage
         which is fundamentally different from that of cx_Oracle.  Added support

--- a/doc/build/changelog/migration_10.rst
+++ b/doc/build/changelog/migration_10.rst
@@ -432,7 +432,7 @@ is typically used by sessions that make use of the
 series of engines (although in this use case, things frequently
 "worked" in most cases anyway as the bind would be located via the
 mapped table object), or more specifically implement a user-defined
-:meth:`.Session.get_bind` method that provies some pattern of
+:meth:`.Session.get_bind` method that provides some pattern of
 selecting engines based on mappers, such as horizontal sharding or a
 so-called "routing" session that routes queries to different backends.
 

--- a/doc/build/changelog/migration_11.rst
+++ b/doc/build/changelog/migration_11.rst
@@ -689,7 +689,7 @@ The above value of ``A.some_name.__doc__`` is now honored::
 
 However, to accomplish this, the mechanics of hybrid properties necessarily
 becomes more complex.  Previously, the class-level accessor for a hybrid
-would be a simple pass-thru, that is, this test would succeed::
+would be a simple pass-through, that is, this test would succeed::
 
     >>> assert A.name is A.some_name
 

--- a/doc/build/changelog/migration_20.rst
+++ b/doc/build/changelog/migration_20.rst
@@ -1567,7 +1567,7 @@ will all be removed in 2.0::
     q = session.query(User).join("addresses")
 
     # string use removed
-    q = session.query(User).options(joinedload("addresess"))
+    q = session.query(User).options(joinedload("addresses"))
 
     # string use removed
     q = session.query(Address).filter(with_parent(u1, "addresses"))
@@ -1582,7 +1582,7 @@ is to use mapped attributes::
 
     q = session.query(User).join(User.addresses)
 
-    q = session.query(User).options(joinedload(User.addresess))
+    q = session.query(User).options(joinedload(User.addresses))
 
     q = session.query(Address).filter(with_parent(u1, User.addresses))
 
@@ -1593,7 +1593,7 @@ The same techniques apply to :term:`2.0-style` style use::
     stmt = select(User).join(User.addresses)
     result = session.execute(stmt)
 
-    stmt = select(User).options(joinedload(User.addresess))
+    stmt = select(User).options(joinedload(User.addresses))
     result = session.execute(stmt)
 
     stmt = select(Address).where(with_parent(u1, User.addresses))

--- a/doc/build/faq/sessions.rst
+++ b/doc/build/faq/sessions.rst
@@ -68,7 +68,7 @@ Three ways, from most common to least:
 
 3. We can run whole queries while setting them to definitely overwrite
    already-loaded objects as they read rows by using "populate existing".
-   This is an exection option described at
+   This is an execution option described at
    :ref:`orm_queryguide_populate_existing`.
 
 But remember, **the ORM cannot see changes in rows if our isolation


### PR DESCRIPTION
Fix various typos under the doc/build/changelog and doc/build/faq section. Separate PR's, when time allows, will be pushed for other areas with typos.

### Description
This PR identified typos in the documentation using the codespell project with an updated dictionary from September 7th to locate the typos. Filters were used to avoid known "typos" such as `selectin` and `FROMs` which are library-specific rather than actual typos.

X-Ref: https://github.com/codespell-project/codespell
Relates To: #7003 

### Checklist
This pull request is:

- [X] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
Thanks for the project!