### PR TITLE
Relax the Python version check for `__class_getitem__` tests

### DIFF
--- a/lib/sqlalchemy/testing/requirements.py
+++ b/lib/sqlalchemy/testing/requirements.py
@@ -1448,6 +1448,6 @@ class SuiteRequirements(Requirements):
         return exclusions.open()
 
     @property
-    def builtin_generics(self):
-        "If list[int] is a valid syntax. basically py3.9+"
-        return exclusions.only_if(lambda: util.py39)
+    def generic_classes(self):
+        "If X[Y] can be implemented with ``__class_getitem__``. py3.7+"
+        return exclusions.only_if(lambda: util.py37)

--- a/test/base/test_misc_py3k.py
+++ b/test/base/test_misc_py3k.py
@@ -4,7 +4,7 @@ from sqlalchemy.testing import requires
 
 
 class TestGenerics(fixtures.TestBase):
-    @requires.builtin_generics
+    @requires.generic_classes
     def test_traversible_is_generic(self):
         col = Column[int]
         assert col is Column


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
`__class_getitem__` to support generics was introduced in Python 3.7.
In 3.9 some built-ins were made generic but the functionality
for user-defined classes has been there since 3.7.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
