### PR TITLE
IGNORE THIS. Probable typo in doc example

### DIFF
--- a/doc/build/orm/extensions/associationproxy.rst
+++ b/doc/build/orm/extensions/associationproxy.rst
@@ -63,7 +63,7 @@ attribute, which can be awkward::
     >>> print(user.kw[0].keyword)
     cheese inspector
     >>> print([keyword.keyword for keyword in user.kw])
-    ['cheese inspector']
+    ['cheese', 'inspector']
 
 The ``association_proxy`` is applied to the ``User`` class to produce
 a "view" of the ``kw`` relationship, which only exposes the string


### PR DESCRIPTION
Looks like a hand created example contains an incorrect result.

### Description
the list comprehension doesn't yield a joined string. You either need a ''.join() in the example or corrected output.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
