### PR TITLE
Use tuple instead of raw url in string formatting

### DIFF
--- a/lib/sqlalchemy/testing/provision.py
+++ b/lib/sqlalchemy/testing/provision.py
@@ -290,13 +290,13 @@ def create_db(cfg, eng, ident):
     Used when a test run will employ multiple processes, e.g., when run
     via `tox` or `pytest -n4`.
     """
-    raise NotImplementedError("no DB creation routine for cfg: %s" % eng.url)
+    raise NotImplementedError("no DB creation routine for cfg: %s" % (eng.url,))
 
 
 @register.init
 def drop_db(cfg, eng, ident):
     """Drop a database that we dynamically created for testing."""
-    raise NotImplementedError("no DB drop routine for cfg: %s" % eng.url)
+    raise NotImplementedError("no DB drop routine for cfg: %s" % (eng.url,))
 
 
 @register.init
@@ -380,7 +380,7 @@ def temp_table_keyword_args(cfg, eng):
     ComponentReflectionTest class in suite/test_reflection.py
     """
     raise NotImplementedError(
-        "no temp table keyword args routine for cfg: %s" % eng.url
+        "no temp table keyword args routine for cfg: %s" % (eng.url,)
     )
 
 

--- a/lib/sqlalchemy/testing/provision.py
+++ b/lib/sqlalchemy/testing/provision.py
@@ -290,7 +290,9 @@ def create_db(cfg, eng, ident):
     Used when a test run will employ multiple processes, e.g., when run
     via `tox` or `pytest -n4`.
     """
-    raise NotImplementedError("no DB creation routine for cfg: %s" % (eng.url,))
+    raise NotImplementedError(
+        "no DB creation routine for cfg: %s" % (eng.url,)
+    )
 
 
 @register.init


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
The `url` is not a string, so needs to be wrapped in a tuple in order to be interpolated into a string. ~I would appreciate any suggestions on how to test, since I can't find anywhere where this file is currently tested~

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

Fixes #7902

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
