### PR TITLE
Added missing python_type to postgres UUID

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1815,6 +1815,10 @@ class UUID(sqltypes.TypeEngine):
 
             return process
 
+    @property
+    def python_type(self):
+        return _python_UUID if self.as_uuid else str
+
 
 PGUuid = UUID
 

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -2832,6 +2832,10 @@ class UUIDTest(fixtures.TestBase):
         )
         eq_(v1.fetchone()[0], value1)
 
+    def test_python_type(self):
+        eq_(UUID(as_uuid=True).python_type, uuid.UUID)
+        eq_(UUID(as_uuid=False).python_type, str)
+
 
 class HStoreTest(AssertsCompiledSQL, fixtures.TestBase):
     __dialect__ = "postgresql"


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
This implements the `python_type` property for the PostgreSQL UUID column type.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [X] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
