### PR TITLE
Fix overlapping slots, base classes without slots

### DIFF
--- a/lib/sqlalchemy/cyextension/immutabledict.pyx
+++ b/lib/sqlalchemy/cyextension/immutabledict.pyx
@@ -6,6 +6,9 @@ def _immutable_fn(obj):
 
 
 class ImmutableContainer:
+
+    __slots__ = ()
+
     def _immutable(self, *a,**kw):
         _immutable_fn(self)
 

--- a/lib/sqlalchemy/dialects/mysql/aiomysql.py
+++ b/lib/sqlalchemy/dialects/mysql/aiomysql.py
@@ -179,7 +179,7 @@ class AsyncAdapt_aiomysql_ss_cursor(AsyncAdapt_aiomysql_cursor):
 
 class AsyncAdapt_aiomysql_connection(AdaptedConnection):
     await_ = staticmethod(await_only)
-    __slots__ = ("dbapi", "_connection", "_execute_mutex")
+    __slots__ = ("dbapi", "_execute_mutex")
 
     def __init__(self, dbapi, connection):
         self.dbapi = dbapi

--- a/lib/sqlalchemy/dialects/sqlite/aiosqlite.py
+++ b/lib/sqlalchemy/dialects/sqlite/aiosqlite.py
@@ -165,7 +165,7 @@ class AsyncAdapt_aiosqlite_ss_cursor(AsyncAdapt_aiosqlite_cursor):
 
 class AsyncAdapt_aiosqlite_connection(AdaptedConnection):
     await_ = staticmethod(await_only)
-    __slots__ = ("dbapi", "_connection")
+    __slots__ = ("dbapi",)
 
     def __init__(self, dbapi, connection):
         self.dbapi = dbapi

--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -2257,7 +2257,7 @@ class TwoPhaseTransaction(RootTransaction):
 
     """
 
-    __slots__ = ("connection", "is_active", "xid", "_is_prepared")
+    __slots__ = ("xid", "_is_prepared")
 
     def __init__(self, connection, xid):
         self._is_prepared = False

--- a/lib/sqlalchemy/engine/row.py
+++ b/lib/sqlalchemy/engine/row.py
@@ -194,10 +194,7 @@ class ROMappingView(
     collections_abc.ValuesView,
     collections_abc.ItemsView,
 ):
-    __slots__ = (
-        "_mapping",
-        "_items",
-    )
+    __slots__ = ("_items",)
 
     def __init__(self, mapping, items):
         self._mapping = mapping

--- a/lib/sqlalchemy/engine/util.py
+++ b/lib/sqlalchemy/engine/util.py
@@ -43,7 +43,7 @@ class TransactionalContext:
 
     """
 
-    __slots__ = ("_outer_trans_ctx", "_trans_subject")
+    __slots__ = ("_outer_trans_ctx", "_trans_subject", "__weakref__")
 
     def _transaction_is_active(self):
         raise NotImplementedError()

--- a/lib/sqlalchemy/engine/util.py
+++ b/lib/sqlalchemy/engine/util.py
@@ -43,7 +43,7 @@ class TransactionalContext:
 
     """
 
-    _trans_subject = None
+    __slots__ = ("_outer_trans_ctx", "_trans_subject")
 
     def _transaction_is_active(self):
         raise NotImplementedError()

--- a/lib/sqlalchemy/engine/util.py
+++ b/lib/sqlalchemy/engine/util.py
@@ -95,7 +95,7 @@ class TransactionalContext:
         return self
 
     def __exit__(self, type_, value, traceback):
-        subject = self._trans_subject
+        subject = getattr(self, "_trans_subject", None)
 
         # simplistically we could assume that
         # "subject._trans_context_manager is self".  However, any calling

--- a/lib/sqlalchemy/orm/interfaces.py
+++ b/lib/sqlalchemy/orm/interfaces.py
@@ -760,6 +760,8 @@ class ORMOption(ExecutableOption):
 
     """
 
+    __slots__ = ()
+
     _is_legacy_option = False
 
     propagate_to_loaders = False

--- a/lib/sqlalchemy/orm/interfaces.py
+++ b/lib/sqlalchemy/orm/interfaces.py
@@ -760,8 +760,6 @@ class ORMOption(ExecutableOption):
 
     """
 
-    __slots__ = ()
-
     _is_legacy_option = False
 
     propagate_to_loaders = False

--- a/lib/sqlalchemy/orm/properties.py
+++ b/lib/sqlalchemy/orm/properties.py
@@ -64,7 +64,6 @@ class ColumnProperty(StrategizedProperty[_T]):
         "descriptor",
         "active_history",
         "expire_on_flush",
-        "info",
         "doc",
         "strategy_key",
         "_creation_order",

--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -1165,6 +1165,8 @@ class LoadLazyAttribute:
 class PostLoader(AbstractRelationshipLoader):
     """A relationship loader that emits a second SELECT statement."""
 
+    __slots__ = ()
+
     def _check_recursive_postload(self, context, path, join_depth=None):
         effective_path = (
             context.compile_state.current_path or orm_util.PathRegistry.root

--- a/lib/sqlalchemy/orm/unitofwork.py
+++ b/lib/sqlalchemy/orm/unitofwork.py
@@ -456,6 +456,9 @@ class UOWTransaction:
 
 
 class IterateMappersMixin:
+
+    __slots__ = ()
+
     def _mappers(self, uow):
         if self.fromparent:
             return iter(

--- a/lib/sqlalchemy/sql/base.py
+++ b/lib/sqlalchemy/sql/base.py
@@ -639,6 +639,8 @@ class _MetaOptions(type):
 class Options(metaclass=_MetaOptions):
     """A cacheable option dictionary with defaults."""
 
+    __slots__ = ()
+
     def __init_subclass__(cls) -> None:
         dict_ = cls.__dict__
         cls._cache_attrs = tuple(

--- a/lib/sqlalchemy/sql/operators.py
+++ b/lib/sqlalchemy/sql/operators.py
@@ -57,6 +57,8 @@ _T = TypeVar("_T", bound=Any)
 class OperatorType(Protocol):
     """describe an op() function."""
 
+    __slots__ = ()
+
     __name__: str
 
     def __call__(

--- a/lib/sqlalchemy/sql/visitors.py
+++ b/lib/sqlalchemy/sql/visitors.py
@@ -184,6 +184,8 @@ class _HasTraversalDispatch:
 
     """
 
+    __slots__ = ()
+
     def __init_subclass__(cls) -> None:
         cls._generate_traversal_dispatch()
         super().__init_subclass__()
@@ -298,6 +300,8 @@ class InternalTraversal(_HasTraversalDispatch):
     .. versionadded:: 1.4
 
     """
+
+    __slots__ = ()
 
     dp_has_cache_key = symbol("HC")
     """Visit a :class:`.HasCacheKey` object."""

--- a/lib/sqlalchemy/sql/visitors.py
+++ b/lib/sqlalchemy/sql/visitors.py
@@ -508,6 +508,8 @@ class ExtendedInternalTraversal(InternalTraversal):
 
     """
 
+    __slots__ = ()
+
     dp_ignore = symbol("IG")
     """Specify an object that should be ignored entirely.
 


### PR DESCRIPTION
Some `__slots__` were not in order.

Fixes #7527

### Description

I'm fixing two types of slots mistakes:
- [x] remove overlapping slots (i.e. slots already defined on a base class)
- [x] fix broken inheritance (i.e. slots class inheriting from a non-slots class)
  - [x] slots added to base class `TransactionalContext`. It seemed to use two attributes, which I've added as slots.
  - [x] empty slots removed from `ORMOption`. Its base class explicitly makes use of `__dict__` so empty slots don't add anything.
  - [x] empty slots added to `PostLoader`. It doesn't appear to use any slots not already defined on its base classes.
  - [x] empty slots added to `IterateMappersMixin`. It doesn't appear to use any slots not already defined on its subclasses.
  - [x] empty slots added to `ImmutableContainer`. It doesn't use any fields.
  - [x] empty slots added to `OperatorType`. It's a protocol.
  - [x] empty slots added to `InternalTraversal`, `_HasTraversalDispatch`. They don't seem to use attributes on their own.

### Checklist

This pull request is:

- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.

**Have a nice day!**
