### PR TITLE
Remove `__cmp__` methods

### DIFF
--- a/lib/sqlalchemy/cyextension/collections.pyx
+++ b/lib/sqlalchemy/cyextension/collections.pyx
@@ -213,9 +213,6 @@ cdef class IdentitySet:
     def clear(self):
         self._members.clear()
 
-    def __cmp__(self, other):
-        raise TypeError("cannot compare sets using cmp()")
-
     def __eq__(self, other):
         cdef IdentitySet other_
         if isinstance(other, IdentitySet):

--- a/lib/sqlalchemy/sql/annotation.py
+++ b/lib/sqlalchemy/sql/annotation.py
@@ -257,7 +257,7 @@ class Annotated(SupportsAnnotations):
     """clones a SupportsAnnotations and applies an 'annotations' dictionary.
 
     Unlike regular clones, this clone also mimics __hash__() and
-    __cmp__() of the original element so that it takes its place
+    __eq__() of the original element so that it takes its place
     in hashed collections.
 
     A reference to the original element is maintained, for the important

--- a/lib/sqlalchemy/util/_py_collections.py
+++ b/lib/sqlalchemy/util/_py_collections.py
@@ -296,9 +296,6 @@ class IdentitySet:
     def clear(self) -> None:
         self._members.clear()
 
-    def __cmp__(self, other: Any) -> NoReturn:
-        raise TypeError("cannot compare sets using cmp()")
-
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, IdentitySet):
             return self._members == other._members


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Python3 does not support `__cmp__` (similar to #8308).
Python3 also does not have `cmp()` builtin anymore.

So, I don't think these methods are useful.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
