### PR TITLE
Add reflection for Postgres expression-based indexes

### DIFF
--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -999,6 +999,13 @@ class Inspector:
         ("nulls_last", operators.nulls_last_op),
     ]
 
+    def _column_name_to_column(self, col_name, table, cols_by_orig_name):
+        return (
+            cols_by_orig_name[col_name]
+            if col_name in cols_by_orig_name
+            else table.c[col_name]
+        )
+
     def _reflect_indexes(
         self,
         table_name,
@@ -1031,20 +1038,16 @@ class Inspector:
             # look for columns by orig name in cols_by_orig_name,
             # but support columns that are in-Python only as fallback
             idx_cols = []
-            for c in columns:
+            for i, c in enumerate(columns):
                 try:
-                    idx_col = (
-                        cols_by_orig_name[c]
-                        if c in cols_by_orig_name
-                        else table.c[c]
-                    )
+                    idx_col = self._column_name_to_column(c, table, cols_by_orig_name)
                 except KeyError:
                     util.warn(
                         "%s key '%s' was not located in "
                         "columns for table '%s'" % (flavor, c, table_name)
                     )
                     continue
-                c_sorting = column_sorting.get(c, ())
+                c_sorting = column_sorting.get(i, ())
                 for k, op in self._index_sort_exprs:
                     if k in c_sorting:
                         idx_col = op(idx_col)

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,14 +60,25 @@ mariadb_connector =
 oracle =
     cx_oracle>=7,<8;python_version<"3"
     cx_oracle>=7;python_version>="3"
-postgresql = psycopg2>=2.7
-postgresql_pg8000 = pg8000>=1.16.6
+postgresql =
+    psycopg2>=2.7
+    psqlparse
+postgresql_pg8000 =
+    pg8000>=1.16.6
+    psqlparse
 postgresql_asyncpg =
     %(asyncio)s
     asyncpg;python_version>="3"
-postgresql_psycopg2binary = psycopg2-binary
-postgresql_psycopg2cffi = psycopg2cffi
-postgresql_psycopg = psycopg>=3.0.2
+    psqlparse
+postgresql_psycopg2binary =
+    psycopg2-binary
+    psqlparse
+postgresql_psycopg2cffi =
+    psycopg2cffi
+    psqlparse
+postgresql_psycopg =
+    psycopg>=3.0.2
+    psqlparse
 pymysql =
     pymysql;python_version>="3"
     pymysql<1;python_version<"3"

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -548,6 +548,14 @@ class DefaultRequirements(SuiteRequirements):
         return only_on(["postgresql", "sqlite>=3.9.0"])
 
     @property
+    def nonreflected_indexes_with_expressions(self):
+        return only_on(["sqlite>=3.9.0"])
+
+    @property
+    def reflected_indexes_with_expressions(self):
+        return only_on(["postgresql>=8.5"])
+
+    @property
     def temp_table_names(self):
         """target dialect supports listing of temporary table names"""
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

This PR is a proof-of-concept implementation of reflection for expression-based indexes in Postgres.

It is intentionally suboptimal and rough on the edges to start the discussion ASAP, and I'm fine with the first implementation being thrown away completely.

It also simplifies slightly the code for processing the indexes (avoiding a join that would generate multiple rows for a single index), but I think I'm going to have to revert that as `LATERAL` subqueries were only added in PG 9.3.

Fixes #7442 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
