### PR TITLE
fix: typos in doc/build/core and doc/build/errors

### DIFF
--- a/doc/build/core/connections.rst
+++ b/doc/build/core/connections.rst
@@ -1409,7 +1409,7 @@ Basic guidelines include:
       # ...
     sqlalchemy.exc.InvalidRequestError: Closure variable named 'foo' inside of
     lambda callable <code object <lambda> at 0x7fed15f35450, file
-    "<stdin>", line 2> does not refer to a cachable SQL element, and also
+    "<stdin>", line 2> does not refer to a cacheable SQL element, and also
     does not appear to be serving as a SQL literal bound value based on the
     default SQL expression returned by the function.  This variable needs to
     remain outside the scope of a SQL-generating lambda so that a proper cache
@@ -1419,7 +1419,7 @@ Basic guidelines include:
     closure variables from being part of the cache key.
 
   The above error indicates that :class:`_sql.LambdaElement` will not assume
-  that the ``Foo`` object passed in will contine to behave the same in all
+  that the ``Foo`` object passed in will continue to behave the same in all
   cases.    It also won't assume it can use ``Foo`` as part of the cache key
   by default; if it were to use the ``Foo`` object as part of the cache key,
   if there were many different ``Foo`` objects this would fill up the cache

--- a/doc/build/errors.rst
+++ b/doc/build/errors.rst
@@ -48,7 +48,7 @@ select() construct created in "legacy" mode; keyword arguments, etc.
 The :func:`_expression.select` construct has been updated as of SQLAlchemy
 1.4 to support the newer calling style that will be standard in
 :ref:`SQLAlchemy 2.0 <error_b8d9>`.   For backwards compatibility in the
-interm, the construct accepts arguments in both the "legacy" style as well
+interim, the construct accepts arguments in both the "legacy" style as well
 as the "new" style.
 
 The "new" style features that column and table expressions are passed
@@ -1267,7 +1267,7 @@ attempt, which is unsupported when using SQLAlchemy with AsyncIO dialects.
 
 .. _error_xd3s:
 
-No Inspection Avaliable
+No Inspection Available
 -----------------------
 
 Using the :func:`_sa.inspect` function directly on an


### PR DESCRIPTION
Fix various typos under the doc/build/core and doc/build/errors section. Separate PR's, when time allows, will be pushed for other areas with typos.

### Description
This PR identified typos in the documentation using the codespell project with an updated dictionary from September 7th to locate the typos. Filters were used to avoid known "typos" such as selectin and FROMs which are library-specific rather than actual typos.

X-Ref: https://github.com/codespell-project/codespell
Relates To: #7003, #7004, and #7005

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [X] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
👍 