### PR TITLE
Docs Update - Add **kwargs to CaseInsensitiveComparator docs

### DIFF
--- a/lib/sqlalchemy/ext/hybrid.py
+++ b/lib/sqlalchemy/ext/hybrid.py
@@ -789,8 +789,8 @@ class::
                 return q.join(self.parent_alias, Node.parent)
             return go
 
-        def operate(self, op, other):
-            return op(self.parent_alias.parent, other)
+        def operate(self, op, other, **kwargs):
+            return op(self.parent_alias.parent, other, **kwargs)
 
 .. sourcecode:: pycon+sql
 

--- a/lib/sqlalchemy/ext/hybrid.py
+++ b/lib/sqlalchemy/ext/hybrid.py
@@ -484,8 +484,8 @@ lowercasing can be applied to all comparison operations (i.e. ``eq``,
 ``lt``, ``gt``, etc.) using :meth:`.Operators.operate`::
 
     class CaseInsensitiveComparator(Comparator):
-        def operate(self, op, other):
-            return op(func.lower(self.__clause_element__()), func.lower(other))
+        def operate(self, op, other, **kwargs):
+            return op(func.lower(self.__clause_element__()), func.lower(other), **kwargs)
 
 .. _hybrid_reuse_subclass:
 

--- a/lib/sqlalchemy/ext/hybrid.py
+++ b/lib/sqlalchemy/ext/hybrid.py
@@ -485,7 +485,11 @@ lowercasing can be applied to all comparison operations (i.e. ``eq``,
 
     class CaseInsensitiveComparator(Comparator):
         def operate(self, op, other, **kwargs):
-            return op(func.lower(self.__clause_element__()), func.lower(other), **kwargs)
+            return op(
+                func.lower(self.__clause_element__()),
+                func.lower(other),
+                **kwargs,
+            )
 
 .. _hybrid_reuse_subclass:
 
@@ -575,10 +579,10 @@ Replacing the previous ``CaseInsensitiveComparator`` class with a new
             else:
                 self.word = func.lower(word)
 
-        def operate(self, op, other):
+        def operate(self, op, other, **kwargs):
             if not isinstance(other, CaseInsensitiveWord):
                 other = CaseInsensitiveWord(other)
-            return op(self.word, other.word)
+            return op(self.word, other.word, **kwargs)
 
         def __clause_element__(self):
             return self.word
@@ -706,12 +710,14 @@ the ``Node.parent`` attribute and filtered based on the given criterion::
     from sqlalchemy.ext.hybrid import Comparator
 
     class GrandparentTransformer(Comparator):
-        def operate(self, op, other):
+        def operate(self, op, other, **kwargs):
             def transform(q):
                 cls = self.__clause_element__()
                 parent_alias = aliased(cls)
-                return q.join(parent_alias, cls.parent).\
-                            filter(op(parent_alias.parent, other))
+                return q.join(parent_alias, cls.parent).filter(
+                    op(parent_alias.parent, other, **kwargs)
+                )
+
             return transform
 
     Base = declarative_base()

--- a/lib/sqlalchemy/sql/operators.py
+++ b/lib/sqlalchemy/sql/operators.py
@@ -320,8 +320,8 @@ class Operators:
         side::
 
             class MyComparator(ColumnOperators):
-                def operate(self, op, other):
-                    return op(func.lower(self), func.lower(other))
+                def operate(self, op, other, **kwargs):
+                    return op(func.lower(self), func.lower(other), **kwargs)
 
         :param op:  Operator callable.
         :param \*other: the 'other' side of the operation. Will


### PR DESCRIPTION
### Description

Add arbitrary kwargs to `CaseInsensitiveComparator` example. Without it, attempting to use operations like `like` will throw the following exception:

```
>       return self.operate(like_op, other, escape=escape)
E       TypeError: CaseInsensitiveComparator.operate() got an unexpected keyword argument 'escape'
```

### Checklist

This pull request is:

- [ x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
