### PR TITLE
Fix signature for modified_json example

### DIFF
--- a/lib/sqlalchemy/ext/mutable.py
+++ b/lib/sqlalchemy/ext/mutable.py
@@ -219,7 +219,7 @@ from within the mutable extension::
         data = Column(MutableDict.as_mutable(JSONEncodedDict))
 
     @event.listens_for(MyDataClass.data, "modified")
-    def modified_json(instance):
+    def modified_json(instance, initiator):
         print("json value modified:", instance.data)
 
 .. _mutable_composites:


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

I tried the code example to receive events for a MutableDict attribute and got an error. I noticed that the signature in the example was wrong as described at https://docs.sqlalchemy.org/en/14/orm/events.html#sqlalchemy.orm.AttributeEvents.modified

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.