### PR TITLE
add slotscheck to CI

### DIFF
--- a/.github/workflows/run-on-pr.yaml
+++ b/.github/workflows/run-on-pr.yaml
@@ -84,8 +84,8 @@ jobs:
       - name: Run tests
         run: tox -e mypy ${{ matrix.pytest-args }}
 
-  run-pep8:
-    name: pep8-${{ matrix.python-version }}
+  run-lint:
+    name: lint-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       # run this job using this matrix, excluding some combinations below.
@@ -115,7 +115,7 @@ jobs:
           pip list
 
       - name: Run tests
-        run: tox -e pep8
+        run: tox -e lint
 
   # Arm emulation is quite slow (~20min) so for now just run it when merging to main
   # run-test-arm64:

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -156,8 +156,8 @@ jobs:
       - name: Run tests
         run: tox -e mypy ${{ matrix.pytest-args }}
 
-  run-pep8:
-    name: pep8-${{ matrix.python-version }}
+  run-lint:
+    name: lint-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       # run this job using this matrix, excluding some combinations below.
@@ -187,7 +187,7 @@ jobs:
           pip list
 
       - name: Run tests
-        run: tox -e pep8
+        run: tox -e lint
 
   run-pep484:
     name: pep484-${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,13 @@ repos:
           - pydocstyle
           - pygments
 
-
-
-
+-   repo: https://github.com/ariebovenberg/slotscheck
+    rev: v0.11.0
+    hooks:
+    -   id: slotscheck
+        exclude: "^(?!lib/sqlalchemy)"
+        additional_dependencies:
+          - typing_extensions
+          - mypy
+          - greenlet
+        entry: env PYTHONPATH=lib slotscheck -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,6 @@ repos:
           - pydocstyle
           - pygments
 
--   repo: https://github.com/ariebovenberg/slotscheck
-    rev: v0.11.0
-    hooks:
-    -   id: slotscheck
-        exclude: "^(?!lib/sqlalchemy)"
-        additional_dependencies:
-          - typing_extensions
-          - mypy
-          - greenlet
-        entry: env PYTHONPATH=lib slotscheck -v
+
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@
 line-length = 79
 target-version = ['py37']
 
+[tool.slotscheck]
+exclude-modules = '^sqlalchemy\.testing'
+
 
 [tool.pytest.ini_options]
 addopts = "--tb native -v -r sfxX --maxfail=250 -p warnings -p logging --strict-markers"

--- a/tox.ini
+++ b/tox.ini
@@ -151,7 +151,7 @@ commands =
     pytest -m mypy {posargs}
 
 # thanks to https://julien.danjou.info/the-best-flake8-extensions/
-[testenv:pep8]
+[testenv:lint]
 basepython = python3
 deps=
       flake8
@@ -164,9 +164,12 @@ deps=
       pydocstyle
       pygments
       black==21.12b0
+      mypy
+      slotscheck>=0.12,<0.13
 commands =
      flake8 ./lib/ ./test/ ./examples/ setup.py doc/build/conf.py {posargs}
      black --check ./lib/ ./test/ ./examples/ setup.py doc/build/conf.py
+     slotscheck -m sqlalchemy
 
 
 # command run in the github action when cext are active.

--- a/tox.ini
+++ b/tox.ini
@@ -172,6 +172,14 @@ commands =
      slotscheck -m sqlalchemy
 
 
+# "pep8" env was renamed to "lint".
+# Kept for backwards compatibility until rename is completed elsewhere.
+[testenv:pep8]
+basepython = {[testenv:lint]basepython}
+deps = {[testenv:lint]deps}
+commands = {[testenv:lint]commands}
+
+
 # command run in the github action when cext are active.
 [testenv:github-cext]
 deps = {[testenv]deps}


### PR DESCRIPTION
### Description

As discussed in #7589, `slotscheck` can prevent slots-related mistakes from creeping back in.

Note that because slotscheck imports files, `additional_dependencies` was needed in the pre-commit config. The versions of these dependencies are not kept in sync with `sqlalchemy` requirements. If this is not OK, there are [alternative setups](https://slotscheck.readthedocs.io/en/latest/advanced.html#pre-commit-hook) or the check could be moved to `tox`.

### Checklist
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.

**Have a nice day!**

