### PR TITLE
[mypy plugin] Support lambda expressions

### DIFF
--- a/lib/sqlalchemy/ext/mypy/infer.py
+++ b/lib/sqlalchemy/ext/mypy/infer.py
@@ -16,6 +16,7 @@ from mypy.nodes import AssignmentStmt
 from mypy.nodes import CallExpr
 from mypy.nodes import Expression
 from mypy.nodes import FuncDef
+from mypy.nodes import LambdaExpr
 from mypy.nodes import MemberExpr
 from mypy.nodes import NameExpr
 from mypy.nodes import RefExpr
@@ -422,6 +423,9 @@ def _infer_type_from_decl_column(
                 continue
         elif isinstance(column_arg, (StrExpr,)):
             # x = Column("name", String), go to next argument
+            continue
+        elif isinstance(column_arg, (LambdaExpr,)):
+            # x = Column("name", default=lambda: uuid.uuid4(), String), go to next argument
             continue
         else:
             assert False


### PR DESCRIPTION
:wave: Hi

This changes only the (_alpha, not really maintained_) mypy plugin to avoid an `error: INTERNAL ERROR` when the default of a column is a lambda

### Description

Add a condition so we don't crash on lambdas

### Checklist

This pull request is:
- [ ] A documentation / typographical error fix
- [x] A short code fix
- [ ] A new feature implementation

**Have a nice day!**
Thanks a lot !