### PR TITLE
Remove all `__nonzero__` methods

### DIFF
--- a/lib/sqlalchemy/event/attr.py
+++ b/lib/sqlalchemy/event/attr.py
@@ -398,8 +398,6 @@ class _EmptyListener(_InstanceLevelDispatch[_ET]):
     def __bool__(self) -> bool:
         return bool(self.parent_listeners)
 
-    __nonzero__ = __bool__
-
 
 class _MutexProtocol(Protocol):
     def __enter__(self) -> bool:
@@ -508,8 +506,6 @@ class _CompoundListener(_InstanceLevelDispatch[_ET]):
 
     def __bool__(self) -> bool:
         return bool(self.listeners or self.parent_listeners)
-
-    __nonzero__ = __bool__
 
 
 class _ListenerCollection(_CompoundListener[_ET]):

--- a/lib/sqlalchemy/ext/associationproxy.py
+++ b/lib/sqlalchemy/ext/associationproxy.py
@@ -1316,8 +1316,6 @@ class _AssociationCollection(Generic[_IT]):
     def __bool__(self) -> bool:
         return bool(self.col)
 
-    __nonzero__ = __bool__
-
     def __getstate__(self) -> Any:
         return {"parent": self.parent, "lazy_collection": self.lazy_collection}
 
@@ -1748,8 +1746,6 @@ class _AssociationSet(_AssociationSingleItem[_T], MutableSet[_T]):
             return True
         else:
             return False
-
-    __nonzero__ = __bool__
 
     def __contains__(self, __o: object) -> bool:
         for member in self.col:

--- a/lib/sqlalchemy/orm/collections.py
+++ b/lib/sqlalchemy/orm/collections.py
@@ -614,8 +614,6 @@ class CollectionAdapter:
     def __bool__(self):
         return True
 
-    __nonzero__ = __bool__
-
     def fire_append_wo_mutation_event(self, item, initiator=None):
         """Notify that a entity is entering the collection but is already
         present.

--- a/lib/sqlalchemy/orm/dynamic.py
+++ b/lib/sqlalchemy/orm/dynamic.py
@@ -337,8 +337,6 @@ class DynamicCollectionAdapter:
     def __bool__(self):
         return True
 
-    __nonzero__ = __bool__
-
 
 class AppenderMixin:
     query_class = None

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -696,8 +696,6 @@ class ClauseElement(
     def __bool__(self):
         raise TypeError("Boolean value of this clause is not defined")
 
-    __nonzero__ = __bool__
-
     def __repr__(self):
         friendly = self.description
         if friendly is None:

--- a/lib/sqlalchemy/sql/lambdas.py
+++ b/lib/sqlalchemy/sql/lambdas.py
@@ -1341,10 +1341,6 @@ class PyWrapper(ColumnOperators):
         to_evaluate = object.__getattribute__(self, "_to_evaluate")
         return bool(to_evaluate)
 
-    def __nonzero__(self):
-        to_evaluate = object.__getattribute__(self, "_to_evaluate")
-        return bool(to_evaluate)
-
     def __getattribute__(self, key):
         if key.startswith("_sa_"):
             return object.__getattribute__(self, key[4:])


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

`__nonzero__` was used in python2 just like we use `__bool__` today.
It is no longer used right now.

I think it is safe to remove it, because python2 is not supported for a long time now.

I've noticed it while working on type annotations in [`typeshed`](https://github.com/python/typeshed/blob/183a43a7e0d6b994f4d84f251a2301c4ae0eac21/stubs/SQLAlchemy/sqlalchemy/event/attr.pyi#L49)

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
