### PR TITLE
Fix a small bug in docs

### DIFF
--- a/doc/build/orm/declarative_config.rst
+++ b/doc/build/orm/declarative_config.rst
@@ -287,7 +287,7 @@ be illustrated using :meth:`_orm.registry.mapped` as follows::
         id = Column(Integer, primary_key=True)
 
     @reg.mapped
-    class ClassThree(BaseOne):
+    class ClassThree(BaseTwo):
         __tablename__ = 't1'  # will use BaseTwo.metadata
 
         id = Column(Integer, primary_key=True)


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
This is to fix #7016. As described in the issue, ClassThree should have BaseTwo as its parent. 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
