### PR TITLE
add is_literal flag to TextClause

### DIFF
--- a/test/sql/test_text.py
+++ b/test/sql/test_text.py
@@ -363,6 +363,18 @@ class BindParamTest(fixtures.TestBase, AssertsCompiledSQL):
             literal_binds=True,
         )
 
+    def test_is_literal(self):
+        t = text(
+            "select * from foo where lala=':bar' ahd hoho=':foo:whee'",
+            is_literal=True,
+        )
+
+        self.assert_compile(
+            t,
+            "select * from foo where lala=':bar' ahd hoho=':foo:whee'",
+            checkparams={},
+        )
+
     def _assert_type_map(self, t, compare):
         map_ = dict((b.key, b.type) for b in t._bindparams.values())
         for k in compare:
@@ -465,7 +477,7 @@ class BindParamTest(fixtures.TestBase, AssertsCompiledSQL):
                 r"SELECT * FROM pg_attribute WHERE "
                 r"attrelid = :tab\:\:regclass"
             ),
-            "SELECT * FROM pg_attribute WHERE " "attrelid = %(tab)s::regclass",
+            "SELECT * FROM pg_attribute WHERE attrelid = %(tab)s::regclass",
             params={"tab": None},
             dialect="postgresql",
         )
@@ -478,7 +490,7 @@ class BindParamTest(fixtures.TestBase, AssertsCompiledSQL):
                 r"SELECT * FROM pg_attribute WHERE "
                 r"attrelid = foo::regclass"
             ),
-            "SELECT * FROM pg_attribute WHERE " "attrelid = foo::regclass",
+            "SELECT * FROM pg_attribute WHERE attrelid = foo::regclass",
             params={},
             dialect="postgresql",
         )


### PR DESCRIPTION
### Description
Currently `TextClause` doesn't support a literal mode like `ColumnClause` does. While strings prefixed by colons can be escaped with a backslash, it would be convenient to be able to explicitly state that a `TextClause` doesn't include any binds, especially given the fact that colons can't be universally escaped (see added docs). This need is typical in scenarios where the input text is known not to contain any binds. See #125 and https://stackoverflow.com/questions/49902843/avoid-parameter-binding-when-executing-query-with-sqlalchemy for prior similar needs.

This PR introduces a new parameter `is_literal` to `TextClause`, which skips parsing the text for bound parameters. The PR also refines the regular expression that is used to detect bound parameters, which currently incorrectly detects the following binds:
- `:foo:bar` is detected as the bind parameter `fo` due to matching until the last non-colon word character and are added to `self._bindparams`. The same applies to `:foo::TIMESTAMP`. It is unclear to me why these don't later raise an exception during compilation, but apparently there is some additional logic downstream that removes these false positives.

### Checklist
This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
