### PR TITLE
Fix doc constraints snippet: List -> Tuple

### DIFF
--- a/doc/build/core/constraints.rst
+++ b/doc/build/core/constraints.rst
@@ -78,7 +78,7 @@ And then a table ``invoice_item`` with a composite foreign key referencing
         Column('item_name', String(60), nullable=False),
         Column('invoice_id', Integer, nullable=False),
         Column('ref_num', Integer, nullable=False),
-        ForeignKeyConstraint(['invoice_id', 'ref_num'], ['invoice.invoice_id', 'invoice.ref_num'])
+        ForeignKeyConstraint(('invoice_id', 'ref_num'), ['invoice.invoice_id', 'invoice.ref_num'])
     )
 
 It's important to note that the


### PR DESCRIPTION
When using a composite ForeignKeyConstraint, the doc example uses a List for the columns attribute, while my IDE complains that instead of a list, it should be a tuple

### Description
Old: ['invoice_id', 'ref_num']
New: ('invoice_id', 'ref_num')

![Screen Shot 2022-08-25 at 22 49 26](https://user-images.githubusercontent.com/8230037/186799466-c85e0dfa-f31c-4851-9c4a-ee9a65bbb697.png)


### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.


