### PR TITLE
fix instances of objects as instances of classes

### DIFF
--- a/doc/build/orm/quickstart.rst
+++ b/doc/build/orm/quickstart.rst
@@ -181,7 +181,7 @@ Create Objects and Persist
 ---------------------------
 
 We are now ready to insert data in the database.  We accomplish this by
-creating instances of ``User`` and ``Address`` objects, which have
+creating instances of ``User`` and ``Address`` classes, which have
 an ``__init__()`` method already as established automatically by the
 declarative mapping process.  We then pass them
 to the database using an object called a :ref:`Session <tutorial_executing_orm_session>`,


### PR DESCRIPTION
## A documentation/typographical error fix

### Description
document mentions `creating instances of "User" and "Address" objects` which is a mistake as we create instances or objects from classes.

This pull request is:

- [x] A documentation/typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.