### PR TITLE
Add async_engine_from_config(), was: Enable async engines from engine_from_config()

### DIFF
--- a/lib/sqlalchemy/ext/asyncio/__init__.py
+++ b/lib/sqlalchemy/ext/asyncio/__init__.py
@@ -5,6 +5,7 @@
 # This module is part of SQLAlchemy and is released under
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
 
+from .engine import async_engine_from_config
 from .engine import AsyncConnection
 from .engine import AsyncEngine
 from .engine import AsyncTransaction

--- a/lib/sqlalchemy/ext/asyncio/engine.py
+++ b/lib/sqlalchemy/ext/asyncio/engine.py
@@ -41,6 +41,29 @@ def create_async_engine(*arg, **kw):
     return AsyncEngine(sync_engine)
 
 
+def async_engine_from_config(configuration, prefix="sqlalchemy.", **kwargs):
+    """Create a new AsyncEngine instance using a configuration dictionary.
+
+    This works analogous to :func:`_sa.engine_from_config`, but the
+    configured dialect must be an asyncio-compatible dialect such as
+    :ref:`dialect-postgresql-asyncpg`. Arguments
+    passed to :func:`_asyncio.async_engine_from_config` are mostly
+    identical to :func:`_sa.engine_from_config`.
+
+    .. versionadded:: 1.4.28
+
+    """
+    options = {
+        key[len(prefix) :]: value
+        for key, value in configuration.items()
+        if key.startswith(prefix)
+    }
+    options["_coerce_config"] = True
+    options.update(kwargs)
+    url = options.pop("url")
+    return create_async_engine(url, **options)
+
+
 class AsyncConnectable:
     __slots__ = "_slots_dispatch", "__weakref__"
 

--- a/test/ext/asyncio/test_engine_py3k.py
+++ b/test/ext/asyncio/test_engine_py3k.py
@@ -14,6 +14,7 @@ from sqlalchemy import Table
 from sqlalchemy import testing
 from sqlalchemy import text
 from sqlalchemy import union_all
+from sqlalchemy.ext.asyncio import async_engine_from_config
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.ext.asyncio import engine as _async_engine
 from sqlalchemy.ext.asyncio import exc as asyncio_exc
@@ -589,6 +590,16 @@ class AsyncEngineTest(EngineFixture):
             testing.db.url,
             server_side_cursors=True,
         )
+
+    def test_async_engine_from_config(self):
+        config = {
+            "sqlalchemy.url": str(testing.db.url),
+            "sqlalchemy.echo": "true",
+        }
+        engine = async_engine_from_config(config)
+        assert engine.url == testing.db.url
+        assert engine.echo is True
+        assert engine.dialect.is_async is True
 
 
 class AsyncEventTest(EngineFixture):


### PR DESCRIPTION
Fixes: #7301 

<!-- Provide a general summary of your proposed changes in the Title field above -->

~~This lets you use `engine_from_config()` to create `AsyncEngine` instances by passing `create_engine=create_async_engine` into it.~~

### Description
<!-- Describe your changes in detail -->

I'm not sure this implementation is the best approach to achieve this, an alternative or addition could be having `sqlalchemy.ext.asyncio.engine.async_engine_from_config()` as a modified copy or tiny wrapper. At any rate, I'd like to avoid monkey patching in productive code (see #7301 for what I mean)… :wink: 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
