### PR TITLE
Add missing * and - operators for PostgreSQL range types

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/ranges.py
+++ b/lib/sqlalchemy/dialects/postgresql/ranges.py
@@ -98,6 +98,18 @@ class RangeOperators(object):
             """
             return self.expr.op("+")(other)
 
+        def __mul__(self, other):
+            """Range expression. Returns the intersection of the two ranges.
+            """
+            return self.expr.op("*")(other)
+
+        def __sub__(self, other):
+            """Range expression. Returns the difference of the two ranges.
+            Will raise an exception if the resulting range is not
+            contiguous.
+            """
+            return self.expr.op("-")(other)
+
 
 class INT4RANGE(RangeOperators, sqltypes.TypeEngine):
     """Represent the PostgreSQL INT4RANGE type."""


### PR DESCRIPTION
### Description
Add missing range `*` and `-` operators for PostgreSQL range types.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
