### PR TITLE
Attempt to resolve edge case related to escaping of curly braces in ODBC connection strings

### DIFF
--- a/lib/sqlalchemy/connectors/pyodbc.py
+++ b/lib/sqlalchemy/connectors/pyodbc.py
@@ -77,9 +77,6 @@ class PyODBCConnector(Connector):
         else:
 
             def check_quote(token: str) -> str:
-                # token is already quoted, so return it as-is
-                if str(token).startswith("{") and str(token).endswith("}"):
-                    return token
                 if ";" in str(token) or str(token).startswith("{"):
                     token = "{%s}" % token.replace("}", "}}")
                 return token

--- a/lib/sqlalchemy/connectors/pyodbc.py
+++ b/lib/sqlalchemy/connectors/pyodbc.py
@@ -76,12 +76,11 @@ class PyODBCConnector(Connector):
             connectors = [unquote_plus(keys.pop("odbc_connect"))]
         else:
 
-            def check_quote(token: Any) -> str:
-                token = str(token)
+            def check_quote(token: str) -> str:
                 # token is already quoted, so return it as-is
-                if token.startswith("{") and token.endswith("}"):
+                if str(token).startswith("{") and str(token).endswith("}"):
                     return token
-                if ";" in token or token.startswith("{"):
+                if ";" in str(token) or str(token).startswith("{"):
                     token = "{%s}" % token.replace("}", "}}")
                 return token
 

--- a/lib/sqlalchemy/connectors/pyodbc.py
+++ b/lib/sqlalchemy/connectors/pyodbc.py
@@ -77,6 +77,9 @@ class PyODBCConnector(Connector):
         else:
 
             def check_quote(token: str) -> str:
+                # token is already quoted, so return it as-is
+                if token.startswith("{") and token.endswith("}"):
+                    return token
                 if ";" in str(token) or str(token).startswith("{"):
                     token = "{%s}" % token.replace("}", "}}")
                 return token

--- a/lib/sqlalchemy/connectors/pyodbc.py
+++ b/lib/sqlalchemy/connectors/pyodbc.py
@@ -76,8 +76,7 @@ class PyODBCConnector(Connector):
             connectors = [unquote_plus(keys.pop("odbc_connect"))]
         else:
 
-            def check_quote(token: Any) -> str:
-                token = str(token)
+            def check_quote(token: str) -> str:
                 # token is already quoted, so return it as-is
                 if token.startswith("{") and token.endswith("}"):
                     return token
@@ -85,7 +84,10 @@ class PyODBCConnector(Connector):
                     token = "{%s}" % token.replace("}", "}}")
                 return token
 
-            keys = dict((k, check_quote(v)) for k, v in keys.items())
+            keys = dict(
+                (k, check_quote(v) if type(v) == str else v)
+                for k, v in keys.items()
+            )
 
             dsn_connection = "dsn" in keys or (
                 "host" in keys and "database" not in keys

--- a/lib/sqlalchemy/connectors/pyodbc.py
+++ b/lib/sqlalchemy/connectors/pyodbc.py
@@ -78,7 +78,7 @@ class PyODBCConnector(Connector):
 
             def check_quote(token: str) -> str:
                 # token is already quoted, so return it as-is
-                if token.startswith("{") and token.endswith("}"):
+                if str(token).startswith("{") and str(token).endswith("}"):
                     return token
                 if ";" in str(token) or str(token).startswith("{"):
                     token = "{%s}" % token.replace("}", "}}")

--- a/lib/sqlalchemy/connectors/pyodbc.py
+++ b/lib/sqlalchemy/connectors/pyodbc.py
@@ -76,7 +76,8 @@ class PyODBCConnector(Connector):
             connectors = [unquote_plus(keys.pop("odbc_connect"))]
         else:
 
-            def check_quote(token: str) -> str:
+            def check_quote(token: Any) -> str:
+                token = str(token)
                 # token is already quoted, so return it as-is
                 if token.startswith("{") and token.endswith("}"):
                     return token
@@ -84,10 +85,7 @@ class PyODBCConnector(Connector):
                     token = "{%s}" % token.replace("}", "}}")
                 return token
 
-            keys = dict(
-                (k, check_quote(v) if type(v) == str else v)
-                for k, v in keys.items()
-            )
+            keys = dict((k, check_quote(v)) for k, v in keys.items())
 
             dsn_connection = "dsn" in keys or (
                 "host" in keys and "database" not in keys

--- a/lib/sqlalchemy/connectors/pyodbc.py
+++ b/lib/sqlalchemy/connectors/pyodbc.py
@@ -76,11 +76,12 @@ class PyODBCConnector(Connector):
             connectors = [unquote_plus(keys.pop("odbc_connect"))]
         else:
 
-            def check_quote(token: str) -> str:
+            def check_quote(token: Any) -> str:
+                token = str(token)
                 # token is already quoted, so return it as-is
-                if str(token).startswith("{") and str(token).endswith("}"):
+                if token.startswith("{") and token.endswith("}"):
                     return token
-                if ";" in str(token) or str(token).startswith("{"):
+                if ";" in token or token.startswith("{"):
                     token = "{%s}" % token.replace("}", "}}")
                 return token
 

--- a/test/dialect/mssql/test_engine.py
+++ b/test/dialect/mssql/test_engine.py
@@ -257,11 +257,11 @@ class ParseConnectTest(fixtures.TestBase):
                 "larry",
                 "{moe",
                 "localhost",
-                1433,
+                None,
                 "mydb",
             ),
             (
-                "DRIVER={foob};Server=localhost,1433;"
+                "DRIVER={foob};Server=localhost;"
                 "Database=mydb;UID=larry;"
                 "PWD={{moe}",
             ),
@@ -272,11 +272,11 @@ class ParseConnectTest(fixtures.TestBase):
                 "alice",
                 "{password}",
                 "localhost",
-                1433,
+                None,
                 "mydb",
             ),
             (
-                "DRIVER={foob};Server=localhost,1433;"
+                "DRIVER={foob};Server=localhost;"
                 "Database=mydb;UID=alice;"
                 "PWD={{password}}}",
             ),
@@ -285,7 +285,9 @@ class ParseConnectTest(fixtures.TestBase):
         id_="iaa",
     )
     def test_pyodbc_token_injection(self, tokens, connection_string):
-        u = url.make_url("mssql+pyodbc://%s:%s@%s:%s/%s?driver=foob" % tokens)
+        username, password, hostname, port, database = tokens
+        raw_url = f"mssql+pyodbc://{username}:{password}@{hostname}{':%s' % port if port else ''}/{database}?driver=foob"
+        u = url.make_url(raw_url)
         dialect = pyodbc.dialect()
         connection = dialect.create_connect_args(u)
         eq_(

--- a/test/dialect/mssql/test_engine.py
+++ b/test/dialect/mssql/test_engine.py
@@ -278,7 +278,7 @@ class ParseConnectTest(fixtures.TestBase):
             (
                 "DRIVER={foob};Server=localhost,1433;"
                 "Database=mydb;UID=alice;"
-                "PWD={password}",
+                "PWD={{password}}}",
             ),
         ),
         argnames="tokens, connection_string",

--- a/test/dialect/mssql/test_engine.py
+++ b/test/dialect/mssql/test_engine.py
@@ -242,10 +242,11 @@ class ParseConnectTest(fixtures.TestBase):
                 "someuser%3BPORT%3D50001",
                 "some{strange}pw%3BPORT%3D50001",
                 "somehost%3BPORT%3D50001",
+                50001,
                 "somedb%3BPORT%3D50001",
             ),
             (
-                "DRIVER={foob};Server=somehost%3BPORT%3D50001;"
+                "DRIVER={foob};Server=somehost%3BPORT%3D50001,50001;"
                 "Database=somedb%3BPORT%3D50001;UID={someuser;PORT=50001};"
                 "PWD={some{strange}}pw;PORT=50001}",
             ),
@@ -256,10 +257,11 @@ class ParseConnectTest(fixtures.TestBase):
                 "larry",
                 "{moe",
                 "localhost",
+                5432,
                 "mydb",
             ),
             (
-                "DRIVER={foob};Server=localhost;"
+                "DRIVER={foob};Server=localhost,5432;"
                 "Database=mydb;UID=larry;"
                 "PWD={{moe}",
             ),
@@ -270,10 +272,11 @@ class ParseConnectTest(fixtures.TestBase):
                 "alice",
                 "{password}",
                 "localhost",
+                5432,
                 "mydb",
             ),
             (
-                "DRIVER={foob};Server=localhost;"
+                "DRIVER={foob};Server=localhost,5432;"
                 "Database=mydb;UID=alice;"
                 "PWD={password}",
             ),
@@ -282,7 +285,7 @@ class ParseConnectTest(fixtures.TestBase):
         id_="iaa",
     )
     def test_pyodbc_token_injection(self, tokens, connection_string):
-        u = url.make_url("mssql+pyodbc://%s:%s@%s/%s?driver=foob" % tokens)
+        u = url.make_url("mssql+pyodbc://%s:%s@%s:%s/%s?driver=foob" % tokens)
         dialect = pyodbc.dialect()
         connection = dialect.create_connect_args(u)
         eq_(

--- a/test/dialect/mssql/test_engine.py
+++ b/test/dialect/mssql/test_engine.py
@@ -264,6 +264,20 @@ class ParseConnectTest(fixtures.TestBase):
                 "PWD={{moe}",
             ),
         ),
+        (
+            "issue_8062_extra",
+            (
+                "alice",
+                "{password}",
+                "localhost",
+                "mydb",
+            ),
+            (
+                "DRIVER={foob};Server=localhost;"
+                "Database=mydb;UID=alice;"
+                "PWD={password}",
+            ),
+        ),
         argnames="tokens, connection_string",
         id_="iaa",
     )

--- a/test/dialect/mssql/test_engine.py
+++ b/test/dialect/mssql/test_engine.py
@@ -257,11 +257,11 @@ class ParseConnectTest(fixtures.TestBase):
                 "larry",
                 "{moe",
                 "localhost",
-                3306,
+                1433,
                 "mydb",
             ),
             (
-                "DRIVER={foob};Server=localhost,3306;"
+                "DRIVER={foob};Server=localhost,1433;"
                 "Database=mydb;UID=larry;"
                 "PWD={{moe}",
             ),
@@ -272,11 +272,11 @@ class ParseConnectTest(fixtures.TestBase):
                 "alice",
                 "{password}",
                 "localhost",
-                3306,
+                1433,
                 "mydb",
             ),
             (
-                "DRIVER={foob};Server=localhost,3306;"
+                "DRIVER={foob};Server=localhost,1433;"
                 "Database=mydb;UID=alice;"
                 "PWD={password}",
             ),

--- a/test/dialect/mssql/test_engine.py
+++ b/test/dialect/mssql/test_engine.py
@@ -257,11 +257,11 @@ class ParseConnectTest(fixtures.TestBase):
                 "larry",
                 "{moe",
                 "localhost",
-                5432,
+                3306,
                 "mydb",
             ),
             (
-                "DRIVER={foob};Server=localhost,5432;"
+                "DRIVER={foob};Server=localhost,3306;"
                 "Database=mydb;UID=larry;"
                 "PWD={{moe}",
             ),
@@ -272,11 +272,11 @@ class ParseConnectTest(fixtures.TestBase):
                 "alice",
                 "{password}",
                 "localhost",
-                5432,
+                3306,
                 "mydb",
             ),
             (
-                "DRIVER={foob};Server=localhost,5432;"
+                "DRIVER={foob};Server=localhost,3306;"
                 "Database=mydb;UID=alice;"
                 "PWD={password}",
             ),


### PR DESCRIPTION
### Description
Issue #8062 (resolved by 8ac7cb92b4972a08b8008b80b34989694510139f) relates to handling of curly braces within ODBC connection strings.

There may be a remaining [edge case](https://github.com/sqlalchemy/sqlalchemy/issues/8062#issuecomment-1152894834) if a connection string token begins with an opening curly brace and finishes with a closing curly brace (in other words, it appears to already be escaped by curly braces).

This pull request offers a solution, which is not to perform escaping on tokens that appear to already be escaped.

**Question**: should I open a follow-up issue for this?

### Checklist
- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.