### PR TITLE
Bugfix: MySQL  expression:  may be bindparam

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/expression.py
+++ b/lib/sqlalchemy/dialects/mysql/expression.py
@@ -68,7 +68,7 @@ class match(Generative, elements.BinaryExpression):
 
         against = kw.pop("against", None)
 
-        if not against:
+        if against is None:
             raise exc.ArgumentError("against is required")
         against = coercions.expect(
             roles.ExpressionElementRole,

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -53,7 +53,7 @@ from sqlalchemy.dialects.mysql import insert
 from sqlalchemy.dialects.mysql import match
 from sqlalchemy.sql import column
 from sqlalchemy.sql import table
-from sqlalchemy.sql.expression import literal_column
+from sqlalchemy.sql.expression import bindparam, literal_column
 from sqlalchemy.testing import assert_raises_message
 from sqlalchemy.testing import AssertsCompiledSQL
 from sqlalchemy.testing import eq_
@@ -1281,6 +1281,16 @@ class MatchExpressionTest(fixtures.TestBase, AssertsCompiledSQL):
         expr = match(firstname, lastname, against="Firstname Lastname")
 
         expr = case(expr)
+        self.assert_compile(expr, expected)
+
+    def test_match_expression_supports_bindparam(self):
+        firstname = self.match_table.c.firstname
+        lastname = self.match_table.c.lastname
+        against = bindparam('against', required=True)
+
+        expr = match(firstname, lastname, against=against)
+
+        expected = "MATCH (user.firstname, user.lastname) AGAINST (%s)"
         self.assert_compile(expr, expected)
 
     def test_cols_required(self):

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -1286,7 +1286,7 @@ class MatchExpressionTest(fixtures.TestBase, AssertsCompiledSQL):
     def test_match_expression_supports_bindparam(self):
         firstname = self.match_table.c.firstname
         lastname = self.match_table.c.lastname
-        against = bindparam('against', required=True)
+        against = bindparam("against", required=True)
 
         expr = match(firstname, lastname, against=against)
 


### PR DESCRIPTION
Fixes: #7144 

### Description
MySQL expression `match(*columns, against=clause)` should allow be against bindparam
But when `...mysql.match` checks `against` clause is `None`, it tries to cast `sqlalchemy.bindparam` as boolean

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
