### PR TITLE
Remove duplicate word "other" in sentence

### DIFF
--- a/doc/build/core/constraints.rst
+++ b/doc/build/core/constraints.rst
@@ -275,7 +275,7 @@ parent row is deleted all corresponding child rows are set to null or deleted.
 In data definition language these are specified using phrases like "ON UPDATE
 CASCADE", "ON DELETE CASCADE", and "ON DELETE SET NULL", corresponding to
 foreign key constraints. The phrase after "ON UPDATE" or "ON DELETE" may also
-other allow other phrases that are specific to the database in use. The
+allow other phrases that are specific to the database in use. The
 :class:`~sqlalchemy.schema.ForeignKey` and
 :class:`~sqlalchemy.schema.ForeignKeyConstraint` objects support the
 generation of this clause via the ``onupdate`` and ``ondelete`` keyword


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Spotted this while reading the docs (thanks to everyone for working hard on the docs!).

Word wrapping makes it less obvious, but the sentence previously read:

> The phrase after "ON UPDATE" or "ON DELETE" may also ~~other~~ allow other phrases


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
