### PR TITLE
fix(mypy): Placeholder vars should have fullname set

### DIFF
--- a/lib/sqlalchemy/ext/mypy/apply.py
+++ b/lib/sqlalchemy/ext/mypy/apply.py
@@ -292,6 +292,7 @@ def _apply_placeholder_attr_to_class(
     else:
         type_ = AnyType(TypeOfAny.special_form)
     var = Var(attrname)
+    var._fullname = cls.fullname + "." + attrname
     var.info = cls.info
     var.type = type_
     cls.info.names[attrname] = SymbolTableNode(MDEF, var)


### PR DESCRIPTION
Otherwise the dmypy daemon will crash on an incremental re-run.

### Description

Fixes #7347 (see that for more details).

Made against the 1.4 branch since this is what I reproduced it on, but it also works and should be cherry-pickable on main.

---

Interesting detail: GitHub Copilot could autocomplete basically the entire fix starting from a `var._f` prompt. Programmers are now obsolete?

![image](https://user-images.githubusercontent.com/639345/142701999-cd5a16ae-bd5d-4538-ad70-b1dc5f5b8096.png)
