### PR TITLE
swap order of views in get_isolation_level for mssql dialect for Synapse. Fixes: #8231

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -2862,8 +2862,6 @@ class MSDialect(default.DefaultDialect):
         ),
     ]
 
-    sqlserver_variant = "sqlserver"
-
     def __init__(
         self,
         query_timeout=None,

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -2924,7 +2924,9 @@ class MSDialect(default.DefaultDialect):
     def get_isolation_level(self, dbapi_connection):
         last_error = None
 
-        views = ("sys.dm_exec_sessions", "sys.dm_pdw_nodes_exec_sessions")
+        # for compatibility with PDW/Synapse, dm_pdw_nodes_exec_sessions must
+        # be checked first
+        views = ("sys.dm_pdw_nodes_exec_sessions", "sys.dm_exec_sessions")
         for view in views:
             cursor = dbapi_connection.cursor()
             try:


### PR DESCRIPTION
In discussion #8223, discovered that swapping the order of the views in `get_isolation_level` in the mssql dialect allows transactions to function properly on SQL Data Warehouse and related products.

### Description
In mssql\base.py in get_isolation_level, the order of the views to check to get the isolation level is swapped so that `sys.dm_pdw_nodes_exec_sessions` is first to be checked. When these are in the original order, SQLAlchemy first checks `sys.dm_exec_sessions`, which causes the transaction to fail and leaves SQLAlchemy unable to connect to Synapse unless `autocommit` is set to True.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
