### PR TITLE
Fix inline documentation for Index.create() and Index.drop(): bind argument required in 2.0

### DIFF
--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -4195,6 +4195,9 @@ class Index(DialectKWArgs, ColumnCollectionMixin, SchemaItem):
         :class:`.Index`, using the given :class:`.Connectable`
         for connectivity.
 
+        .. note:: the "bind" argument will be required in
+           SQLAlchemy 2.0.
+
         .. seealso::
 
             :meth:`_schema.MetaData.create_all`.
@@ -4209,6 +4212,9 @@ class Index(DialectKWArgs, ColumnCollectionMixin, SchemaItem):
         """Issue a ``DROP`` statement for this
         :class:`.Index`, using the given :class:`.Connectable`
         for connectivity.
+
+        .. note:: the "bind" argument will be required in
+           SQLAlchemy 2.0.
 
         .. seealso::
 


### PR DESCRIPTION
I think this documentation line is missing: it should be the same as for `Table.create` ([see this line](https://github.com/sqlalchemy/sqlalchemy/blob/main/lib/sqlalchemy/sql/schema.py#L939)) and `Table.drop`, for the same reason ([Implicit” and “Connectionless” execution, “bound metadata” removed](https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#migration-20-implicit-execution)).

I did a "sanity test" with unbound metadata and got the expected error: 
`sqlalchemy.exc.UnboundExecutionError: Index object 'ix1' is not bound to an Engine or Connection.  Execution can not proceed without a database to execute against.`

I assume this is minor and does not require an issue and a test.
(First PR here, sorry if I messed up.)

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
