### PR TITLE
Include new MySQL error code 4031 for MySQL disconnect check

### DIFF
--- a/doc/build/changelog/unreleased_14/8036.rst
+++ b/doc/build/changelog/unreleased_14/8036.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: bug, mysql
+    :tickets: 8036
+
+    Fixed an issue in the mysql dialect when using the
+    :paramref:`.create_engine.pool_pre_ping` parameter with MySQL >=
+    8.0.24, an exception was raised instead of reconnecting

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2568,6 +2568,7 @@ class MySQLDialect(default.DefaultDialect):
             2014,
             2045,
             2055,
+            4031,
         ):
             return True
         elif isinstance(

--- a/test/dialect/mysql/test_dialect.py
+++ b/test/dialect/mysql/test_dialect.py
@@ -199,6 +199,10 @@ class DialectTest(fixtures.TestBase):
         (2006, "foo", "OperationalError", "pymysql", True),
         (2007, "foo", "OperationalError", "mysqldb", False),
         (2007, "foo", "OperationalError", "pymysql", False),
+        (4031, "foo", "OperationalError", "mysqldb", True),
+        (4031, "foo", "OperationalError", "pymysql", True),
+        (4032, "foo", "OperationalError", "mysqldb", False),
+        (4032, "foo", "OperationalError", "pymysql", False),
     )
     def test_is_disconnect(
         self, arg0, message, exc_cls_name, dialect_name, is_disconnect


### PR DESCRIPTION

<!-- Provide a general summary of your proposed changes in the Title field above -->

When using pool_pre_ping=True with MySQL version 8.0.28 and a stale
connection, SQLAlchemy raises the following error instead of
reconnecting:

MySQLdb._exceptions.OperationalError: (4031, 'The client was disconnected by the server because of inactivity. See wait_timeout and interactive_timeout for configuring this behavior.')

4031 (ER_CLIENT_INTERACTION_TIMEOUT) is a new error code added in
MySQL version 8.0.24:
https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_client_interaction_timeout

This commit adds 4031 to the error codes list checked in MySQL dialect
"is_disconnect" check.

Fixes: #8036

<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
