### PR TITLE
7720: Mysql SET column type values are missing when using the repr method

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/enumerated.py
+++ b/lib/sqlalchemy/dialects/mysql/enumerated.py
@@ -233,3 +233,6 @@ class SET(_StringType):
     def adapt(self, impltype, **kw):
         kw["retrieve_as_bitwise"] = self.retrieve_as_bitwise
         return util.constructor_copy(self, impltype, *self.values, **kw)
+
+    def __repr__(self):
+        return util.generic_repr(self, to_inspect=[SET, _StringType])

--- a/test/dialect/mysql/test_types.py
+++ b/test/dialect/mysql/test_types.py
@@ -1310,6 +1310,20 @@ class EnumSetTest(
             [("", ""), ("", ""), ("two", "two"), (None, None)],
         )
 
+    @testing.combinations(
+        ([""]),
+        (["a"]),
+        (["a", "b"]),
+        (["a", "b", "c"]),
+        argnames="value",
+    )
+    def test_set_repr(self, value):
+        val = ", ".join((f"'{i}'" for i in value))
+        eq_(
+            repr(Column("e", mysql.SET(*value, retrieve_as_bitwise=True))),
+            f"Column('e', SET({val}), table=None)",
+        )
+
 
 def colspec(c):
     return testing.db.dialect.ddl_compiler(


### PR DESCRIPTION
### Description
Fixes #7720 
Mysql SET column type values are missing when using the repr method.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
