### PR TITLE
Add missing query before trying to print

### DIFF
--- a/lib/sqlalchemy/ext/automap.py
+++ b/lib/sqlalchemy/ext/automap.py
@@ -56,6 +56,7 @@ asking it to reflect the schema and produce mappings::
 
     # collection-based relationships are by default named
     # "<classname>_collection"
+    u1 = session.query(User).first()
     print (u1.address_collection)
 
 Above, calling :meth:`.AutomapBase.prepare` while passing along the


### PR DESCRIPTION
The documentation had a print before a query was run.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
This change is simple to add a query to populate u1 before printing it on line 59 so that the code in the documentation can be run. 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
