### PR TITLE
Add alembic `extras_require` to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     typing-extensions >= 4.1.0
 
 [options.extras_require]
+alembic = alembic
 asyncio =
     greenlet!=0.4.17
 mypy =


### PR DESCRIPTION
### Description
This merge request adds a new `extras_require` to setup.cfg to allow users to install Alembic to be installed with SQLAlchemy via extras requires.

While alembic currently requires SQLAlchemy to function, it does not allow the user to include the database driver or mypy at the same time. By providing this option, a user will be able to install SQLAlchemy, a database driver, Mypy, and Alembic via a single command for easy inclusion into projects.

Thank you for your consideration of this change.

Apologies for the newline at the end, that was added by Github (done via web UI) and I'm not sure how to easily remove this.



### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [X] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
