### PR TITLE
Fix order of warnings filters

### DIFF
--- a/doc/build/changelog/migration_20.rst
+++ b/doc/build/changelog/migration_20.rst
@@ -260,7 +260,12 @@ the SQLAlchemy project itself, the approach taken is as follows:
 
         import warnings
         from sqlalchemy import exc
-
+        
+        # for warnings not included in regex-based filter below, just log
+        warnings.filterwarnings(
+          "always", category=exc.RemovedIn20Warning
+        )
+        
         # for warnings related to execute() / scalar(), raise
         for msg in [
             r"The (?:Executable|Engine)\.(?:execute|scalar)\(\) function",
@@ -275,11 +280,6 @@ the SQLAlchemy project itself, the approach taken is as follows:
           warnings.filterwarnings(
               "error", message=msg, category=exc.RemovedIn20Warning,
           )
-
-        # for all other warnings, just log
-        warnings.filterwarnings(
-          "always", category=exc.RemovedIn20Warning
-        )
 
 3. As each sub-category of warnings are resolved in the application, new
    warnings that are caught by the "always" filter can be added to the list


### PR DESCRIPTION
### Description
As written, the regex-based filters are completely ignored because [`warnings.filterwarnings`](https://docs.python.org/3/library/warnings.html?highlight=#warnings.filterwarnings) inserts entries at the front of the filter list, and entries closer to the front of the list override entries later in the list, if both match a particular warning.

The intended behavior is for all `RemovedIn20Warning` warnings to log and continue, except that specific warnings that match the defined regular expressions should be raised as exceptions. To accomplish this intent, the general filter must be inserted before the regular expression special cases.

The original order would work if `warnings.filterwarnings` for the default case were invoked with `append=True`, but the intent of the documentation is for this set of filters to be determinative (i.e. to override any conflicting pre-existing filters that may exist), so `append=True` should not be used.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
