### PR TITLE
5667: Comments on (named) constraints

### DIFF
--- a/doc/build/changelog/migration_20.rst
+++ b/doc/build/changelog/migration_20.rst
@@ -77,6 +77,25 @@ New Features and Improvements
 This section covers new features and improvements in SQLAlchemy 2.0 which
 are not otherwise part of the major 1.4->2.0 migration path.
 
+.. _change_5667:
+
+-- Support for comments on named constraints
+----------------------------------------------------------------------------
+
+The Core receives support for string comments associated with named constraints.
+These are specified via the :paramref:`.Constraint.comment` arguments
+
+Table(
+   'example', metadata,
+   Column('id', Integer),
+   CheckConstraint('id < 100', name="id_cons", comment="Id value can't exceed
+   100")
+)
+
+Current backend support includes Postgresql.
+
+:ticket:`5677`
+
 .. _ticket_6842:
 
 Dialect support for psycopg 3 (a.k.a. "psycopg")

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -54,6 +54,7 @@ class DefaultDialect(interfaces.Dialect):
     preparer = compiler.IdentifierPreparer
     supports_alter = True
     supports_comments = False
+    supports_constraint_comments = False
     inline_comments = False
     supports_statement_cache = True
 

--- a/lib/sqlalchemy/engine/interfaces.py
+++ b/lib/sqlalchemy/engine/interfaces.py
@@ -274,7 +274,21 @@ class ReflectedColumn(TypedDict):
     object"""
 
 
-class ReflectedCheckConstraint(TypedDict):
+class ReflectedConstraint(TypedDict):
+    """Dictionary representing the reflected elements corresponding to
+    :class:`.Constraint`
+
+    A base class for all constraints
+    """
+
+    name: Optional[str]
+    """constraint name"""
+
+    comment: NotRequired[Optional[str]]
+    """comment for the constraint, if present"""
+
+
+class ReflectedCheckConstraint(ReflectedConstraint):
     """Dictionary representing the reflected elements corresponding to
     :class:`.CheckConstraint`.
 
@@ -282,9 +296,6 @@ class ReflectedCheckConstraint(TypedDict):
     :meth:`.Inspector.get_check_constraints` method.
 
     """
-
-    name: Optional[str]
-    """constraint name"""
 
     sqltext: str
     """the check constraint's SQL expression"""
@@ -294,7 +305,7 @@ class ReflectedCheckConstraint(TypedDict):
     object"""
 
 
-class ReflectedUniqueConstraint(TypedDict):
+class ReflectedUniqueConstraint(ReflectedConstraint):
     """Dictionary representing the reflected elements corresponding to
     :class:`.UniqueConstraint`.
 
@@ -302,9 +313,6 @@ class ReflectedUniqueConstraint(TypedDict):
     :meth:`.Inspector.get_unique_constraints` method.
 
     """
-
-    name: Optional[str]
-    """constraint name"""
 
     column_names: List[str]
     """column names which comprise the constraint"""
@@ -314,7 +322,7 @@ class ReflectedUniqueConstraint(TypedDict):
     object"""
 
 
-class ReflectedPrimaryKeyConstraint(TypedDict):
+class ReflectedPrimaryKeyConstraint(ReflectedConstraint):
     """Dictionary representing the reflected elements corresponding to
     :class:`.PrimaryKeyConstraint`.
 
@@ -334,7 +342,7 @@ class ReflectedPrimaryKeyConstraint(TypedDict):
     object"""
 
 
-class ReflectedForeignKeyConstraint(TypedDict):
+class ReflectedForeignKeyConstraint(ReflectedConstraint):
     """Dictionary representing the reflected elements corresponding to
     :class:`.ForeignKeyConstraint`.
 
@@ -342,9 +350,6 @@ class ReflectedForeignKeyConstraint(TypedDict):
     the :meth:`.Inspector.get_foreign_keys` method.
 
     """
-
-    name: Optional[str]
-    """constraint name"""
 
     constrained_columns: List[str]
     """local column names which comprise the constraint"""
@@ -626,6 +631,9 @@ class Dialect:
     """Indicates the dialect supports comment DDL that's inline with the
     definition of a Table or Column.  If False, this implies that ALTER must
     be used to set table and column comments."""
+
+    supports_constraint_comments: bool
+    """Indicates if the dialect supports comment DDL on constraints."""
 
     _has_events = False
 

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -516,6 +516,9 @@ class Inspector(inspection.Inspectable["Inspector"]):
         * ``name`` -
           optional name of the primary key constraint.
 
+        * ``comment`` -
+          optional comment on the primary key constraint.
+
         :param table_name: string name of the table.  For special quoting,
          use :class:`.quoted_name`.
 
@@ -550,6 +553,9 @@ class Inspector(inspection.Inspectable["Inspector"]):
 
         * ``name`` -
           optional name of the foreign key constraint.
+
+        * ``comment`` -
+          optional comment on the foreign key constraint
 
         :param table_name: string name of the table.  For special quoting,
          use :class:`.quoted_name`.
@@ -618,6 +624,9 @@ class Inspector(inspection.Inspectable["Inspector"]):
         * ``column_names`` -
           list of column names in order
 
+        * ``comment`` -
+          optional comment on the constraint
+
         :param table_name: string name of the table.  For special quoting,
          use :class:`.quoted_name`.
 
@@ -668,6 +677,9 @@ class Inspector(inspection.Inspectable["Inspector"]):
         * ``dialect_options`` -
           may or may not be present; a dictionary with additional
           dialect-specific options for this CHECK constraint
+
+        * ``comment`` -
+          optional comment on the constraint
 
           .. versionadded:: 1.3.8
 
@@ -913,6 +925,10 @@ class Inspector(inspection.Inspectable["Inspector"]):
             # update pk constraint name
             table.primary_key.name = pk_cons.get("name")
 
+            comment = pk_cons.get("comment", None)
+            if comment is not None:
+                table.primary_key.comment = comment
+
             # tell the PKConstraint to re-initialize
             # its column collection
             table.primary_key._reload(pk_cols)
@@ -977,12 +993,18 @@ class Inspector(inspection.Inspectable["Inspector"]):
                 options = fkey_d["options"]
             else:
                 options = {}
+
+            if "comment" in fkey_d:
+                comment = fkey_d["comment"]
+            else:
+                comment = None
             table.append_constraint(
                 sa_schema.ForeignKeyConstraint(
                     constrained_columns,
                     refspec,
                     conname,
                     link_to_name=True,
+                    comment=comment,
                     **options,
                 )
             )
@@ -1073,6 +1095,12 @@ class Inspector(inspection.Inspectable["Inspector"]):
         for const_d in constraints:
             conname = const_d["name"]
             columns = const_d["column_names"]
+            if "comment" in const_d:
+                comment = const_d["comment"]
+            else:
+                comment = None
+            if comment is not None:
+                table.primary_key.comment = comment
             duplicates = const_d.get("duplicates_index")
             if include_columns and not set(columns).issubset(include_columns):
                 util.warn(

--- a/lib/sqlalchemy/schema.py
+++ b/lib/sqlalchemy/schema.py
@@ -26,12 +26,14 @@ from .sql.ddl import DDLBase as DDLBase
 from .sql.ddl import DDLElement as DDLElement
 from .sql.ddl import DropColumnComment as DropColumnComment
 from .sql.ddl import DropConstraint as DropConstraint
+from .sql.ddl import DropConstraintComment as DropConstraintComment
 from .sql.ddl import DropIndex as DropIndex
 from .sql.ddl import DropSchema as DropSchema
 from .sql.ddl import DropSequence as DropSequence
 from .sql.ddl import DropTable as DropTable
 from .sql.ddl import DropTableComment as DropTableComment
 from .sql.ddl import SetColumnComment as SetColumnComment
+from .sql.ddl import SetConstraintComment as SetConstraintComment
 from .sql.ddl import SetTableComment as SetTableComment
 from .sql.ddl import sort_tables as sort_tables
 from .sql.ddl import (

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -4622,6 +4622,37 @@ class DDLCompiler(Compiled):
             drop.element, use_table=True
         )
 
+    def visit_set_constraint_comment(self, create, **kw):
+        constraint = create.element
+        if constraint.name is not None:
+            formatted_name = self.preparer.format_constraint(constraint)
+        else:
+            raise exc.CompileError(
+                "Can't emit COMMENT ON for constraint %r; "
+                "it has no name" % create.element
+            )
+        return "COMMENT ON CONSTRAINT %s ON %s IS %s" % (
+            formatted_name,
+            self.preparer.format_table(create.element.table),
+            self.sql_compiler.render_literal_value(
+                create.element.comment, sqltypes.String()
+            ),
+        )
+
+    def visit_drop_constraint_comment(self, drop, **kw):
+        constraint = drop.element
+        if constraint.name is not None:
+            formatted_name = self.preparer.format_constraint(constraint)
+        else:
+            raise exc.CompileError(
+                "Can't emit COMMENT ON for constraint %r; "
+                "it has no name" % drop.element
+            )
+        return "COMMENT ON CONSTRAINT %s ON %s IS NULL" % (
+            formatted_name,
+            self.preparer.format_table(drop.element.table),
+        )
+
     def get_identity_options(self, identity_options):
         text = []
         if identity_options.increment is not None:

--- a/lib/sqlalchemy/sql/ddl.py
+++ b/lib/sqlalchemy/sql/ddl.py
@@ -661,6 +661,18 @@ class DropColumnComment(_CreateDropBase):
     __visit_name__ = "drop_column_comment"
 
 
+class SetConstraintComment(_CreateDropBase):
+    """Represent a COMMENT ON CONSTRAINT IS statement."""
+
+    __visit_name__ = "set_constraint_comment"
+
+
+class DropConstraintComment(_CreateDropBase):
+    """Represent a COMMENT ON CONSTRAINT IS NULL statement."""
+
+    __visit_name__ = "drop_constraint_comment"
+
+
 class DDLBase(SchemaVisitor):
     def __init__(self, connection):
         self.connection = connection
@@ -805,6 +817,13 @@ class SchemaGenerator(DDLBase):
             for column in table.columns:
                 if column.comment is not None:
                     self.connection.execute(SetColumnComment(column))
+
+            if self.dialect.supports_constraint_comments:
+                for constraint in table.constraints:
+                    if constraint.comment is not None:
+                        self.connection.execute(
+                            SetConstraintComment(constraint)
+                        )
 
         table.dispatch.after_create(
             table,

--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -2209,6 +2209,7 @@ class ForeignKey(DialectKWArgs, SchemaItem):
         link_to_name: bool = False,
         match: Optional[str] = None,
         info: Optional[Dict[Any, Any]] = None,
+        comment: Optional[str] = None,
         **dialect_kw: Any,
     ):
         r"""
@@ -2269,6 +2270,9 @@ class ForeignKey(DialectKWArgs, SchemaItem):
 
             .. versionadded:: 1.0.0
 
+        :param comment: Optional string that will render an SQL comment on
+          foreign key constraint creation.
+
         :param \**dialect_kw:  Additional keyword arguments are dialect
             specific, and passed in the form ``<dialectname>_<argname>``.  The
             arguments are ultimately handled by a corresponding
@@ -2311,6 +2315,7 @@ class ForeignKey(DialectKWArgs, SchemaItem):
         self.initially = initially
         self.link_to_name = link_to_name
         self.match = match
+        self.comment = comment
         if info:
             self.info = info
         self._unvalidated_dialect_kw = dialect_kw
@@ -2352,6 +2357,7 @@ class ForeignKey(DialectKWArgs, SchemaItem):
             initially=self.initially,
             link_to_name=self.link_to_name,
             match=self.match,
+            comment=self.comment,
             **self._unvalidated_dialect_kw,
         )
         return self._schema_item_copy(fk)
@@ -2631,6 +2637,7 @@ class ForeignKey(DialectKWArgs, SchemaItem):
                 deferrable=self.deferrable,
                 initially=self.initially,
                 match=self.match,
+                comment=self.comment,
                 **self._unvalidated_dialect_kw,
             )
             self.constraint._append_element(column, self)
@@ -3230,6 +3237,7 @@ class Constraint(DialectKWArgs, SchemaItem):
         initially=None,
         _create_rule=None,
         info=None,
+        comment=None,
         _type_bound=False,
         **dialect_kw,
     ):
@@ -3250,6 +3258,10 @@ class Constraint(DialectKWArgs, SchemaItem):
             :attr:`.SchemaItem.info` attribute of this object.
 
             .. versionadded:: 1.0.0
+
+
+        :param comment: Optional string that will render an SQL comment on
+          foreign key constraint creation.
 
         :param \**dialect_kw:  Additional keyword arguments are dialect
             specific, and passed in the form ``<dialectname>_<argname>``.  See
@@ -3274,6 +3286,7 @@ class Constraint(DialectKWArgs, SchemaItem):
         self._type_bound = _type_bound
         util.set_creation_order(self)
         self._validate_dialect_kwargs(dialect_kw)
+        self.comment = comment
 
     @property
     def table(self):
@@ -3636,6 +3649,7 @@ class ForeignKeyConstraint(ColumnCollectionConstraint):
         match=None,
         table=None,
         info=None,
+        comment=None,
         **dialect_kw,
     ):
         r"""Construct a composite-capable FOREIGN KEY.
@@ -3700,6 +3714,9 @@ class ForeignKeyConstraint(ColumnCollectionConstraint):
 
             .. versionadded:: 1.0.0
 
+        :param comment: Optional string that will render an SQL comment on
+          foreign key constraint creation.
+
         :param \**dialect_kw:  Additional keyword arguments are dialect
           specific, and passed in the form ``<dialectname>_<argname>``.  See
           the documentation regarding an individual dialect at
@@ -3715,6 +3732,7 @@ class ForeignKeyConstraint(ColumnCollectionConstraint):
             deferrable=deferrable,
             initially=initially,
             info=info,
+            comment=comment,
             **dialect_kw,
         )
         self.onupdate = onupdate

--- a/lib/sqlalchemy/testing/requirements.py
+++ b/lib/sqlalchemy/testing/requirements.py
@@ -607,6 +607,10 @@ class SuiteRequirements(Requirements):
         return exclusions.closed()
 
     @property
+    def constraint_comment_reflection(self):
+        return exclusions.closed()
+
+    @property
     def view_column_reflection(self):
         """target database must support retrieval of the columns in a view,
         similarly to how a table is inspected.

--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -405,63 +405,65 @@ class ComponentReflectionTest(fixtures.TablesTest):
             comment=r"""the test % ' " \ table comment""",
         )
         # Test constraint comments
-        if testing.requires.foreign_key_constraint_reflection:
-            Table(
-                "fk_constraint_comment_test_1",
-                metadata,
-                Column("id", sa.Integer, primary_key=True),
-                schema=schema,
-                test_needs_fk=True,
-            )
-            Table(
-                "fk_constraint_comment_test_2",
-                metadata,
-                Column("id", sa.Integer, primary_key=True),
-                Column(
-                    "another_id",
-                    sa.Integer,
-                    sa.ForeignKey(
-                        "%sfk_constraint_comment_test_1.id" % schema_prefix,
-                        comment="Comment",
-                        name="another_id_fk",
+        if testing.requires.constraint_comment_reflection.enabled:
+            if testing.requires.foreign_key_constraint_reflection.enabled:
+                Table(
+                    "fk_constraint_comment_test_1",
+                    metadata,
+                    Column("id", sa.Integer, primary_key=True),
+                    schema=schema,
+                    test_needs_fk=True,
+                )
+                Table(
+                    "fk_constraint_comment_test_2",
+                    metadata,
+                    Column("id", sa.Integer, primary_key=True),
+                    Column(
+                        "another_id",
+                        sa.Integer,
+                        sa.ForeignKey(
+                            "%sfk_constraint_comment_test_1.id"
+                            % schema_prefix,
+                            comment="Comment",
+                            name="another_id_fk",
+                        ),
                     ),
-                ),
-                schema=schema,
-                test_needs_fk=True,
-            )
-        if testing.requires.primary_key_constraint_reflection:
-            Table(
-                "pk_constraint_comment_test",
-                metadata,
-                Column("id", sa.Integer, primary_key=True),
-                sa.PrimaryKeyConstraint(
-                    "id", name="id_pk", comment="id_pk comment"
-                ),
-                schema=schema,
-            )
+                    schema=schema,
+                    test_needs_fk=True,
+                )
+            if testing.requires.primary_key_constraint_reflection.enabled:
+                Table(
+                    "pk_constraint_comment_test",
+                    metadata,
+                    Column("id", sa.Integer, primary_key=True),
+                    sa.PrimaryKeyConstraint(
+                        "id", name="id_pk", comment="id_pk comment"
+                    ),
+                    schema=schema,
+                )
 
-        if testing.requires.check_constraint_reflection:
-            Table(
-                "check_constraint_comment_test",
-                metadata,
-                Column("id", sa.Integer, primary_key=True),
-                sa.CheckConstraint(
-                    "id < 100", name="cc1", comment="id_cc comment"
-                ),
-                schema=schema,
-            )
+            if testing.requires.check_constraint_reflection.enabled:
+                Table(
+                    "check_constraint_comment_test",
+                    metadata,
+                    Column("id", sa.Integer, primary_key=True),
+                    sa.CheckConstraint(
+                        "id < 100", name="cc1", comment="id_cc comment"
+                    ),
+                    schema=schema,
+                )
 
-        if testing.requires.unique_constraint_reflection:
-            Table(
-                "unique_constraint_comment_test",
-                metadata,
-                Column("id", sa.Integer, primary_key=True),
-                Column("data", sa.String(30)),
-                sa.UniqueConstraint(
-                    "data", name="uc1", comment="id_uc comment"
-                ),
-                schema=schema,
-            )
+            if testing.requires.unique_constraint_reflection.enabled:
+                Table(
+                    "unique_constraint_comment_test",
+                    metadata,
+                    Column("id", sa.Integer, primary_key=True),
+                    Column("data", sa.String(30)),
+                    sa.UniqueConstraint(
+                        "data", name="uc1", comment="id_uc comment"
+                    ),
+                    schema=schema,
+                )
 
         if testing.requires.cross_schema_fk_reflection.enabled:
             if schema is None:
@@ -746,7 +748,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
     def _test_get_constraint_comments(self, schema=None):
         insp = inspect(self.bind)
 
-        if testing.requires.foreign_key_constraint_reflection:
+        if testing.requires.foreign_key_constraint_reflection.enabled:
             fkeys = insp.get_foreign_keys(
                 "fk_constraint_comment_test_2", schema=schema
             )
@@ -757,7 +759,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
             eq_(named_fkey["comment"], "Comment")
             eq_(named_fkey["referred_columns"], ["id"])
 
-        if testing.requires.primary_key_constraint_reflection:
+        if testing.requires.primary_key_constraint_reflection.enabled:
             cons = insp.get_pk_constraint(
                 "pk_constraint_comment_test", schema=schema
             )
@@ -765,7 +767,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
             eq_(pkeys, ["id"])
             eq_(cons["comment"], "id_pk comment")
 
-        if testing.requires.check_constraint_reflection:
+        if testing.requires.check_constraint_reflection.enabled:
             ccs = insp.get_check_constraints(
                 "check_constraint_comment_test", schema=schema
             )
@@ -780,7 +782,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
                 ],
             )
 
-        if testing.requires.unique_constraint_reflection:
+        if testing.requires.unique_constraint_reflection.enabled:
             ucs = insp.get_unique_constraints(
                 "unique_constraint_comment_test", schema=schema
             )

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -1707,7 +1707,7 @@ class ReflectionTest(
         )
 
     def test_reflect_check_warning(self):
-        rows = [("some name", "NOTCHECK foobar")]
+        rows = [("some name", "NOTCHECK foobar", None)]
         conn = mock.Mock(
             execute=lambda *arg, **kw: mock.MagicMock(
                 fetchall=lambda: rows, __iter__=lambda self: iter(rows)
@@ -1723,10 +1723,10 @@ class ReflectionTest(
 
     def test_reflect_extra_newlines(self):
         rows = [
-            ("some name", "CHECK (\n(a \nIS\n NOT\n\n NULL\n)\n)"),
-            ("some other name", "CHECK ((b\nIS\nNOT\nNULL))"),
-            ("some CRLF name", "CHECK ((c\r\n\r\nIS\r\nNOT\r\nNULL))"),
-            ("some name", "CHECK (c != 'hi\nim a name\n')"),
+            ("some name", "CHECK (\n(a \nIS\n NOT\n\n NULL\n)\n)", None),
+            ("some other name", "CHECK ((b\nIS\nNOT\nNULL))", None),
+            ("some CRLF name", "CHECK ((c\r\n\r\nIS\r\nNOT\r\nNULL))", None),
+            ("some name", "CHECK (c != 'hi\nim a name\n')", None),
         ]
         conn = mock.Mock(
             execute=lambda *arg, **kw: mock.MagicMock(
@@ -1756,7 +1756,7 @@ class ReflectionTest(
             )
 
     def test_reflect_with_not_valid_check_constraint(self):
-        rows = [("some name", "CHECK ((a IS NOT NULL)) NOT VALID")]
+        rows = [("some name", "CHECK ((a IS NOT NULL)) NOT VALID", None)]
         conn = mock.Mock(
             execute=lambda *arg, **kw: mock.MagicMock(
                 fetchall=lambda: rows, __iter__=lambda self: iter(rows)

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -155,6 +155,10 @@ class DefaultRequirements(SuiteRequirements):
         return only_on(["postgresql", "mysql", "mariadb", "oracle"])
 
     @property
+    def constraint_comment_reflection(self):
+        return only_on(["postgresql"])
+
+    @property
     def unbounded_varchar(self):
         """Target database must support VARCHAR with no length"""
 


### PR DESCRIPTION
Adds support for comments on named constraints, including `ForeignKeyConstraint`, `PrimaryKeyConstraint`, `CheckConstraint`, `UniqueConstraint`, solving the [Issue 5667](https://github.com/sqlalchemy/sqlalchemy/issues/5667). 

Supports only PostgreSQL backend.

### Description

Following the example of [Issue 1546](https://github.com/sqlalchemy/sqlalchemy/issues/1546), supports comments on constraints. Specifically, enables comments on _named_ ones — as I get it, PostgreSQL prohibits comments on unnamed constraints.

Enables setting the comments for named constraints like this:
```
Table(
   'example', metadata,
   Column('id', Integer),
   Column('data', sa.String(30)),
   PrimaryKeyConstraint(
       "id", name="id_pk", comment="id_pk comment"
    ),
   CheckConstraint('id < 100', name="cc1", comment="Id value can't exceed 100"),
   UniqueConstraint(['data'], name="uc1", comment="Must have unique data field"),
)
```

Provides the DDL representation for constraint comments and routines to create and drop them. Class `.Inspector` reflects constraint comments via methods like `get_check_constraints` .
### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
- [ ] A short code fix
- [x] A new feature implementation
	- Solves the issue 5667.
	- The commit message includes `Fixes: 5667`.
	- Includes tests based on comment reflection.

**Have a nice day!**
