### PR TITLE
don't update state when db did not really insert

### DIFF
--- a/lib/sqlalchemy/orm/persistence.py
+++ b/lib/sqlalchemy/orm/persistence.py
@@ -1225,15 +1225,16 @@ def _emit_insert_statements(
                         )
 
                     primary_key = result.inserted_primary_key
-                    for pk, col in zip(
-                        primary_key, mapper._pks_by_table[table]
-                    ):
-                        prop = mapper_rec._columntoproperty[col]
-                        if (
-                            col in value_params
-                            or state_dict.get(prop.key) is None
+                    if primary_key is not None:
+                        for pk, col in zip(
+                            primary_key, mapper._pks_by_table[table]
                         ):
-                            state_dict[prop.key] = pk
+                            prop = mapper_rec._columntoproperty[col]
+                            if (
+                                col in value_params
+                                or state_dict.get(prop.key) is None
+                            ):
+                                state_dict[prop.key] = pk
                     if bookkeeping:
                         if state:
                             _postfetch(


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
Fixes: https://github.com/sqlalchemy/sqlalchemy/issues/7594

### Description
<!-- Describe your changes in detail -->
When a pg before insert trigger causes an insert to be skipped (i.e. returns NULL instead of a record) there is no returning record. If a table has a primary key with server default (e.g. auto increment), and no value is set for that column then an exception will be thrown when the record insert is persisted.

Solution: Don't set primary key attributes when there is none. This is what SQLAlchemy <1.4 did.


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.


### No test yet
Can anyone point me in the right direction on how to write a test for this?