### PR TITLE
Update dbapi_transactions.rst

### DIFF
--- a/doc/build/tutorial/dbapi_transactions.rst
+++ b/doc/build/tutorial/dbapi_transactions.rst
@@ -270,7 +270,7 @@ Below we illustrate a variety of ways to access rows.
           y = row.y
 
           # illustrate use with Python f-strings
-          print(f"Row: {row.x} {row.y}")
+          print(f"Row: {row.x} {y}")
 
   ..
 


### PR DESCRIPTION
If you're defining 'y=row.y' then you might as well use 'y' in the print statement.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
The example defines y= row.y but then doesn't use y in the example.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [X] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
