### PR TITLE
Fixes(#7561) Add support for postgres.UUID literal_binds compilation

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1751,12 +1751,22 @@ class UUID(sqltypes.TypeEngine):
             return None
 
     def literal_processor(self, dialect):
-        bp = self.bind_processor(dialect)
+        if self.as_uuid:
 
-        def process(value):
-            return "'%s'" % bp(value)
+            def process(value):
+                if value is not None:
+                    value = "'%s'::UUID" % value
+                return value
 
-        return process
+            return process
+        else:
+
+            def process(value):
+                if value is not None:
+                    value = "'%s'" % value
+                return value
+
+            return process
 
 
 PGUuid = UUID

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1410,7 +1410,6 @@ from ...types import SMALLINT
 from ...types import TEXT
 from ...types import VARCHAR
 
-
 IDX_USING = re.compile(r"^(?:btree|hash|gist|gin|[\w_]+)$", re.I)
 
 RESERVED_WORDS = set(
@@ -1750,6 +1749,14 @@ class UUID(sqltypes.TypeEngine):
             return process
         else:
             return None
+
+    def literal_processor(self, dialect):
+        bp = self.bind_processor(dialect)
+
+        def process(value):
+            return "'%s'" % bp(value)
+
+        return process
 
 
 PGUuid = UUID

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -2793,40 +2793,27 @@ class UUIDTest(fixtures.TestBase):
             "not_as_uuid",
             postgresql.UUID(as_uuid=False),
             str(uuid.uuid4()),
-            str(uuid.uuid4()),
         ),
         (
             "as_uuid",
             postgresql.UUID(as_uuid=True),
             uuid.uuid4(),
-            uuid.uuid4(),
         ),
-        id_="iaaa",
-        argnames="datatype, value1, value2",
+        id_="iaa",
+        argnames="datatype, value1",
     )
-    def test_uuid_literal(self, datatype, value1, value2, connection):
+    def test_uuid_literal(self, datatype, value1, connection):
         v1 = connection.execute(
             select(
                 bindparam(
-                    "uuid_literal",
+                    "key",
+                    value=value1,
                     literal_execute=True,
                     type_=datatype,
                 )
             ),
-            uuid_literal=value1,
-        ).first()
-        v2 = connection.execute(
-            select(
-                bindparam(
-                    "uuid_literal",
-                    literal_execute=True,
-                    type_=datatype,
-                )
-            ),
-            uuid_literal=value2,
-        ).first()
-        eq_(v1, value1)
-        eq_(v2, value2)
+        )
+        eq_(v1.fetchone()[0], value1)
 
 
 class HStoreTest(AssertsCompiledSQL, fixtures.TestBase):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
- Add `literal_processor` to `postgresql.UUID`
- Add respective test

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [X] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
