### PR TITLE
Add __pow__ and __rpow__ to operators.py

### DIFF
--- a/lib/sqlalchemy/sql/operators.py
+++ b/lib/sqlalchemy/sql/operators.py
@@ -30,6 +30,7 @@ from operator import mul as _uncast_mul
 from operator import ne as _uncast_ne
 from operator import neg as _uncast_neg
 from operator import or_ as _uncast_or_
+from operator import pow as _uncast_pow
 from operator import rshift as _uncast_rshift
 from operator import sub as _uncast_sub
 from operator import truediv as _uncast_truediv
@@ -91,6 +92,7 @@ mul = cast(OperatorType, _uncast_mul)
 ne = cast(OperatorType, _uncast_ne)
 neg = cast(OperatorType, _uncast_neg)
 or_ = cast(OperatorType, _uncast_or_)
+pow = cast(OperatorType, _uncast_pow)
 rshift = cast(OperatorType, _uncast_rshift)
 sub = cast(OperatorType, _uncast_sub)
 truediv = cast(OperatorType, _uncast_truediv)
@@ -1705,6 +1707,20 @@ class ColumnOperators(Operators):
 
         """
         return self.reverse_operate(floordiv, other)
+
+        def __pow__(self, other) -> ColumnOperators:
+        """Implement the ``**`` operator.
+
+        In a column context, produces the clause ``pow(a, b)``
+        """
+        return self.operate(pow, other)
+
+    def __rpow__(self, other) -> ColumnOperators:
+        """Implement the ``**`` operator in reverse.
+
+        See :meth:`.ColumnOperators.__pow__`.
+
+        """
 
 
 _commutative: Set[Any] = {eq, ne, add, mul}


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
By adding __pow__ and __rpow__ to `sqlalchemy.sql.operators.py`, the Python `**` operator can be used on columns, similar to how other native python operators can, such as `+, *, /`. The addition of `__pow__` and `__rpow__` follow the same logic as the other operators.

### Description
<!-- Describe your changes in detail -->
Fixes [#8579](https://github.com/sqlalchemy/sqlalchemy/issues/8579)

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
