### PR TITLE
Clarify associationproxy.rst examples by using a one word keyword

### DIFF
--- a/doc/build/orm/extensions/associationproxy.rst
+++ b/doc/build/orm/extensions/associationproxy.rst
@@ -57,13 +57,13 @@ with ``User`` requires traversal from each collection element to the ``.keyword`
 attribute, which can be awkward::
 
     >>> user = User('jek')
-    >>> user.kw.append(Keyword('cheese inspector'))
+    >>> user.kw.append(Keyword('cheese-inspector'))
     >>> print(user.kw)
     [<__main__.Keyword object at 0x12bf830>]
     >>> print(user.kw[0].keyword)
-    cheese inspector
+    cheese-inspector
     >>> print([keyword.keyword for keyword in user.kw])
-    ['cheese', 'inspector']
+    ['cheese-inspector']
 
 The ``association_proxy`` is applied to the ``User`` class to produce
 a "view" of the ``kw`` relationship, which only exposes the string
@@ -88,9 +88,9 @@ which is both readable and writable.  New ``Keyword`` objects are created
 for us transparently::
 
     >>> user = User('jek')
-    >>> user.keywords.append('cheese inspector')
+    >>> user.keywords.append('cheese-inspector')
     >>> user.keywords
-    ['cheese inspector']
+    ['cheese-inspector']
     >>> user.keywords.append('snack ninja')
     >>> user.kw
     [<__main__.Keyword object at 0x12cdd30>, <__main__.Keyword object at 0x12cde30>]
@@ -120,11 +120,11 @@ assignment event) is intercepted by the association proxy, it instantiates a
 new instance of the "intermediary" object using its constructor, passing as a
 single argument the given value. In our example above, an operation like::
 
-    user.keywords.append('cheese inspector')
+    user.keywords.append('cheese-inspector')
 
 Is translated by the association proxy into the operation::
 
-    user.kw.append(Keyword('cheese inspector'))
+    user.kw.append(Keyword('cheese-inspector'))
 
 The example works here because we have designed the constructor for ``Keyword``
 to accept a single positional argument, ``keyword``.   For those cases where a

--- a/doc/build/orm/extensions/associationproxy.rst
+++ b/doc/build/orm/extensions/associationproxy.rst
@@ -63,7 +63,7 @@ attribute, which can be awkward::
     >>> print(user.kw[0].keyword)
     cheese inspector
     >>> print([keyword.keyword for keyword in user.kw])
-    ['cheese inspector']
+    ['cheese', 'inspector']
 
 The ``association_proxy`` is applied to the ``User`` class to produce
 a "view" of the ``kw`` relationship, which only exposes the string

--- a/doc/build/orm/extensions/associationproxy.rst
+++ b/doc/build/orm/extensions/associationproxy.rst
@@ -215,8 +215,12 @@ collection of ``User`` to the ``.keyword`` attribute present on each
             return 'Keyword(%s)' % repr(self.keyword)
 
 With the above configuration, we can operate upon the ``.keywords``
-collection of each ``User`` object, and the usage of ``UserKeyword``
-is concealed::
+collection of each ``User`` object, as if it contains ``Keyword``
+instances (and the usage of ``UserKeyword`` is concealed). Note: This
+example differs from the first one on this page in that the
+``.keywords`` association is not returning the string values within
+the ``Keyword`` objects, but rather the ``Keyword`` objects
+themselves.::
 
     >>> user = User('log')
     >>> for kw in (Keyword('new_from_blammo'), Keyword('its_big')):
@@ -229,18 +233,23 @@ Where above, each ``.keywords.append()`` operation is equivalent to::
 
     >>> user.user_keywords.append(UserKeyword(Keyword('its_heavy')))
 
-The ``UserKeyword`` association object has two attributes here which are populated;
-the ``.keyword`` attribute is populated directly as a result of passing
-the ``Keyword`` object as the first argument.   The ``.user`` argument is then
-assigned as the ``UserKeyword`` object is appended to the ``User.user_keywords``
-collection, where the bidirectional relationship configured between ``User.user_keywords``
-and ``UserKeyword.user`` results in a population of the ``UserKeyword.user`` attribute.
-The ``special_key`` argument above is left at its default value of ``None``.
+The ``UserKeyword`` association object has two attributes which are
+populated, with each attribute populated at a different stage of the
+operation; the ``.keyword`` attribute is populated directly as a
+result of passing the ``Keyword`` object as the first argument and
+this happens via the ``user.keywords.append()`` operation.  The
+``.user`` argument is then assigned during the step where the
+``UserKeyword`` object is appended to the ``User.user_keywords``
+collection, wherein the bidirectional relationship configured between
+``User.user_keywords`` and ``UserKeyword.user`` results in a
+population of the ``UserKeyword.user`` attribute.  The ``special_key``
+argument above is left at its default value of ``None``.
 
 For those cases where we do want ``special_key`` to have a value, we
-create the ``UserKeyword`` object explicitly.  Below we assign all three
-attributes, where the assignment of ``.user`` has the effect of the ``UserKeyword``
-being appended to the ``User.user_keywords`` collection::
+create the ``UserKeyword`` object explicitly.  Below we assign all
+three attributes, wherein the assignment of ``.user`` during
+construction, has the effect of appending the new ``UserKeyword`` to
+the ``User.user_keywords`` collection (via the relationship)::
 
     >>> UserKeyword(Keyword('its_wood'), user, special_key='my special key')
 


### PR DESCRIPTION
The examples are based on a `keyword` attribute but use a value that a human may interpret as multiple keywords. 

### Description
I've added a dash to make the example value used be one "word."

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
