### PR TITLE
Update connection.rst

### DIFF
--- a/doc/build/faq/connections.rst
+++ b/doc/build/faq/connections.rst
@@ -281,7 +281,7 @@ statement executions::
                               trans.rollback()
 
                       time.sleep(retry_interval)
-                      context.cursor = cursor_obj = connection.connection.cursor()
+                      context.cursor = cursor = connection.connection.cursor()
                   else:
                       raise
               else:
@@ -290,15 +290,15 @@ statement executions::
       e = engine.execution_options(isolation_level="AUTOCOMMIT")
 
       @event.listens_for(e, "do_execute_no_params")
-      def do_execute_no_params(cursor_obj, statement, context):
+      def do_execute_no_params(cursor, statement, context):
           return _run_with_retries(
-              context.dialect.do_execute_no_params, context, cursor_obj, statement
+              context.dialect.do_execute_no_params, context, cursor, statement
           )
 
       @event.listens_for(e, "do_execute")
-      def do_execute(cursor_obj, statement, parameters, context):
+      def do_execute(cursor, statement, parameters, context):
           return _run_with_retries(
-              context.dialect.do_execute, context, cursor_obj, statement, parameters
+              context.dialect.do_execute, context, cursor, statement, parameters
           )
 
       return e


### PR DESCRIPTION
Fix a bug on reconnecting logic since at it is right now it is assigning the new connection to a new cursor variable that remains unused and therefore it retries the connection on the old cursor, not the newly created one.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
