### PR TITLE
clarify that @reconstructor only applies to a single method

### DIFF
--- a/doc/build/orm/constructors.rst
+++ b/doc/build/orm/constructors.rst
@@ -21,7 +21,7 @@ If you need to do some setup on database-loaded instances before they're ready
 to use, there is an event hook known as :meth:`.InstanceEvents.load` which
 can achieve this; it is also available via a class-specific decorator called
 :func:`_orm.reconstructor`.   When using :func:`_orm.reconstructor`,
-the mapper will invoke the decorated method with no
+the mapper will invoke a single decorated method with no
 arguments every time it loads or reconstructs an instance of the
 class. This is
 useful for recreating transient properties that are normally assigned in
@@ -45,7 +45,7 @@ loaded during a :class:`~sqlalchemy.orm.query.Query` operation as in
 ``query(MyMappedClass).one()``, ``init_on_load`` is called.
 
 Any method may be tagged as the :func:`_orm.reconstructor`, even
-the ``__init__`` method itself.    It is invoked after all immediate
+the ``__init__`` method itself, but only one method may be tagged as such.    It is invoked after all immediate
 column-level attributes are loaded as well as after eagerly-loaded scalar
 relationships.  Eagerly loaded collections may be only partially populated
 or not populated at all, depending on the kind of eager loading used.

--- a/lib/sqlalchemy/orm/mapper.py
+++ b/lib/sqlalchemy/orm/mapper.py
@@ -3515,7 +3515,7 @@ def _dispose_registries(registries, cascade):
 def reconstructor(fn):
     """Decorate a method as the 'reconstructor' hook.
 
-    Designates a method as the "reconstructor", an ``__init__``-like
+    Designates a single method as the "reconstructor", an ``__init__``-like
     method that will be called by the ORM after the instance has been
     loaded from the database or otherwise reconstituted.
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Add minor wording clarifying that like `__init__`, there can only be one reconstructor method per class.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
