### PR TITLE
Update async_scoped_session example

### DIFF
--- a/doc/build/orm/extensions/asyncio.rst
+++ b/doc/build/orm/extensions/asyncio.rst
@@ -756,6 +756,8 @@ the usual ``await`` keywords are necessary, including for the
     async def some_function(some_async_session, some_object):
        # use the AsyncSession directly
        some_async_session.add(some_object)
+       # or as alternative use the AsyncSession via the context-local proxy
+       AsyncScopedSession.add(some_object)
 
        # use the AsyncSession via the context-local proxy
        await AsyncScopedSession.commit()


### PR DESCRIPTION
Added example adding new object using `async_scoped_session` proxy object

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
When exploring docs about `async_scoped_session` with my colleague, I found the example with `async_scoped_session` to be a bit confusing. I thought we should create `AsyncSession` to add a new object, but after trying, I found that we shouldn't — that object can be added through `async_scoped_session` proxy. For that reason, I've added an example where an object could be added via proxy object.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
