### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/run-on-pr.yaml
+++ b/.github/workflows/run-on-pr.yaml
@@ -12,6 +12,9 @@ env:
   # global env to all steps
   TOX_WORKERS: -n2
 
+permissions:
+  contents: read
+
 jobs:
   run-test-amd64:
     name: ${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -16,6 +16,9 @@ env:
   # global env to all steps
   TOX_WORKERS: -n2
 
+permissions:
+  contents: read
+
 jobs:
   run-test:
     name: ${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
