### PR TITLE
Update references to tables in PostgreSQL documentation

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/ranges.py
+++ b/lib/sqlalchemy/dialects/postgresql/ranges.py
@@ -13,15 +13,15 @@ __all__ = ("INT4RANGE", "INT8RANGE", "NUMRANGE")
 class RangeOperators(object):
     """
     This mixin provides functionality for the Range Operators
-    listed in Table 9-44 of the `PostgreSQL documentation`__ for Range
-    Functions and Operators. It is used by all the range types
+    listed in the Range Operators table of the `PostgreSQL documentation`__
+    for Range Functions and Operators. It is used by all the range types
     provided in the ``postgres`` dialect and can likely be used for
     any range types you create yourself.
 
     __ https://www.postgresql.org/docs/devel/static/functions-range.html
 
-    No extra support is provided for the Range Functions listed in
-    Table 9-45 of the PostgreSQL documentation. For these, the normal
+    No extra support is provided for the Range Functions listed in the Range
+    Functions table of the PostgreSQL documentation. For these, the normal
     :func:`~sqlalchemy.sql.expression.func` object should be used.
 
     """


### PR DESCRIPTION
### Description
The table numbers in the PostgreSQL documentation change from version to version. Update the table numbers for PostgreSQL 14 (the latest version, as of this writing) and use a fixed URL for that version.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
