### PR TITLE
Add __copy__, __deepcopy__ to URL. Fixes: #7400

### DIFF
--- a/lib/sqlalchemy/engine/url.py
+++ b/lib/sqlalchemy/engine/url.py
@@ -560,6 +560,20 @@ class URL(
     def __repr__(self):
         return self.render_as_string()
 
+    def __copy__(self):
+        return __class__.create(
+            self.drivername,
+            self.username,
+            self.password,
+            self.host,
+            self.port,
+            self.database,
+            self.query,
+        )
+
+    def __deepcopy__(self, memo):
+        return self.__copy__()
+
     def __hash__(self):
         return hash(str(self))
 

--- a/test/engine/test_parseconnect.py
+++ b/test/engine/test_parseconnect.py
@@ -1,6 +1,8 @@
 from unittest.mock import call
 from unittest.mock import MagicMock
 from unittest.mock import Mock
+import copy
+import warnings
 
 import sqlalchemy as tsa
 from sqlalchemy import create_engine
@@ -195,6 +197,18 @@ class URLTest(fixtures.TestBase):
         is_false(url1 != url2)
         is_true(url1 != url3)
         is_false(url1 == url3)
+
+    def test_warnings(self):
+        assert_raises(
+            exc.SADeprecationWarning,
+            url.URL,
+            "dbtype"
+        )
+        url1 = url.URL.create("dbtype")
+        url2 = copy.copy(url1)
+        url3 = copy.deepcopy(url2)
+        is_true(url1 == url2)
+        is_true(url2 == url3)
 
     @testing.combinations(
         "drivername",


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Allows `copy.copy` and `copy.deepcopy` to be used on instances of `sqlalchemy.engine.url.URL`.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
