### PR TITLE
Fix various lib / test / examples typos

### DIFF
--- a/examples/elementtree/optimized_al.py
+++ b/examples/elementtree/optimized_al.py
@@ -132,7 +132,7 @@ mapper(
     properties={
         "children": relationship(
             _Node, lazy=None
-        ),  # doesnt load; used only for the save relationship
+        ),  # doesn't load; used only for the save relationship
         "attributes": relationship(
             _Attribute, lazy="joined", cascade="all, delete-orphan"
         ),  # eagerly load attributes

--- a/examples/versioned_rows/versioned_rows_w_versionid.py
+++ b/examples/versioned_rows/versioned_rows_w_versionid.py
@@ -3,7 +3,7 @@ an UPDATE statement on a single row into an INSERT statement, so that a new
 row is inserted with the new data, keeping the old row intact.
 
 This example adds a numerical version_id to the Versioned class as well
-as the ability to see which row is the most "current" vesion.
+as the ability to see which row is the most "current" version.
 
 """
 from sqlalchemy import Boolean

--- a/lib/sqlalchemy/cextension/immutabledict.c
+++ b/lib/sqlalchemy/cextension/immutabledict.c
@@ -173,7 +173,7 @@ ImmutableDict_union(PyObject *self, PyObject *args, PyObject *kw)
     }
 
     if (!PyDict_CheckExact(arg_dict)) {
-        // if we didnt get a dict, and got lists of tuples or
+        // if we didn't get a dict, and got lists of tuples or
         // keyword args, make a dict
         arg_dict = PyObject_Call((PyObject *) &PyDict_Type, args, kw);
         if (arg_dict == NULL) {

--- a/lib/sqlalchemy/cextension/resultproxy.c
+++ b/lib/sqlalchemy/cextension/resultproxy.c
@@ -442,7 +442,7 @@ BaseRow_subscript_impl(BaseRow *self, PyObject *key, int asmapping)
 
         // support negative indexes.   We can also call PySequence_GetItem,
         // but here we can stay with the simpler tuple protocol
-        // rather than the seqeunce protocol which has to check for
+        // rather than the sequence protocol which has to check for
         // __getitem__ methods etc.
         if (index < 0)
             index += (long)BaseRow_length(self);
@@ -467,7 +467,7 @@ BaseRow_subscript_impl(BaseRow *self, PyObject *key, int asmapping)
 
         // support negative indexes.   We can also call PySequence_GetItem,
         // but here we can stay with the simpler tuple protocol
-        // rather than the seqeunce protocol which has to check for
+        // rather than the sequence protocol which has to check for
         // __getitem__ methods etc.
         if (index < 0)
             index += (long)BaseRow_length(self);

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -514,7 +514,7 @@ or embedded dots, use two sets of brackets::
 
 
 .. versionchanged:: 1.2 the SQL Server dialect now treats brackets as
-   identifier delimeters splitting the schema into separate database
+   identifier delimiters splitting the schema into separate database
    and owner tokens, to allow dots within either name itself.
 
 .. _legacy_schema_rendering:

--- a/lib/sqlalchemy/dialects/oracle/cx_oracle.py
+++ b/lib/sqlalchemy/dialects/oracle/cx_oracle.py
@@ -108,7 +108,7 @@ Any cx_Oracle parameter value and/or constant may be passed, such as::
     )
 
 Note that the default value for ``encoding`` and ``nencoding`` was changed to
-"UTF-8" in cx_Oracle 8.0 so these parameters can be ommitted when using that
+"UTF-8" in cx_Oracle 8.0 so these parameters can be omitted when using that
 version, or later.
 
 Options consumed by the SQLAlchemy cx_Oracle dialect outside of the driver

--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -1037,7 +1037,7 @@ class PGDialect_psycopg2(PGDialect):
                 "connection not open",
                 "could not receive data from server",
                 "could not send data to server",
-                # psycopg2 client errors, psycopg2/conenction.h,
+                # psycopg2 client errors, psycopg2/connection.h,
                 # psycopg2/cursor.h
                 "connection already closed",
                 "cursor already closed",

--- a/lib/sqlalchemy/orm/decl_api.py
+++ b/lib/sqlalchemy/orm/decl_api.py
@@ -126,7 +126,7 @@ class declared_attr(interfaces._MappedAttribute, property):
     :class:`_orm.declared_attr` is typically applied as a decorator to a class
     level method, turning the attribute into a scalar-like property that can be
     invoked from the uninstantiated class. The Declarative mapping process
-    looks for these :class:`_orm.declared_attr` callables as it scans classe,
+    looks for these :class:`_orm.declared_attr` callables as it scans classes,
     and assumes any attribute marked with :class:`_orm.declared_attr` will be a
     callable that will produce an object specific to the Declarative mapping or
     table configuration.

--- a/lib/sqlalchemy/orm/path_registry.py
+++ b/lib/sqlalchemy/orm/path_registry.py
@@ -420,7 +420,7 @@ class AbstractEntityRegistry(PathRegistry):
                 )
         # it seems to make sense that since these paths get mixed up
         # with statements that are cached or not, we should make
-        # sure the natural path is cachable across different occurrences
+        # sure the natural path is cacheable across different occurrences
         # of equivalent AliasedClass objects.  however, so far this
         # does not seem to be needed for whatever reason.
         # elif not parent.path and self.is_aliased_class:

--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -3431,7 +3431,7 @@ class JoinCondition(object):
                         and pr.key not in self.prop._overlaps
                         and self.prop.key not in pr._overlaps
                         # note: the "__*" symbol is used internally by
-                        # SQLAlchemy as a general means of supressing the
+                        # SQLAlchemy as a general means of suppressing the
                         # overlaps warning for some extension cases, however
                         # this is not currently
                         # a publicly supported symbol and may change at

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -610,7 +610,7 @@ class SQLCompiler(Compiled):
     """
 
     _loose_column_name_matching = False
-    """tell the result object that the SQL staement is textual, wants to match
+    """tell the result object that the SQL statement is textual, wants to match
     up to Column objects, and may be using the ._tq_label in the SELECT rather
     than the base name.
 

--- a/lib/sqlalchemy/sql/lambdas.py
+++ b/lib/sqlalchemy/sql/lambdas.py
@@ -905,7 +905,7 @@ class AnalyzedCode(object):
         util.raise_(
             exc.InvalidRequestError(
                 "Closure variable named '%s' inside of lambda callable %s "
-                "does not refer to a cachable SQL element, and also does not "
+                "does not refer to a cacheable SQL element, and also does not "
                 "appear to be serving as a SQL literal bound value based on "
                 "the default "
                 "SQL expression returned by the function.   This variable "

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -809,7 +809,7 @@ class FromClause(roles.AnonymizedFromClauseRole, Selectable):
         objects maintained by this :class:`_expression.FromClause`.
 
         The :attr:`_sql.FromClause.c` attribute is an alias for the
-        :attr:`_sql.FromClause.columns` atttribute.
+        :attr:`_sql.FromClause.columns` attribute.
 
         :return: a :class:`.ColumnCollection`
 

--- a/lib/sqlalchemy/testing/requirements.py
+++ b/lib/sqlalchemy/testing/requirements.py
@@ -500,7 +500,7 @@ class SuiteRequirements(Requirements):
     def foreign_key_constraint_name_reflection(self):
         """Target supports refleciton of FOREIGN KEY constraints and
         will return the name of the constraint that was used in the
-        "CONSTRANT <name> FOREIGN KEY" DDL.
+        "CONSTRAINT <name> FOREIGN KEY" DDL.
 
         MySQL prior to version 8 and MariaDB prior to version 10.5
         don't support this.

--- a/test/dialect/mssql/test_types.py
+++ b/test/dialect/mssql/test_types.py
@@ -197,7 +197,7 @@ class RowVersionTest(fixtures.TablesTest):
         assert isinstance(insp.get_columns("ts_t")[1]["type"], TIMESTAMP)
 
     def test_class_hierarchy(self):
-        """TIMESTAMP and ROWVERSION aren't datetime types, theyre binary."""
+        """TIMESTAMP and ROWVERSION aren't datetime types, they're binary."""
 
         assert issubclass(TIMESTAMP, sqltypes._Binary)
         assert issubclass(ROWVERSION, sqltypes._Binary)
@@ -1179,7 +1179,7 @@ class StringTest(fixtures.TestBase, AssertsCompiledSQL):
         )
 
     def test_string_text_explicit_literal_binds(self):
-        # the literal experssion here coerces the right side to
+        # the literal expression here coerces the right side to
         # Unicode on Python 3 for plain string, test with unicode
         # string just to confirm literal is doing this
         self.assert_compile(

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -767,7 +767,7 @@ class SQLTest(fixtures.TestBase, AssertsCompiledSQL):
                 "SELECT EXTRACT(%s FROM t.col1) AS anon_1 FROM t" % field,
             )
 
-        # millsecondS to millisecond
+        # millseconds to millisecond
         self.assert_compile(
             select(extract("milliseconds", t.c.col1)),
             "SELECT EXTRACT(millisecond FROM t.col1) AS anon_1 FROM t",

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -767,7 +767,7 @@ class SQLTest(fixtures.TestBase, AssertsCompiledSQL):
                 "SELECT EXTRACT(%s FROM t.col1) AS anon_1 FROM t" % field,
             )
 
-        # millseconds to millisecond
+        # milliseconds to millisecond
         self.assert_compile(
             select(extract("milliseconds", t.c.col1)),
             "SELECT EXTRACT(millisecond FROM t.col1) AS anon_1 FROM t",

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -997,7 +997,7 @@ class ReflectionTest(
         )
 
     def test_index_reflection_partial(self, metadata, connection):
-        """Reflect the filter defintion on partial indexes"""
+        """Reflect the filter definition on partial indexes"""
 
         metadata = metadata
 

--- a/test/orm/test_attributes.py
+++ b/test/orm/test_attributes.py
@@ -1285,7 +1285,7 @@ class BackrefTest(fixtures.ORMTest):
     def test_symmetric_o2o_inheritance(self):
         """Test that backref 'initiator' catching goes against
         a token that is global to all InstrumentedAttribute objects
-        within a particular class, not just the indvidual IA object
+        within a particular class, not just the individual IA object
         since we use distinct objects in an inheritance scenario.
 
         """

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -4909,7 +4909,7 @@ class DistinctTest(QueryTest, AssertsCompiledSQL):
 
         subq = q.subquery()
 
-        # note this is a bit cutting edge; two differnet entities against
+        # note this is a bit cutting edge; two different entities against
         # the same subquery.
         uentity = aliased(User, subq)
         aentity = aliased(Address, subq)

--- a/test/orm/test_update_delete.py
+++ b/test/orm/test_update_delete.py
@@ -317,7 +317,7 @@ class UpdateDeleteTest(fixtures.MappedTest):
             if expire_jane_age:
                 asserter.assert_(
                     # it has to unexpire jane.name, because jane is not fully
-                    # expired and the critiera needs to look at this particular
+                    # expired and the critieria needs to look at this particular
                     # key
                     CompiledSQL(
                         "SELECT users.age_int AS users_age_int, "
@@ -335,7 +335,7 @@ class UpdateDeleteTest(fixtures.MappedTest):
             else:
                 asserter.assert_(
                     # it has to unexpire jane.name, because jane is not fully
-                    # expired and the critiera needs to look at this particular
+                    # expired and the critieria needs to look at this particular
                     # key
                     CompiledSQL(
                         "SELECT users.name AS users_name FROM users "

--- a/test/sql/test_compare.py
+++ b/test/sql/test_compare.py
@@ -860,7 +860,7 @@ class CoreFixtures(object):
             subq = select(l).subquery()
 
             # this creates a ColumnClause as a proxy to the Label() that has
-            # an anoymous name, so the column has one too.
+            # an anonymous name, so the column has one too.
             anon_col = subq.c[0]
 
             # then when BindParameter is created, it checks the label
@@ -876,7 +876,7 @@ class CoreFixtures(object):
             subq = select(l).subquery()
 
             # this creates a ColumnClause as a proxy to the Label() that has
-            # an anoymous name, so the column has one too.
+            # an anonymous name, so the column has one too.
             anon_col = subq.c[0]
 
             # then when BindParameter is created, it checks the label

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -3682,7 +3682,7 @@ class BindParameterTest(AssertsCompiledSQL, fixtures.TestBase):
         subq = select(l).subquery()
 
         # this creates a ColumnClause as a proxy to the Label() that has
-        # an anoymous name, so the column has one too.
+        # an anonymous name, so the column has one too.
         anon_col = subq.c[0]
         assert isinstance(anon_col.name, elements._anonymous_label)
 
@@ -3896,7 +3896,7 @@ class BindParameterTest(AssertsCompiledSQL, fixtures.TestBase):
         # it's anonymous so unique=True
         is_true(original_bind.unique)
 
-        # cache key against hte original param
+        # cache key against the original param
         cache_key = stmt._generate_cache_key()
 
         # now adapt the statement
@@ -3971,7 +3971,7 @@ class BindParameterTest(AssertsCompiledSQL, fixtures.TestBase):
         # it's anonymous so unique=True
         is_true(original_bind.unique)
 
-        # cache key against hte original param
+        # cache key against the original param
         cache_key = stmt._generate_cache_key()
 
         # now adapt the statement and separately adapt the inner
@@ -5309,7 +5309,7 @@ class DDLTest(fixtures.TestBase, AssertsCompiledSQL):
         for kw in ("onupdate", "ondelete", "initially"):
             for phrase in (
                 "NOT SQL",
-                "INITALLY NOT SQL",
+                "INITIALLY NOT SQL",
                 "FOO RESTRICT",
                 "CASCADE WRONG",
                 "SET  NULL",

--- a/test/sql/test_type_expressions.py
+++ b/test/sql/test_type_expressions.py
@@ -24,7 +24,7 @@ class _ExprFixture(object):
     def _fixture(self):
         class MyString(String):
 
-            # supercedes any processing that might be on
+            # supersedes any processing that might be on
             # String
             def bind_expression(self, bindvalue):
                 return func.lower(bindvalue)

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -1116,7 +1116,7 @@ class TypeCoerceCastTest(fixtures.TablesTest):
         MyType = self.MyType
 
         # test coerce from nulltype - e.g. use an object that
-        # does't match to a known type
+        # doesn't match to a known type
         class MyObj(object):
             def __str__(self):
                 return "THISISMYOBJ"

--- a/tox.ini
+++ b/tox.ini
@@ -147,7 +147,7 @@ deps=
       flake8-builtins
       flake8-docstrings>=1.3.1
       flake8-rst-docstrings
-      # flake8-rst-docstrings depdendency, leaving it here
+      # flake8-rst-docstrings dependency, leaving it here
       # in case it requires a version pin
       pydocstyle
       pygments


### PR DESCRIPTION
Fixes various typos located throughout the various sections of the codebase. Primarily in comments and docstrings.

### Description
Typos were located using codepspell with filtering to avoid false positives.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [X] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
You too!