### PR TITLE
 fix: #8010

### DIFF
--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -1500,7 +1500,7 @@ class Connection(ConnectionEventsTarget, inspection.Inspectable["Inspector"]):
         if distilled_parameters:
             # ensure we don't retain a link to the view object for keys()
             # which links to the values, which we don't want to cache
-            keys = sorted(distilled_parameters[0])
+            keys = sorted(distilled_parameters[0].keys())
             for_executemany = len(distilled_parameters) > 1
         else:
             keys = []


### PR DESCRIPTION
 TypeError: '<' not supported between instances of 'datetime.datetime' and 'int' #8010

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Added parameter ```.keys()``` solved the problem 
### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:
Short fix #8010


**Have a nice day!**
