### PR TITLE
Remove misplaced apostrophe in tutorial/index.rst

### DIFF
--- a/doc/build/tutorial/index.rst
+++ b/doc/build/tutorial/index.rst
@@ -91,7 +91,7 @@ The major sections of this tutorial are as follows:
   :class:`_engine.Engine` object; here's how to create one.
 
 * :ref:`tutorial_working_with_transactions` - the usage API of the
-  :class:`_engine.Engine` and it's related objects :class:`_engine.Connection`
+  :class:`_engine.Engine` and its related objects :class:`_engine.Connection`
   and :class:`_result.Result` are presented here. This content is Core-centric
   however ORM users will want to be familiar with at least the
   :class:`_result.Result` object.


### PR DESCRIPTION
Citation: http://www.sussex.ac.uk/informatics/punctuation/apostrophe/possessives

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Fixes a minor typo/punctuation error in the tutorial.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
