### PR TITLE
Fix up Python logging metadata

### DIFF
--- a/doc/build/changelog/unreleased_14/7612.rst
+++ b/doc/build/changelog/unreleased_14/7612.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: bug, engine
+    :tickets: 7612
+
+    Log messages emitted via sqlalchemy.engine.base and sqlalchemy.log now
+    report correct function names and line numbers.

--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -136,7 +136,7 @@ class Connection(ConnectionEventsTarget, inspection.Inspectable["Inspector"]):
         if fmt:
             message = fmt(message)
 
-        self.engine.logger.info(message, *arg, **kw)
+        self.engine.logger.info(message, *arg, stacklevel=2, **kw)
 
     def _log_debug(self, message, *arg, **kw):
         fmt = self._message_formatter
@@ -144,7 +144,7 @@ class Connection(ConnectionEventsTarget, inspection.Inspectable["Inspector"]):
         if fmt:
             message = fmt(message)
 
-        self.engine.logger.debug(message, *arg, **kw)
+        self.engine.logger.debug(message, *arg, stacklevel=2, **kw)
 
     @property
     def _schema_translate_map(self):

--- a/lib/sqlalchemy/log.py
+++ b/lib/sqlalchemy/log.py
@@ -161,7 +161,14 @@ class InstanceLogger:
 
         self.log(logging.CRITICAL, msg, *args, **kwargs)
 
-    def log(self, level: int, msg: str, *args: Any, **kwargs: Any) -> None:
+    def log(
+        self,
+        level: int,
+        msg: str,
+        *args: Any,
+        stacklevel: int = 1,
+        **kwargs: Any,
+    ) -> None:
         """Delegate a log call to the underlying logger.
 
         The level here is determined by the echo
@@ -181,7 +188,9 @@ class InstanceLogger:
             selected_level = self.logger.getEffectiveLevel()
 
         if level >= selected_level:
-            self.logger._log(level, msg, args, **kwargs)
+            self.logger._log(
+                level, msg, args, stacklevel=stacklevel + 1, **kwargs
+            )
 
     def isEnabledFor(self, level: int) -> bool:
         """Is this logger enabled for level 'level'?"""


### PR DESCRIPTION


<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Log messages emitted via `sqlalchemy.engine.base` and `sqlalchemy.log` may
report incorrect function names and line numbers, as they may be based
off a helper function stack frame. Add, and increment, the `stacklevel`
keyword argument to function calls to ensure that helper functions are
not themselves visible in the log records.

Fixes #7612


Open questions:
I don't know in what context `sqlalchemy.log` is otherwise used. I'm not entirely convinced that the stacklevel logic implemented here is correct in _all_ cases.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
