### PR TITLE
Detection of PEP 604 union syntax.

### DIFF
--- a/lib/sqlalchemy/orm/properties.py
+++ b/lib/sqlalchemy/orm/properties.py
@@ -52,8 +52,8 @@ from ..sql.schema import SchemaConst
 from ..util.typing import de_optionalize_union_types
 from ..util.typing import de_stringify_annotation
 from ..util.typing import is_fwd_ref
+from ..util.typing import is_optional_union
 from ..util.typing import is_pep593
-from ..util.typing import NoneType
 from ..util.typing import Self
 from ..util.typing import typing_get_args
 
@@ -652,17 +652,15 @@ class MappedColumn(
     ) -> None:
         sqltype = self.column.type
 
-        nullable = False
+        if is_fwd_ref(argument):
+            argument = de_stringify_annotation(cls, argument)
 
-        if hasattr(argument, "__origin__"):
-            nullable = NoneType in argument.__args__  # type: ignore
+        nullable = is_optional_union(argument)
 
         if not self._has_nullable:
             self.column.nullable = nullable
 
         our_type = de_optionalize_union_types(argument)
-        if is_fwd_ref(our_type):
-            our_type = de_stringify_annotation(cls, our_type)
 
         use_args_from = None
         if is_pep593(our_type):

--- a/lib/sqlalchemy/util/typing.py
+++ b/lib/sqlalchemy/util/typing.py
@@ -169,7 +169,7 @@ def make_union_type(*types: _AnnotationScanType) -> Type[Any]:
 def expand_unions(
     type_: Type[Any], include_union: bool = False, discard_none: bool = False
 ) -> Tuple[Type[Any], ...]:
-    """Return a type as as a tuple of individual types, expanding for
+    """Return a type as a tuple of individual types, expanding for
     ``Union`` types."""
 
     if is_union(type_):
@@ -191,7 +191,12 @@ def is_optional(type_):
         type_,
         "Optional",
         "Union",
+        "UnionType",
     )
+
+
+def is_optional_union(type_: Any) -> bool:
+    return is_optional(type_) and NoneType in typing_get_args(type_)
 
 
 def is_union(type_):
@@ -204,7 +209,7 @@ def is_origin_of(
     """return True if the given type has an __origin__ with the given name
     and optional module."""
 
-    origin = getattr(type_, "__origin__", None)
+    origin = typing_get_origin(type_)
     if origin is None:
         return False
 

--- a/test/orm/declarative/test_typed_mapping.py
+++ b/test/orm/declarative/test_typed_mapping.py
@@ -879,9 +879,14 @@ class MappedColumnTest(fixtures.TestBase, testing.AssertsCompiledSQL):
             decimal_data: Mapped[Decimal] = mapped_column()
 
             if compat.py310:
-                pep604_data: Mapped["float | Decimal"] = mapped_column()
-                pep604_reverse: Mapped["Decimal | float"] = mapped_column()
+                pep604_data: Mapped[float | Decimal] = mapped_column()
+                pep604_reverse: Mapped[Decimal | float] = mapped_column()
                 pep604_optional: Mapped[
+                    Decimal | float | None
+                ] = mapped_column()
+                pep604_data_fwd: Mapped["float | Decimal"] = mapped_column()
+                pep604_reverse_fwd: Mapped["Decimal | float"] = mapped_column()
+                pep604_optional_fwd: Mapped[
                     "Decimal | float | None"
                 ] = mapped_column()
 
@@ -900,12 +905,16 @@ class MappedColumnTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         is_(User.__table__.c.decimal_data.type, our_type)
 
         if compat.py310:
-            is_(User.__table__.c.pep604_data.type, our_type)
-            is_false(User.__table__.c.pep604_data.nullable)
-            is_(User.__table__.c.pep604_reverse.type, our_type)
-            is_false(User.__table__.c.pep604_reverse.nullable)
-            is_(User.__table__.c.pep604_optional.type, our_type)
-            is_true(User.__table__.c.pep604_optional.nullable)
+            for suffix in ("", "_fwd"):
+                data_col = User.__table__.c[f"pep604_data{suffix}"]
+                reverse_col = User.__table__.c[f"pep604_reverse{suffix}"]
+                optional_col = User.__table__.c[f"pep604_optional{suffix}"]
+                is_(data_col.type, our_type)
+                is_false(data_col.nullable)
+                is_(reverse_col.type, our_type)
+                is_false(reverse_col.nullable)
+                is_(optional_col.type, our_type)
+                is_true(optional_col.nullable)
 
     def test_missing_mapped_lhs(self, decl_base):
         with expect_raises_message(


### PR DESCRIPTION
### Description

Fixes #8478 

Handle `UnionType` as arguments to `Mapped`, e.g., `Mapped[str | None]`:

- adds `utils.typing.is_optional_union()` used to detect if a column should be nullable.
- adds `"UnionType"` to `utils.typing.is_optional()` names.
- uses `get_origin()` in `utils.typing.is_origin_of()` as `UnionType` has no `__origin__` attribute.
- tests with runtime type and postponed annotations and guard the tests running with `compat.py310`.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
