### PR TITLE
Fixed issue in visit_on_duplicate_key_update within a composed expression 

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1302,7 +1302,7 @@ class MySQLCompiler(compiler.SQLCompiler):
                         and obj.table is on_duplicate.inserted_alias
                     ):
                         obj = literal_column(
-                            "VALUES(" + self.preparer.quote(column.name) + ")"
+                            "VALUES(" + self.preparer.quote(obj.name) + ")"
                         )
                         return obj
                     else:

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -1110,12 +1110,12 @@ class InsertOnDuplicateTest(fixtures.TestBase, AssertsCompiledSQL):
         )
         stmt = stmt.on_duplicate_key_update(
             bar=func.coalesce(stmt.inserted.bar),
-            baz=stmt.inserted.baz + "some literal",
+            baz=stmt.inserted.baz + "some literal" + stmt.inserted.bar,
         )
         expected_sql = (
             "INSERT INTO foos (id, bar) VALUES (%s, %s), (%s, %s) ON "
             "DUPLICATE KEY UPDATE bar = coalesce(VALUES(bar)), "
-            "baz = (concat(VALUES(baz), %s))"
+            "baz = (concat(VALUES(bar), %s, VALUES(baz)))"
         )
         self.assert_compile(
             stmt,

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -1115,7 +1115,7 @@ class InsertOnDuplicateTest(fixtures.TestBase, AssertsCompiledSQL):
         expected_sql = (
             "INSERT INTO foos (id, bar) VALUES (%s, %s), (%s, %s) ON "
             "DUPLICATE KEY UPDATE bar = coalesce(VALUES(bar)), "
-            "baz = (concat(VALUES(bar), %s, VALUES(baz)))"
+            "baz = (concat(VALUES(baz), %s, VALUES(bar)))"
         )
         self.assert_compile(
             stmt,

--- a/test/dialect/mysql/test_on_duplicate.py
+++ b/test/dialect/mysql/test_on_duplicate.py
@@ -105,15 +105,14 @@ class OnDuplicateTest(fixtures.TablesTest):
         )
         result = conn.execute(stmt)
         eq_(result.inserted_primary_key, (None,))
-        # first entry triggers ON DUPLICATE
         eq_(
-            conn.execute(foos.select().where(foos.c.id == 1)).fetchall(),
-            [(1, "ab_foo", "ab_bz", False)],
-        )
-        # second entry should be an insert
-        eq_(
-            conn.execute(foos.select().where(foos.c.id == 2)).fetchall(),
-            [(2, "b", None, False)],
+            conn.execute(foos.select()).fetchall(),
+            [
+                # first entry triggers ON DUPLICATE
+                (1, "ab_foo", "ab_bz", False),
+                # second entry must be an insert
+                (2, "b", None, False),
+            ],
         )
 
     def test_on_duplicate_key_update_preserve_order(self, connection):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Fixes: #7281
When referencing a column within a composed expression would render the `VALUES` keyword to the column name of the argument.

```
# expected
name = IF(VALUES(updated) > debug_tbl.updated, VALUES(name), debug_tbl.name),

# actual
name = IF(VALUES(name) > debug_tbl.updated, VALUES(name), debug_tbl.name),
```

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
