### PR TITLE
Fix various source comment/doc typos

### DIFF
--- a/doc/build/core/connections.rst
+++ b/doc/build/core/connections.rst
@@ -119,7 +119,7 @@ illustrated in the example below::
 .. topic::  the Python DBAPI is where autobegin actually happens
 
     The design of "commit as you go" is intended to be complementary to the
-    design of the :term:`DBAPI`, which is the underyling database interface
+    design of the :term:`DBAPI`, which is the underlying database interface
     that SQLAlchemy interacts with. In the DBAPI, the ``connection`` object does
     not assume changes to the database will be automatically committed, instead
     requiring in the default case that the ``connection.commit()`` method is

--- a/doc/build/errors.rst
+++ b/doc/build/errors.rst
@@ -1431,7 +1431,7 @@ the :term:`detached` state.
 .. note:: The above reference to a "pre-buffered" vs. "un-buffered"
    :class:`_result.Result` object refers to the process by which the ORM
    converts incoming raw database rows from the :term:`DBAPI` into ORM
-   objects.  It does not imply whether or not the underyling ``cursor``
+   objects.  It does not imply whether or not the underlying ``cursor``
    object itself, which represents pending results from the DBAPI, is itself
    buffered or unbuffered, as this is essentially a lower layer of buffering.
    For background on buffering of the ``cursor`` results itself, see the

--- a/doc/build/faq/connections.rst
+++ b/doc/build/faq/connections.rst
@@ -446,8 +446,8 @@ as all methods are proxied through::
    attribute is also added which will always refer to the real driver-level
    connection regardless of what API it presents.
 
-Accessing the underlying connnection for an asyncio driver
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Accessing the underlying connection for an asyncio driver
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When an asyncio driver is in use, there are two changes to the above
 scheme.  The first is that when using an :class:`_asyncio.AsyncConnection`,

--- a/doc/build/orm/extensions/asyncio.rst
+++ b/doc/build/orm/extensions/asyncio.rst
@@ -583,7 +583,7 @@ The above example prints something along the lines of::
     particular SQLAlchemy API has been invoked by end-user code, and *before*
     some other internal aspect of that API occurs.
 
-    Constrast this to the architecture of the asyncio extension, which takes
+    Contrast this to the architecture of the asyncio extension, which takes
     place on the **exterior** of SQLAlchemy's usual flow from end-user API to
     DBAPI function.
 

--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -179,7 +179,7 @@ class Connection(Connectable):
         keeping the effect of such an option localized to a "sub" connection.
 
         .. versionchanged:: 2.0  The :meth:`_engine.Connection.execution_options`
-           method, in constrast to other objects with this method, modifies
+           method, in contrast to other objects with this method, modifies
            the connection in-place without creating copy of it.
 
         As discussed elsewhere, the :meth:`_engine.Connection.execution_options`

--- a/lib/sqlalchemy/sql/type_api.py
+++ b/lib/sqlalchemy/sql/type_api.py
@@ -1591,7 +1591,7 @@ class TypeDecorator(SchemaEventTarget, TypeEngine):
             in a result row subsequent to statement execution time.
 
         Subclasses of :class:`_types.TypeDecorator` can override this method
-        to provide custom column expresion behavior for the type.  This
+        to provide custom column expression behavior for the type.  This
         implementation will **replace** that of the underlying implementation
         type.
 

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -234,7 +234,7 @@ $$ LANGUAGE plpgsql;"""
             "connection not open",
             "could not receive data from server",
             "could not send data to server",
-            # psycopg2 client errors, psycopg2/conenction.h,
+            # psycopg2 client errors, psycopg2/connection.h,
             # psycopg2/cursor.h
             "connection already closed",
             "cursor already closed",

--- a/test/orm/inheritance/test_single.py
+++ b/test/orm/inheritance/test_single.py
@@ -596,8 +596,8 @@ class SingleInheritanceTest(testing.AssertsCompiledSQL, fixtures.MappedTest):
         ra = aliased(Report, subq)
 
         # this test previously used select_entity_from().  the standard
-        # conversion to use aliased() neds to be adjusted to be against
-        # Employee, not Manger, otherwise the ORM will add the manager single
+        # conversion to use aliased() needs to be adjusted to be against
+        # Employee, not Manager, otherwise the ORM will add the manager single
         # inh criteria to the outside which will break the outer join
         ma = aliased(Employee, subq)
 

--- a/test/orm/test_deferred.py
+++ b/test/orm/test_deferred.py
@@ -1580,7 +1580,7 @@ class InheritanceTest(_Polymorphic):
         )
 
         # note this doesn't apply to "bound" loaders since they don't seem
-        # to have this ".*" featue.
+        # to have this ".*" feature.
 
     def test_load_only_subclass_of_type(self):
         s = fixture_session()

--- a/test/orm/test_mapper.py
+++ b/test/orm/test_mapper.py
@@ -924,7 +924,7 @@ class MapperTest(_fixtures.FixtureTest, AssertsCompiledSQL):
         sess = fixture_session()
         u1 = sess.get(User, 7)
         u2 = sess.get(User, 8)
-        # comparaison ops need to work
+        # comparison ops need to work
         a1 = sess.query(Address).filter(Address.user == u1).one()
         eq_(a1.id, 1)
         a1.user = u2

--- a/test/orm/test_relationships.py
+++ b/test/orm/test_relationships.py
@@ -1034,7 +1034,7 @@ class OverlappingFksSiblingTest(fixtures.MappedTest):
 
     @testing.provide_metadata
     def test_works_two(self):
-        # doesn't actually work with real FKs beacuse it creates conflicts :)
+        # doesn't actually work with real FKs because it creates conflicts :)
         self._fixture_one(
             add_b_a=True, add_b_a_overlaps="a_member", add_bsub1_a=True
         )


### PR DESCRIPTION
### Description
Found via `codespell -q 3 -L ba,crate,datas,froms,gord,hist,inh,nd,selectin,strat,ue`

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed