### PR TITLE
Remove redundant code for EOL Python <= 3.6

### DIFF
--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -76,9 +76,6 @@ jobs:
           pip install -f dist --no-index sqlalchemy
 
       - name: Check c extensions
-        # on windows in python 2.7 the cextension fail to build.
-        # for python 2.7 visual studio 9 is missing
-        if: matrix.os != 'windows-latest' || matrix.python-version != '2.7'
         run: |
           python -c 'from sqlalchemy.util import has_compiled_ext; assert has_compiled_ext()'
 
@@ -153,7 +150,7 @@ jobs:
         run: |
           (cat setup.cfg) | %{$_ -replace "tag_build.?=.?dev",""} | set-content setup.cfg
 
-      - name: Create wheel for manylinux1 and manylinux2010 for py3
+      - name: Create wheel for manylinux1 and manylinux2010
         # this step uses the image provided by pypa here https://github.com/pypa/manylinux to generate the wheels on linux
         # the action uses the image for manylinux2010 but can generate also a manylinux1 wheel
         # change the tag of this image to change the image used
@@ -166,7 +163,7 @@ jobs:
           # `--no-deps` is used to only generate the wheel for the current library. Redundant in sqlalchemy since it has no dependencies
           pip-wheel-args: "-w ./dist -v --no-deps"
 
-      - name: Create wheel for manylinux2014 for py3
+      - name: Create wheel for manylinux2014
         # this step uses the image provided by pypa here https://github.com/pypa/manylinux to generate the wheels on linux
         # the action uses the image for manylinux2010 but can generate also a manylinux1 wheel
         # change the tag of this image to change the image used

--- a/README.unittests.rst
+++ b/README.unittests.rst
@@ -135,7 +135,7 @@ with the tox runner also::
     [db]
     postgresql=postgresql+psycopg2://username:pass@hostname/dbname
 
-Now when we run ``tox -e py27-postgresql``, it will use our custom URL instead
+Now when we run ``tox -e py38-postgresql``, it will use our custom URL instead
 of the fixed one in setup.cfg.
 
 Database Configuration

--- a/examples/space_invaders/space_invaders.py
+++ b/examples/space_invaders/space_invaders.py
@@ -2,7 +2,6 @@ import curses
 import logging
 import random
 import re
-import sys
 import textwrap
 import time
 
@@ -18,11 +17,6 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm import Session
-
-
-_PY3 = sys.version_info > (3, 0)
-if _PY3:
-    xrange = range
 
 
 logging.basicConfig(
@@ -158,7 +152,7 @@ class GlyphCoordinate(Base):
         glyph = self.glyph
         data = glyph.glyph_for_state(self, state)
         for color, char in [
-            (data[i], data[i + 1]) for i in xrange(0, len(data), 2)
+            (data[i], data[i + 1]) for i in range(0, len(data), 2)
         ]:
 
             x = self.x + col
@@ -190,7 +184,7 @@ class GlyphCoordinate(Base):
         glyph = self.glyph
         x = min(max(self.x, 0), MAX_X)
         width = min(glyph.width, MAX_X - x) or 1
-        for y_a in xrange(self.y, self.y + glyph.height):
+        for y_a in range(self.y, self.y + glyph.height):
             y = y_a
             window.addstr(y + VERT_PADDING, x + HORIZ_PADDING, " " * width)
 
@@ -455,9 +449,9 @@ def init_positions(session):
         ("enemy1", 10),
     )
     for (ship_vert, (etype, score)) in zip(
-        xrange(5, 30, ENEMY_VERT_SPACING), arrangement
+        range(5, 30, ENEMY_VERT_SPACING), arrangement
     ):
-        for ship_horiz in xrange(0, 50, 10):
+        for ship_horiz in range(0, 50, 10):
             session.add(
                 GlyphCoordinate(
                     session, etype, ship_horiz, ship_vert, score=score

--- a/lib/sqlalchemy/sql/lambdas.py
+++ b/lib/sqlalchemy/sql/lambdas.py
@@ -8,7 +8,6 @@
 import collections.abc as collections_abc
 import itertools
 import operator
-import sys
 import types
 import weakref
 
@@ -1113,9 +1112,8 @@ class AnalyzedFunction:
         func = type(f)(
             f.__code__, globals_, f.__name__, f.__defaults__, closure
         )
-        if sys.version_info >= (3,):
-            func.__annotations__ = f.__annotations__
-            func.__kwdefaults__ = f.__kwdefaults__
+        func.__annotations__ = f.__annotations__
+        func.__kwdefaults__ = f.__kwdefaults__
         func.__doc__ = f.__doc__
         func.__module__ = f.__module__
 

--- a/lib/sqlalchemy/testing/plugin/pytestplugin.py
+++ b/lib/sqlalchemy/testing/plugin/pytestplugin.py
@@ -13,7 +13,6 @@ import itertools
 import operator
 import os
 import re
-import sys
 
 import pytest
 
@@ -528,13 +527,6 @@ def setup_test_methods(request):
     #    depending on the flags defined by the test class)
 
 
-def getargspec(fn):
-    if sys.version_info.major == 3:
-        return inspect.getfullargspec(fn)
-    else:
-        return inspect.getargspec(fn)
-
-
 def _pytest_fn_decorator(target):
     """Port of langhelpers.decorator with pytest-specific tricks."""
 
@@ -611,12 +603,8 @@ class PytestFixtureFunctions(plugin_base.FixtureFunctions):
         """
         from sqlalchemy.testing import exclusions
 
-        if sys.version_info.major == 3:
-            if len(arg_sets) == 1 and hasattr(arg_sets[0], "__next__"):
-                arg_sets = list(arg_sets[0])
-        else:
-            if len(arg_sets) == 1 and hasattr(arg_sets[0], "next"):
-                arg_sets = list(arg_sets[0])
+        if len(arg_sets) == 1 and hasattr(arg_sets[0], "__next__"):
+            arg_sets = list(arg_sets[0])
 
         argnames = kw.pop("argnames", None)
 
@@ -711,7 +699,7 @@ class PytestFixtureFunctions(plugin_base.FixtureFunctions):
                 return fn
             else:
                 if argnames is None:
-                    _argnames = getargspec(fn).args[1:]
+                    _argnames = inspect.getfullargspec(fn).args[1:]
                 else:
                     _argnames = re.split(r", *", argnames)
 

--- a/test/ext/test_associationproxy.py
+++ b/test/ext/test_associationproxy.py
@@ -734,7 +734,6 @@ class SetTest(_CollectionOperations):
             self.assert_((p1.children > other) == (control > other))
             self.assert_((p1.children >= other) == (control >= other))
 
-    @testing.requires.python_fixed_issue_8743
     def test_set_comparison_empty_to_empty(self):
         # test issue #3265 which was fixed in Python version 2.7.8
         Parent = self.classes.Parent

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -3,8 +3,6 @@
 
 """
 
-import sys
-
 from sqlalchemy import exc
 from sqlalchemy.sql import sqltypes
 from sqlalchemy.sql import text
@@ -1391,26 +1389,6 @@ class DefaultRequirements(SuiteRequirements):
 
         return only_if(
             has_fastexecutemany, "only on pyodbc > 4.0.19 w/ msodbc driver"
-        )
-
-    @property
-    def python_fixed_issue_8743(self):
-        return exclusions.skip_if(
-            lambda: sys.version_info < (2, 7, 8),
-            "Python issue 8743 fixed in Python 2.7.8",
-        )
-
-    @property
-    def granular_timezone(self):
-        """the datetime.timezone class, or SQLAlchemy's port, supports
-        seconds and microseconds.
-
-        SQLAlchemy ported the Python 3.7 version for Python 2, so
-        it passes on that.  For Python 3.6 and earlier, it is not supported.
-
-        """
-        return exclusions.skip_if(
-            lambda: sys.version_info >= (3,) and sys.version_info < (3, 7)
         )
 
     @property


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

There's a few bits and pieces of code to support Python <= 3.6 which are no longer needed and can be removed, to slightly simplify the codebase.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
