### PR TITLE
Add __class_getitem__ to the declarative Base class

### DIFF
--- a/doc/build/changelog/unreleased_14/7368.rst
+++ b/doc/build/changelog/unreleased_14/7368.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: bug, orm, mypy
+    :tickets: 7368
+
+    Fixed 1.4 mypy plugin issue, where the automatic generated declarative base metaclass didn't
+    copy the `__class_getitem__` method which can lead to runtime issues with e.g. generics.

--- a/lib/sqlalchemy/orm/decl_api.py
+++ b/lib/sqlalchemy/orm/decl_api.py
@@ -809,6 +809,8 @@ class registry(object):
         class_dict["__abstract__"] = True
         if mapper:
             class_dict["__mapper_cls__"] = mapper
+        if cls.__class_getitem__:
+            class_dict["__class_getitem__"] = cls.__class_getitem__
 
         return metaclass(name, bases, class_dict)
 

--- a/lib/sqlalchemy/orm/decl_api.py
+++ b/lib/sqlalchemy/orm/decl_api.py
@@ -809,7 +809,7 @@ class registry(object):
         class_dict["__abstract__"] = True
         if mapper:
             class_dict["__mapper_cls__"] = mapper
-        if cls.__class_getitem__:
+        if hasattr(cls, "__class_getitem__"):
             class_dict["__class_getitem__"] = cls.__class_getitem__
 
         return metaclass(name, bases, class_dict)

--- a/test/orm/declarative/test_typing_py3k.py
+++ b/test/orm/declarative/test_typing_py3k.py
@@ -5,19 +5,21 @@ from typing import TypeVar
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy.orm import as_declarative
+from sqlalchemy.testing import fixtures
 
 
-def test_class_getitem():
-    T = TypeVar("T", bound="CommonBase")  # noqa
+class DeclarativeBaseTest(fixtures.TestBase):
+    def test_class_getitem(self):
+        T = TypeVar("T", bound="CommonBase")  # noqa
 
-    class CommonBase(Generic[T]):
-        @classmethod
-        def boring(cls: Type[T]) -> Type[T]:
-            return cls
+        class CommonBase(Generic[T]):
+            @classmethod
+            def boring(cls: Type[T]) -> Type[T]:
+                return cls
 
-    @as_declarative()
-    class Base(CommonBase[T]):
-        pass
+        @as_declarative()
+        class Base(CommonBase[T]):
+            pass
 
-    class Tab(Base["Tab"]):
-        a = Column(Integer, primary_key=True)
+        class Tab(Base["Tab"]):
+            a = Column(Integer, primary_key=True)

--- a/test/orm/declarative/test_typing_py3k.py
+++ b/test/orm/declarative/test_typing_py3k.py
@@ -1,10 +1,14 @@
-from typing import TypeVar, Generic, Type
-from sqlalchemy import Column, Integer
+from typing import Generic
+from typing import Type
+from typing import TypeVar
+
+from sqlalchemy import Column
+from sqlalchemy import Integer
 from sqlalchemy.orm import as_declarative
 
 
 def test_class_getitem():
-    T = TypeVar("T", bound="CommonBase")
+    T = TypeVar("T", bound="CommonBase")  # noqa
 
     class CommonBase(Generic[T]):
         @classmethod

--- a/test/orm/declarative/test_typing_py3k.py
+++ b/test/orm/declarative/test_typing_py3k.py
@@ -1,0 +1,19 @@
+from typing import TypeVar, Generic, Type
+from sqlalchemy import Column, Integer
+from sqlalchemy.orm import as_declarative
+
+
+def test_class_getitem():
+    T = TypeVar("T", bound="CommonBase")
+
+    class CommonBase(Generic[T]):
+        @classmethod
+        def boring(cls: Type[T]) -> Type[T]:
+            return cls
+
+    @as_declarative()
+    class Base(CommonBase[T]):
+        pass
+
+    class Tab(Base["Tab"]):
+        a = Column(Integer, primary_key=True)


### PR DESCRIPTION
### Description
Add __class_getitem__  to the generated declarative base class

Closes #7368 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
