### PR TITLE
Fix missing class attributes when using __class_getitem__

### DIFF
--- a/doc/build/changelog/unreleased_14/7462.rst
+++ b/doc/build/changelog/unreleased_14/7462.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: bug, orm, mypy
+    :tickets: 7368
+
+    Fixed issue where the ``__class_getitem__()`` method of the generated declarative base class by
+    :func:`_orm.as_declarative` lead to inaccessible class attributes such as ``__table__``.
+    Pull request courtesy Kai Mueller.

--- a/lib/sqlalchemy/orm/decl_api.py
+++ b/lib/sqlalchemy/orm/decl_api.py
@@ -788,7 +788,11 @@ class registry:
         if mapper:
             class_dict["__mapper_cls__"] = mapper
         if hasattr(cls, "__class_getitem__"):
-            class_dict["__class_getitem__"] = lambda cls, _: cls
+
+            def __class_getitem__(cls, key):
+                return cls
+
+            class_dict["__class_getitem__"] = __class_getitem__
 
         return metaclass(name, bases, class_dict)
 

--- a/lib/sqlalchemy/orm/decl_api.py
+++ b/lib/sqlalchemy/orm/decl_api.py
@@ -788,7 +788,7 @@ class registry:
         if mapper:
             class_dict["__mapper_cls__"] = mapper
         if hasattr(cls, "__class_getitem__"):
-            class_dict["__class_getitem__"] = cls.__class_getitem__
+            class_dict["__class_getitem__"] = lambda cls, _: cls
 
         return metaclass(name, bases, class_dict)
 

--- a/test/orm/declarative/test_typing_py3k.py
+++ b/test/orm/declarative/test_typing_py3k.py
@@ -19,7 +19,12 @@ class DeclarativeBaseTest(fixtures.TestBase):
 
         @as_declarative()
         class Base(CommonBase[T]):
-            pass
+            foo = 1
 
         class Tab(Base["Tab"]):
+            __tablename__ = "foo"
             a = Column(Integer, primary_key=True)
+
+        assert Tab.foo == 1
+        assert Tab.__table__ is not None
+        assert Tab.boring() == Tab


### PR DESCRIPTION
Closes #7462

### Description
As discussed in #7462, the normal `__class_getitem__` of `typing.Generics` leads to issues, so that the metaclass of the declarative base is not applied to child classes of it. Therefore we replace it with an own imlementation.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
