### PR TITLE
Add compiler support for PostgreSQL "NOT VALID" constraints.

### DIFF
--- a/doc/build/changelog/unreleased_14/7601.rst
+++ b/doc/build/changelog/unreleased_14/7601.rst
@@ -1,0 +1,10 @@
+.. change::
+    :tags: postgresql, dialect
+    :tickets: 7600
+
+    Added compiler support for ``NOT VALID`` CHECK and FOREIGN KEY constraints
+    in PostgreSQL dialect.
+
+    .. seealso::
+
+        :ref:`_postgresql_constraint_options`

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2599,12 +2599,8 @@ class PGDDLCompiler(compiler.DDLCompiler):
         return colspec
 
     def _define_constraint_validity(self, constraint):
-        if self.dialect._supports_not_valid_constraints:
-            not_valid = constraint.dialect_options["postgresql"]["not_valid"]
-            if not_valid:
-                return " NOT VALID"
-
-        return ""
+        not_valid = constraint.dialect_options["postgresql"]["not_valid"]
+        return " NOT VALID" if not_valid else ""
 
     def visit_check_constraint(self, constraint):
         if constraint._type_bound:
@@ -3264,7 +3260,6 @@ class PGDialect(default.DefaultDialect):
     _backslash_escapes = True
     _supports_create_index_concurrently = True
     _supports_drop_index_concurrently = True
-    _supports_not_valid_constraints = True
 
     def __init__(self, json_serializer=None, json_deserializer=None, **kwargs):
         default.DefaultDialect.__init__(self, **kwargs)
@@ -3307,10 +3302,6 @@ class PGDialect(default.DefaultDialect):
             2,
         )
         self.supports_identity_columns = self.server_version_info >= (10,)
-        self._supports_not_valid_constraints = self.server_version_info >= (
-            9,
-            1,
-        )
 
     def get_isolation_level_values(self, dbapi_conn):
         # note the generic dialect doesn't have AUTOCOMMIT, however

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -3,6 +3,7 @@ from sqlalchemy import and_
 from sqlalchemy import BigInteger
 from sqlalchemy import bindparam
 from sqlalchemy import cast
+from sqlalchemy import CheckConstraint
 from sqlalchemy import Column
 from sqlalchemy import Computed
 from sqlalchemy import Date
@@ -10,6 +11,7 @@ from sqlalchemy import delete
 from sqlalchemy import Enum
 from sqlalchemy import exc
 from sqlalchemy import Float
+from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy import func
 from sqlalchemy import Identity
 from sqlalchemy import Index
@@ -826,6 +828,63 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         dialect_9_1._supports_drop_index_concurrently = False
         self.assert_compile(
             schema.DropIndex(idx1), "DROP INDEX test_idx1", dialect=dialect_9_1
+        )
+
+    def test_create_check_constraint_not_valid(self):
+        m = MetaData()
+
+        tbl = Table(
+            "testtbl",
+            m,
+            Column("data", Integer),
+            CheckConstraint("data = 0", postgresql_not_valid=True),
+        )
+
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE testtbl (data INTEGER, CHECK (data = 0) NOT VALID)",
+        )
+
+        dialect_9_0 = postgresql.dialect()
+        dialect_9_0._supports_not_valid_constraints = False
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE testtbl (data INTEGER, CHECK (data = 0))",
+            dialect=dialect_9_0,
+        )
+
+    def test_create_foreign_key_constraint_not_valid(self):
+        m = MetaData()
+
+        tbl = Table(
+            "testtbl",
+            m,
+            Column("a", Integer),
+            Column("b", Integer),
+            ForeignKeyConstraint(
+                "b", ["testtbl.a"], postgresql_not_valid=True
+            ),
+        )
+
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE testtbl ("
+            "a INTEGER, "
+            "b INTEGER, "
+            "FOREIGN KEY(b) REFERENCES testtbl (a) NOT VALID"
+            ")",
+        )
+
+        dialect_9_0 = postgresql.dialect()
+        dialect_9_0._supports_not_valid_constraints = False
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE testtbl ("
+            "a INTEGER, "
+            "b INTEGER, "
+            "FOREIGN KEY(b) REFERENCES testtbl (a)"
+            ")",
+            dialect=dialect_9_0,
         )
 
     def test_exclude_constraint_min(self):

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -845,14 +845,6 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             "CREATE TABLE testtbl (data INTEGER, CHECK (data = 0) NOT VALID)",
         )
 
-        dialect_9_0 = postgresql.dialect()
-        dialect_9_0._supports_not_valid_constraints = False
-        self.assert_compile(
-            schema.CreateTable(tbl),
-            "CREATE TABLE testtbl (data INTEGER, CHECK (data = 0))",
-            dialect=dialect_9_0,
-        )
-
     def test_create_foreign_key_constraint_not_valid(self):
         m = MetaData()
 
@@ -873,18 +865,6 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             "b INTEGER, "
             "FOREIGN KEY(b) REFERENCES testtbl (a) NOT VALID"
             ")",
-        )
-
-        dialect_9_0 = postgresql.dialect()
-        dialect_9_0._supports_not_valid_constraints = False
-        self.assert_compile(
-            schema.CreateTable(tbl),
-            "CREATE TABLE testtbl ("
-            "a INTEGER, "
-            "b INTEGER, "
-            "FOREIGN KEY(b) REFERENCES testtbl (a)"
-            ")",
-            dialect=dialect_9_0,
         )
 
     def test_exclude_constraint_min(self):


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->

PostgreSQL supports declaring CHECK and FOREIGN KEY constraints as "NOT
VALID" which prevents the constraint from being validated on already
inserted rows, but still validates against any newly inserted or updated
rows.

This commit adds compiler support for this dialect option on
`CheckConstraint` and `ForeignKeyConstraint` classes. Although this
option doesn't make much sense on table creation, it doesn't seem to
cause any issue with Postgres and it is a preliminary step to have this
supported in Alembic during `ALTER TABLE`. Note that other constraints
types do not support this option.

See https://www.postgresql.org/docs/current/sql-altertable.html

See also #4825 which added supported for "NOT VALID" constraints
introsecpection.

Fixes #7600

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
