### PR TITLE
initial draft : setting found_table properly so as to also reflect ex…

### DIFF
--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -768,7 +768,7 @@ class Inspector(object):
             if isinstance(table_name, str):
                 table_name = table_name.decode(dialect.encoding)
 
-        found_table = True if table.name in self.engine.table_names() else False
+        found_table = True if self.has_table(table.name) else False
         cols_by_orig_name = {}
 
         for col_d in self.get_columns(

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -768,7 +768,6 @@ class Inspector(object):
             if isinstance(table_name, str):
                 table_name = table_name.decode(dialect.encoding)
 
-        found_table = True if self.has_table(table.name) else False
         cols_by_orig_name = {}
 
         for col_d in self.get_columns(
@@ -782,7 +781,7 @@ class Inspector(object):
                 cols_by_orig_name,
             )
 
-        if not found_table:
+        if not self.has_table(table.name):
             raise exc.NoSuchTableError(table.name)
 
         self._reflect_pk(

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -768,14 +768,12 @@ class Inspector(object):
             if isinstance(table_name, str):
                 table_name = table_name.decode(dialect.encoding)
 
-        found_table = False
+        found_table = True if table.name in self.engine.table_names() else False
         cols_by_orig_name = {}
 
         for col_d in self.get_columns(
             table_name, schema, **table.dialect_kwargs
         ):
-            found_table = True
-
             self._reflect_column(
                 table,
                 col_d,

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -781,7 +781,7 @@ class Inspector(object):
                 cols_by_orig_name,
             )
 
-        if not self.has_table(table.name):
+        if not self.has_table(table.name, schema):
             raise exc.NoSuchTableError(table.name)
 
         self._reflect_pk(


### PR DESCRIPTION
Corresponds to issue #7117 wherein a minor yet important change, enabling reflections for tables that exist but with no columns, by changing the way `found_table` is set. This also saves us through redundant iteration through all the columns unnecessarily setting `found_table` on and on:

```
         for col_d in self.get_columns(
             table_name, schema, **table.dialect_kwargs
         ):
-            found_table = True
-
         ...
``` 

I have tested it with existing but no column tables getting reflected well, whilst tables that don't exist, won't be, resulting in a desired "NoSuchTableError" execption being raised

Fixes: #3247