### PR TITLE
Make if_exists and if_not_exists flags on ddl statements match compiler

### DIFF
--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -4987,12 +4987,16 @@ class DDLCompiler(Compiled):
         return self.sql_compiler.post_process_text(ddl.statement % context)
 
     def visit_create_schema(self, create, **kw):
-        schema = self.preparer.format_schema(create.element)
-        return "CREATE SCHEMA " + schema
+        text = "CREATE SCHEMA "
+        if create.if_not_exists:
+            text += "IF NOT EXISTS "
+        return text + self.preparer.format_schema(create.element)
 
     def visit_drop_schema(self, drop, **kw):
-        schema = self.preparer.format_schema(drop.element)
-        text = "DROP SCHEMA " + schema
+        text = "DROP SCHEMA "
+        if drop.if_exists:
+            text += "IF EXISTS "
+        text += self.preparer.format_schema(drop.element)
         if drop.cascade:
             text += " CASCADE"
         return text
@@ -5241,9 +5245,11 @@ class DDLCompiler(Compiled):
         return " ".join(text)
 
     def visit_create_sequence(self, create, prefix=None, **kw):
-        text = "CREATE SEQUENCE %s" % self.preparer.format_sequence(
-            create.element
-        )
+        text = "CREATE SEQUENCE "
+        if create.if_not_exists:
+            text += "IF NOT EXISTS "
+        text += self.preparer.format_sequence(create.element)
+
         if prefix:
             text += prefix
         if create.element.start is None:
@@ -5254,7 +5260,10 @@ class DDLCompiler(Compiled):
         return text
 
     def visit_drop_sequence(self, drop, **kw):
-        return "DROP SEQUENCE %s" % self.preparer.format_sequence(drop.element)
+        text = "DROP SEQUENCE "
+        if drop.if_exists:
+            text += "IF EXISTS "
+        return text + self.preparer.format_sequence(drop.element)
 
     def visit_drop_constraint(self, drop, **kw):
         constraint = drop.element

--- a/lib/sqlalchemy/sql/ddl.py
+++ b/lib/sqlalchemy/sql/ddl.py
@@ -40,6 +40,7 @@ if typing.TYPE_CHECKING:
     from .schema import Constraint
     from .schema import ForeignKeyConstraint
     from .schema import SchemaItem
+    from .schema import Sequence
     from .schema import Table
     from ..engine.base import _CompiledCacheType
     from ..engine.base import Connection
@@ -434,12 +435,8 @@ class _CreateDropBase(ExecutableDDLElement):
     def __init__(
         self,
         element,
-        if_exists=False,
-        if_not_exists=False,
     ):
         self.element = self.target = element
-        self.if_exists = if_exists
-        self.if_not_exists = if_not_exists
         self._ddl_if = getattr(element, "_ddl_if", None)
 
     @property
@@ -457,7 +454,19 @@ class _CreateDropBase(ExecutableDDLElement):
         return False
 
 
-class CreateSchema(_CreateDropBase):
+class _CreateBase(_CreateDropBase):
+    def __init__(self, element, if_not_exists=False):
+        super().__init__(element)
+        self.if_not_exists = if_not_exists
+
+
+class _DropBase(_CreateDropBase):
+    def __init__(self, element, if_exists=False):
+        super().__init__(element)
+        self.if_exists = if_exists
+
+
+class CreateSchema(_CreateBase):
     """Represent a CREATE SCHEMA statement.
 
     The argument here is the string name of the schema.
@@ -470,18 +479,15 @@ class CreateSchema(_CreateDropBase):
         self,
         name,
         quote=None,
-        if_exists=False,
         if_not_exists=False,
     ):
         """Create a new :class:`.CreateSchema` construct."""
 
+        super().__init__(element=name, if_not_exists=if_not_exists)
         self.quote = quote
-        self.element = name
-        self.if_exists = if_exists
-        self.if_not_exists = if_not_exists
 
 
-class DropSchema(_CreateDropBase):
+class DropSchema(_DropBase):
     """Represent a DROP SCHEMA statement.
 
     The argument here is the string name of the schema.
@@ -496,19 +502,15 @@ class DropSchema(_CreateDropBase):
         quote=None,
         cascade=False,
         if_exists=False,
-        if_not_exists=False,
     ):
         """Create a new :class:`.DropSchema` construct."""
 
-        self.quote = quote
+        super().__init__(element=name, if_exists=if_exists)
         self.cascade = cascade
         self.quote = quote
-        self.element = name
-        self.if_exists = if_exists
-        self.if_not_exists = if_not_exists
 
 
-class CreateTable(_CreateDropBase):
+class CreateTable(_CreateBase):
     """Represent a CREATE TABLE statement."""
 
     __visit_name__ = "create_table"
@@ -544,7 +546,7 @@ class CreateTable(_CreateDropBase):
         self.include_foreign_key_constraints = include_foreign_key_constraints
 
 
-class _DropView(_CreateDropBase):
+class _DropView(_DropBase):
     """Semi-public 'DROP VIEW' construct.
 
     Used by the test suite for dialect-agnostic drops of views.
@@ -669,7 +671,7 @@ class CreateColumn(BaseDDLElement):
         self.element = element
 
 
-class DropTable(_CreateDropBase):
+class DropTable(_DropBase):
     """Represent a DROP TABLE statement."""
 
     __visit_name__ = "drop_table"
@@ -689,19 +691,25 @@ class DropTable(_CreateDropBase):
         super().__init__(element, if_exists=if_exists)
 
 
-class CreateSequence(_CreateDropBase):
+class CreateSequence(_CreateBase):
     """Represent a CREATE SEQUENCE statement."""
 
     __visit_name__ = "create_sequence"
 
+    def __init__(self, element: Sequence, if_not_exists: bool = False):
+        super().__init__(element, if_not_exists=if_not_exists)
 
-class DropSequence(_CreateDropBase):
+
+class DropSequence(_DropBase):
     """Represent a DROP SEQUENCE statement."""
 
     __visit_name__ = "drop_sequence"
 
+    def __init__(self, element: Sequence, if_exists: bool = False):
+        super().__init__(element, if_exists=if_exists)
 
-class CreateIndex(_CreateDropBase):
+
+class CreateIndex(_CreateBase):
     """Represent a CREATE INDEX statement."""
 
     __visit_name__ = "create_index"
@@ -711,7 +719,6 @@ class CreateIndex(_CreateDropBase):
 
         :param element: a :class:`_schema.Index` that's the subject
          of the CREATE.
-        :param on: See the description for 'on' in :class:`.DDL`.
         :param if_not_exists: if True, an IF NOT EXISTS operator will be
          applied to the construct.
 
@@ -721,7 +728,7 @@ class CreateIndex(_CreateDropBase):
         super().__init__(element, if_not_exists=if_not_exists)
 
 
-class DropIndex(_CreateDropBase):
+class DropIndex(_DropBase):
     """Represent a DROP INDEX statement."""
 
     __visit_name__ = "drop_index"
@@ -731,7 +738,6 @@ class DropIndex(_CreateDropBase):
 
         :param element: a :class:`_schema.Index` that's the subject
          of the DROP.
-        :param on: See the description for 'on' in :class:`.DDL`.
         :param if_exists: if True, an IF EXISTS operator will be applied to the
          construct.
 
@@ -741,26 +747,26 @@ class DropIndex(_CreateDropBase):
         super().__init__(element, if_exists=if_exists)
 
 
-class AddConstraint(_CreateDropBase):
+class AddConstraint(_CreateBase):
     """Represent an ALTER TABLE ADD CONSTRAINT statement."""
 
     __visit_name__ = "add_constraint"
 
-    def __init__(self, element, *args, **kw):
-        super().__init__(element, *args, **kw)
+    def __init__(self, element):
+        super().__init__(element)
         element._create_rule = util.portable_instancemethod(
             self._create_rule_disable
         )
 
 
-class DropConstraint(_CreateDropBase):
+class DropConstraint(_DropBase):
     """Represent an ALTER TABLE DROP CONSTRAINT statement."""
 
     __visit_name__ = "drop_constraint"
 
-    def __init__(self, element, cascade=False, **kw):
+    def __init__(self, element, cascade=False, if_exists=False, **kw):
         self.cascade = cascade
-        super().__init__(element, **kw)
+        super().__init__(element, if_exists=if_exists, **kw)
         element._create_rule = util.portable_instancemethod(
             self._create_rule_disable
         )

--- a/test/sql/test_constraints.py
+++ b/test/sql/test_constraints.py
@@ -765,6 +765,14 @@ class ConstraintCompilationTest(fixtures.TestBase, AssertsCompiledSQL):
         i = Index("xyz", t.c.x)
         self.assert_compile(schema.CreateIndex(i), "CREATE INDEX xyz ON t (x)")
 
+    def test_create_index_if_not_exists(self):
+        t = Table("t", MetaData(), Column("x", Integer))
+        i = Index("xyz", t.c.x)
+        self.assert_compile(
+            schema.CreateIndex(i, if_not_exists=True),
+            "CREATE INDEX IF NOT EXISTS xyz ON t (x)",
+        )
+
     def test_drop_index_plain_unattached(self):
         self.assert_compile(
             schema.DropIndex(Index(name="xyz")), "DROP INDEX xyz"
@@ -773,6 +781,12 @@ class ConstraintCompilationTest(fixtures.TestBase, AssertsCompiledSQL):
     def test_drop_index_plain(self):
         self.assert_compile(
             schema.DropIndex(Index(name="xyz")), "DROP INDEX xyz"
+        )
+
+    def test_drop_index_if_exists(self):
+        self.assert_compile(
+            schema.DropIndex(Index(name="xyz"), if_exists=True),
+            "DROP INDEX IF EXISTS xyz",
         )
 
     def test_create_index_schema(self):

--- a/test/sql/test_metadata.py
+++ b/test/sql/test_metadata.py
@@ -2621,7 +2621,15 @@ class SchemaTest(fixtures.TestBase, AssertsCompiledSQL):
             schema.CreateSchema("sa_schema"), "CREATE SCHEMA sa_schema"
         )
         self.assert_compile(
+            schema.CreateSchema("sa_schema", if_not_exists=True),
+            "CREATE SCHEMA IF NOT EXISTS sa_schema",
+        )
+        self.assert_compile(
             schema.DropSchema("sa_schema"), "DROP SCHEMA sa_schema"
+        )
+        self.assert_compile(
+            schema.DropSchema("sa_schema", if_exists=True),
+            "DROP SCHEMA IF EXISTS sa_schema",
         )
         self.assert_compile(
             schema.DropSchema("sa_schema", cascade=True),

--- a/test/sql/test_sequences.py
+++ b/test/sql/test_sequences.py
@@ -93,7 +93,17 @@ class SequenceDDLTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         )
 
         self.assert_compile(
+            CreateSequence(Sequence("foo_seq"), if_not_exists=True),
+            "CREATE SEQUENCE IF NOT EXISTS foo_seq START WITH 1",
+        )
+
+        self.assert_compile(
             DropSequence(Sequence("foo_seq")), "DROP SEQUENCE foo_seq"
+        )
+
+        self.assert_compile(
+            DropSequence(Sequence("foo_seq"), if_exists=True),
+            "DROP SEQUENCE IF EXISTS foo_seq",
         )
 
 


### PR DESCRIPTION
Implement support in the sql compiler for the if_exists and
if_not_exists flags where they are supported by sql and remove the flags
from ddl statements where they are not, so that the generated sql
matches expectations.
Fixes #7354

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
