### PR TITLE
Fix recursive CTE to support nesting

### DIFF
--- a/doc/build/changelog/unreleased_14/4823.rst
+++ b/doc/build/changelog/unreleased_14/4823.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: bug, sql
+    :tickets: 4823
+
+    Fix :class:`_sql.CTE` with :class:`_sql.CTE.recursive` set to True
+    and :class:`_sql.CTE.nesting` set to True was not properly compiled.

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -2118,8 +2118,8 @@ class CTE(
             name=name,
             recursive=self.recursive,
             nesting=self.nesting,
+            # _unique_id is not need as _cte_alias is doing the link
             _cte_alias=self,
-            # _unique_id=self.unique_id,
             _prefixes=self._prefixes,
             _suffixes=self._suffixes,
         )

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -2051,6 +2051,7 @@ class CTE(
             ("_cte_alias", InternalTraversal.dp_clauseelement),
             ("_restates", InternalTraversal.dp_clauseelement),
             ("recursive", InternalTraversal.dp_boolean),
+            ("nesting", InternalTraversal.dp_boolean),
         ]
         + HasPrefixes._has_prefixes_traverse_internals
         + HasSuffixes._has_suffixes_traverse_internals

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -2074,6 +2074,7 @@ class CTE(
         name=None,
         recursive=False,
         nesting=False,
+        _unique_id=None,
         _cte_alias=None,
         _restates=(),
         _prefixes=None,
@@ -2083,6 +2084,9 @@ class CTE(
         self.nesting = nesting
         self._cte_alias = _cte_alias
         self._restates = _restates
+        import uuid
+
+        self.unique_id = _unique_id if _unique_id else uuid.uuid4()
         if _prefixes:
             self._prefixes = _prefixes
         if _suffixes:
@@ -2115,6 +2119,7 @@ class CTE(
             recursive=self.recursive,
             nesting=self.nesting,
             _cte_alias=self,
+            # _unique_id=self.unique_id,
             _prefixes=self._prefixes,
             _suffixes=self._suffixes,
         )
@@ -2125,6 +2130,7 @@ class CTE(
             name=self.name,
             recursive=self.recursive,
             nesting=self.nesting,
+            _unique_id=self.unique_id,
             _restates=self._restates + (self,),
             _prefixes=self._prefixes,
             _suffixes=self._suffixes,
@@ -2136,6 +2142,7 @@ class CTE(
             name=self.name,
             recursive=self.recursive,
             nesting=self.nesting,
+            _unique_id=self.unique_id,
             _restates=self._restates + (self,),
             _prefixes=self._prefixes,
             _suffixes=self._suffixes,

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -2074,9 +2074,8 @@ class CTE(
         name=None,
         recursive=False,
         nesting=False,
-        _unique_id=None,
         _cte_alias=None,
-        _restates=(),
+        _restates=None,
         _prefixes=None,
         _suffixes=None,
     ):
@@ -2084,9 +2083,6 @@ class CTE(
         self.nesting = nesting
         self._cte_alias = _cte_alias
         self._restates = _restates
-        import uuid
-
-        self.unique_id = _unique_id if _unique_id else uuid.uuid4()
         if _prefixes:
             self._prefixes = _prefixes
         if _suffixes:
@@ -2118,7 +2114,6 @@ class CTE(
             name=name,
             recursive=self.recursive,
             nesting=self.nesting,
-            # _unique_id is not need as _cte_alias is doing the link
             _cte_alias=self,
             _prefixes=self._prefixes,
             _suffixes=self._suffixes,
@@ -2130,8 +2125,7 @@ class CTE(
             name=self.name,
             recursive=self.recursive,
             nesting=self.nesting,
-            _unique_id=self.unique_id,
-            _restates=self._restates + (self,),
+            _restates=self,
             _prefixes=self._prefixes,
             _suffixes=self._suffixes,
         )
@@ -2142,11 +2136,13 @@ class CTE(
             name=self.name,
             recursive=self.recursive,
             nesting=self.nesting,
-            _unique_id=self.unique_id,
-            _restates=self._restates + (self,),
+            _restates=self,
             _prefixes=self._prefixes,
             _suffixes=self._suffixes,
         )
+
+    def _get_unique_id(self):
+        return self._restates if self._restates is not None else self
 
 
 class HasCTE(roles.HasCTERole):

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -2082,6 +2082,7 @@ class CTE(
         self.recursive = recursive
         self.nesting = nesting
         self._cte_alias = _cte_alias
+        # Keep recursivity reference with union/union_all
         self._restates = _restates
         if _prefixes:
             self._prefixes = _prefixes
@@ -2141,7 +2142,12 @@ class CTE(
             _suffixes=self._suffixes,
         )
 
-    def _get_unique_id(self):
+    def _get_reference_cte(self):
+        """
+        A recursive CTE is updated to attach the recursive part.
+        Updated CTEs should still refer to the original CTE.
+        This function returns this reference identifier.
+        """
         return self._restates if self._restates is not None else self
 
 

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -2049,7 +2049,7 @@ class CTE(
         AliasedReturnsRows._traverse_internals
         + [
             ("_cte_alias", InternalTraversal.dp_clauseelement),
-            ("_restates", InternalTraversal.dp_clauseelement_list),
+            ("_restates", InternalTraversal.dp_clauseelement),
             ("recursive", InternalTraversal.dp_boolean),
         ]
         + HasPrefixes._has_prefixes_traverse_internals

--- a/test/sql/test_cte.py
+++ b/test/sql/test_cte.py
@@ -2165,3 +2165,43 @@ class NestingCTETest(fixtures.TestBase, AssertsCompiledSQL):
             " WHERE should_continue.val != true))"
             " SELECT recursive_cte.the_value FROM recursive_cte",
         )
+
+    # def test_recursive_cte_w_union_aliased(self):
+    #     nesting_cte = select(literal(1).label("inner_cte")).cte(
+    #         "nesting", recursive=True, nesting=True
+    #     )
+    #     nesting_cte_a = nesting_cte.alias()
+    #     nesting_cte = nesting_cte.union(
+    #         select(nesting_cte_a.c.inner_cte).where(
+    #             nesting_cte_a.c.inner_cte == literal(1)
+    #         )
+    #     )
+
+    #     stmt = select(nesting_cte.c.inner_cte)
+    #     self.assert_compile(
+    #         stmt,
+    #         "WITH RECURSIVE nesting(inner_cte) AS "
+    #         "(SELECT :param_1 AS inner_cte UNION "
+    #         "SELECT anon_1.inner_cte AS inner_cte FROM nesting AS anon_1 "
+    #         "WHERE anon_1.inner_cte = :param_2) "
+    #         "SELECT nesting.inner_cte FROM nesting",
+    #     )
+
+    def test_recursive_cte_w_union(self):
+        nesting_cte = select(literal(1).label("inner_cte")).cte(
+            "nesting", recursive=True, nesting=True
+        )
+        rec_part = select(nesting_cte.c.inner_cte).where(
+            nesting_cte.c.inner_cte == literal(1)
+        )
+        nesting_cte = nesting_cte.union(rec_part)
+
+        stmt = select(nesting_cte.c.inner_cte)
+        self.assert_compile(
+            stmt,
+            "WITH RECURSIVE nesting(inner_cte) AS "
+            "(SELECT :param_1 AS inner_cte UNION "
+            "SELECT nesting.inner_cte AS inner_cte FROM nesting "
+            "WHERE nesting.inner_cte = :param_2) "
+            "SELECT nesting.inner_cte FROM nesting",
+        )

--- a/test/sql/test_cte.py
+++ b/test/sql/test_cte.py
@@ -2166,26 +2166,26 @@ class NestingCTETest(fixtures.TestBase, AssertsCompiledSQL):
             " SELECT recursive_cte.the_value FROM recursive_cte",
         )
 
-    # def test_recursive_cte_w_union_aliased(self):
-    #     nesting_cte = select(literal(1).label("inner_cte")).cte(
-    #         "nesting", recursive=True, nesting=True
-    #     )
-    #     nesting_cte_a = nesting_cte.alias()
-    #     nesting_cte = nesting_cte.union(
-    #         select(nesting_cte_a.c.inner_cte).where(
-    #             nesting_cte_a.c.inner_cte == literal(1)
-    #         )
-    #     )
+    def test_recursive_cte_w_union_aliased(self):
+        nesting_cte = select(literal(1).label("inner_cte")).cte(
+            "nesting", recursive=True, nesting=True
+        )
+        nesting_cte_a = nesting_cte.alias()
+        nesting_cte = nesting_cte.union(
+            select(nesting_cte_a.c.inner_cte).where(
+                nesting_cte_a.c.inner_cte == literal(1)
+            )
+        )
 
-    #     stmt = select(nesting_cte.c.inner_cte)
-    #     self.assert_compile(
-    #         stmt,
-    #         "WITH RECURSIVE nesting(inner_cte) AS "
-    #         "(SELECT :param_1 AS inner_cte UNION "
-    #         "SELECT anon_1.inner_cte AS inner_cte FROM nesting AS anon_1 "
-    #         "WHERE anon_1.inner_cte = :param_2) "
-    #         "SELECT nesting.inner_cte FROM nesting",
-    #     )
+        stmt = select(nesting_cte.c.inner_cte)
+        self.assert_compile(
+            stmt,
+            "WITH RECURSIVE nesting(inner_cte) AS "
+            "(SELECT :param_1 AS inner_cte UNION "
+            "SELECT anon_1.inner_cte AS inner_cte FROM nesting AS anon_1 "
+            "WHERE anon_1.inner_cte = :param_2) "
+            "SELECT nesting.inner_cte FROM nesting",
+        )
 
     def test_recursive_cte_w_union(self):
         nesting_cte = select(literal(1).label("inner_cte")).cte(

--- a/test/sql/test_cte.py
+++ b/test/sql/test_cte.py
@@ -444,13 +444,13 @@ class CTETest(fixtures.TestBase, AssertsCompiledSQL):
         cte = s1.cte(name="cte", recursive=True)
 
         bar = select(cte).cte("bar").alias("cs1")
-        cte = cte.union_all(select(cte.c.x + 1).where(cte.c.x < 10)).alias(
+        cte_rec = cte.union_all(select(cte.c.x + 1).where(cte.c.x < 10)).alias(
             "cs2"
         )
 
         # outer cte rendered first, then bar, which
         # includes "inner" cte
-        s2 = select(cte, bar)
+        s2 = select(cte_rec, bar)
         self.assert_compile(
             s2,
             "WITH RECURSIVE cte(x) AS "
@@ -474,7 +474,7 @@ class CTETest(fixtures.TestBase, AssertsCompiledSQL):
 
         # bar rendered, but then the "outer"
         # cte is rendered.
-        s2 = select(bar, cte)
+        s2 = select(bar, cte_rec)
         self.assert_compile(
             s2,
             "WITH RECURSIVE bar AS (SELECT cte.x AS x FROM cte), "


### PR DESCRIPTION
Issue: #4123

https://github.com/sqlalchemy/sqlalchemy/issues/4123#issuecomment-927314811

> This has not been caught by the tests because the nesting recursive queries there did not union against itself, eg there was only the root clause...

- Now tests are real recursive queries
- Add tests on aliased nested CTEs (recursive or not)
- Adapt the `_restates` attribute to use it as a reference
- Add some docs around to explain some variables usage