### PR TITLE
Fixes: 8023. Getting the original error from the exception wrapper.

### DIFF
--- a/doc/build/changelog/unreleased_14/6199_2.rst
+++ b/doc/build/changelog/unreleased_14/6199_2.rst
@@ -1,0 +1,9 @@
+.. change::
+    :tags: usecase, asyncio, postgresql
+    :tickets: 6199
+
+    Added accessors ``.detail``, ``.message`` and original object exception ``.obj`` to the ``.orig``
+    attribute of the SQLAlchemy exception class raised by the asyncpg DBAPI
+    adapter, that is, the intermediary exception object that wraps on top of
+    that raised by the asyncpg library itself, but below the level of the
+    SQLAlchemy dialect.

--- a/doc/build/changelog/unreleased_14/8023.rst
+++ b/doc/build/changelog/unreleased_14/8023.rst
@@ -1,6 +1,6 @@
 .. change::
     :tags: usecase, asyncio, postgresql
-    :tickets: 6199
+    :tickets: 8023
 
     Added accessors ``.detail``, ``.message`` and original object exception ``.obj`` to the ``.orig``
     attribute of the SQLAlchemy exception class raised by the asyncpg DBAPI

--- a/lib/sqlalchemy/dialects/postgresql/asyncpg.py
+++ b/lib/sqlalchemy/dialects/postgresql/asyncpg.py
@@ -653,6 +653,11 @@ class AsyncAdapt_asyncpg_connection(AdaptedConnection):
                     translated_error.pgcode = (
                         translated_error.sqlstate
                     ) = getattr(error, "sqlstate", None)
+
+                    translated_error.detail = getattr(error, "detail", None)
+                    translated_error.message = getattr(error, "message", None)
+                    translated_error.obj = error
+
                     raise translated_error from error
             else:
                 raise error


### PR DESCRIPTION
adds functionality for: https://github.com/sqlalchemy/sqlalchemy/discussions/8023


When we need to handle an error in depth, just get its details, which constraint caused the error, what table we are working with, we need to know the original error.

In the current realities, this is impossible to do, because. ex.orig is the string that is concatenated from DETAIL + HINT.

My revision allows you to get the original error through
```
orig.obj
detail via orig.detail
message via orig.message
```

This addition partially applies to #6199.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
