### PR TITLE
Fix missing column name in 1.x `IS NULL` example

### DIFF
--- a/doc/build/core/tutorial.rst
+++ b/doc/build/core/tutorial.rst
@@ -805,7 +805,7 @@ objects is at :class:`.ColumnOperators`.
 
 * :meth:`IS NULL <.ColumnOperators.is_>`::
 
-    statement.where(users.c. == None)
+    statement.where(users.c.name == None)
 
     # alternatively, if pep8/linters are a concern
     statement.where(users.c.name.is_(None))


### PR DESCRIPTION
### Description

The `IS NULL` example in "SQL Expression Language Tutorial (1.x API)" is missing the column name that is present in the surrounding examples, so I added it.

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
