### PR TITLE
Add handle `nullable=Flase` case to mypy extension

### DIFF
--- a/lib/sqlalchemy/ext/mypy/infer.py
+++ b/lib/sqlalchemy/ext/mypy/infer.py
@@ -7,6 +7,8 @@
 
 from __future__ import annotations
 
+from contextlib import suppress
+
 from typing import Optional
 from typing import Sequence
 
@@ -450,7 +452,9 @@ def _infer_type_from_decl_column(
         else:
             # x = Column(..., nullable=Flase, ...)
             with suppress(ValueError):
-                nullable_idx = right_hand_expression.arg_names.index("nullable")
+                nullable_idx = (
+                    right_hand_expression.arg_names.index("nullable")
+                )
                 expr = right_hand_expression.args[nullable_idx]
 
                 if expr.name == "False":

--- a/lib/sqlalchemy/ext/mypy/infer.py
+++ b/lib/sqlalchemy/ext/mypy/infer.py
@@ -448,6 +448,14 @@ def _infer_type_from_decl_column(
             )
 
         else:
+            # x = Column(..., nullable=Flase, ...)
+            with suppress(ValueError):
+                nullable_idx = right_hand_expression.arg_names.index("nullable")
+                expr = right_hand_expression.args[nullable_idx]
+
+                if expr.name == "False":
+                    return python_type_for_type
+
             return UnionType([python_type_for_type, NoneType()])
     else:
         # it's not TypeEngine, it's typically implicitly typed

--- a/lib/sqlalchemy/ext/mypy/infer.py
+++ b/lib/sqlalchemy/ext/mypy/infer.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 from contextlib import suppress
-
 from typing import Optional
 from typing import Sequence
 
@@ -452,8 +451,8 @@ def _infer_type_from_decl_column(
         else:
             # x = Column(..., nullable=Flase, ...)
             with suppress(ValueError):
-                nullable_idx = (
-                    right_hand_expression.arg_names.index("nullable")
+                nullable_idx = right_hand_expression.arg_names.index(
+                    "nullable"
                 )
                 expr = right_hand_expression.args[nullable_idx]
 

--- a/test/ext/mypy/plugin_files/ensure_descriptor_type_fully_inferred.py
+++ b/test/ext/mypy/plugin_files/ensure_descriptor_type_fully_inferred.py
@@ -12,9 +12,11 @@ class User:
 
     id = Column(Integer(), primary_key=True)
     name = Column(String, nullable=False)
+    middle_name = Column(String, nullable=True)
 
 
 u1 = User()
 
+v: str = u1.name
 # EXPECTED_MYPY: Incompatible types in assignment (expression has type "Optional[str]", variable has type "str")  # noqa: E501
-p: str = u1.name
+p: str = u1.middle_name


### PR DESCRIPTION
### Description
If column has nullable with the meaning of false then type should be without None variant.

