### PR TITLE
Ignore ephemeral classes in test_all_present()

### DIFF
--- a/test/sql/test_compare.py
+++ b/test/sql/test_compare.py
@@ -1366,6 +1366,7 @@ class CompareAndCopyTest(CoreFixtures, fixtures.TestBase):
                 or "inherit_cache" not in cls.__dict__
             )
             and not issubclass(cls, (Annotated))
+            and cls.__module__.startswith("sqlalchemy.")
             and "orm" not in cls.__module__
             and "compiler" not in cls.__module__
             and "crud" not in cls.__module__


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

In some circumstances, ephemeral class objects that are created within
the scope of a test method don't seem to be garbage collected directly
on exit. Filter out classes created in test modules.

Fixes: #7450

### Description
<!-- Describe your changes in detail -->

Ephemeral classes seem to leak into the class hierarchy of `ClauseElement` while `test_all_present()` is run and muck things up. This only seems to happen on armv7hl, aarch64 and 390x architectures, but there it happens reliably. The solution (or workaround, as the case may be) is to ignore classes created in the `test/` hierarchy of Python modules.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
