### PR TITLE
Add arm64 to the list of supported architectures

### DIFF
--- a/doc/build/orm/extensions/asyncio.rst
+++ b/doc/build/orm/extensions/asyncio.rst
@@ -29,7 +29,7 @@ The asyncio extension requires at least Python version 3.6. It also depends
 upon the `greenlet <https://pypi.org/project/greenlet/>`_ library. This
 dependency is installed by default on common machine platforms including::
 
-    x86_64 aarch64 ppc64le amd64 win32
+    x86_64 aarch64 arm64 ppc64le amd64 win32
 
 For the above platforms, ``greenlet`` is known to supply pre-built wheel files.
 To ensure the ``greenlet`` dependency is present on other platforms, the

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ package_dir =
 
 install_requires =
     importlib-metadata;python_version<"3.8"
-    greenlet != 0.4.17;(platform_machine=='aarch64' or (platform_machine=='ppc64le' or (platform_machine=='x86_64' or (platform_machine=='amd64' or (platform_machine=='AMD64' or (platform_machine=='win32' or platform_machine=='WIN32'))))))
+    greenlet != 0.4.17;(platform_machine=='aarch64' or (platform_machine=='arm64' or (platform_machine=='ppc64le' or (platform_machine=='x86_64' or (platform_machine=='amd64' or (platform_machine=='AMD64' or (platform_machine=='win32' or platform_machine=='WIN32')))))))
     typing-extensions >= 4
 
 [options.extras_require]


### PR DESCRIPTION
Add `arm64` to the list of supported architectures. 

### Description
On Apple M1 the `platform_machine` variable will hold a value of `arm64` instead of `aarch64`; both are synonyms but this will prevent `greenlet` to be installed as expected.
