### PR TITLE
Fix link to RFC 1738 in documentation on Engine Configuration

### DIFF
--- a/doc/build/core/engines.rst
+++ b/doc/build/core/engines.rst
@@ -57,7 +57,7 @@ Database Urls
 
 The :func:`_sa.create_engine` function produces an :class:`_engine.Engine` object based
 on a URL.  These URLs follow `RFC-1738
-<https://rfc.net/rfc1738.html>`_, and usually can include username, password,
+<https://www.ietf.org/rfc/rfc1738.txt>`_, and usually can include username, password,
 hostname, database name as well as optional keyword arguments for additional configuration.
 In some cases a file path is accepted, and in others a "data source name" replaces
 the "host" and "database" portions.  The typical form of a database URL is::


### PR DESCRIPTION
Previous link points to resource that is no longer relevant (https://rfc.net/rfc1738.html is no longer RFC 1738).



This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
