### PR TITLE
Fixed an invalid syntax in an except statement

### DIFF
--- a/doc/build/core/pooling.rst
+++ b/doc/build/core/pooling.rst
@@ -319,7 +319,7 @@ illustrated by the code example below::
         # suppose the database has been restarted.
         c.execute(text("SELECT * FROM table"))
         c.close()
-    except exc.DBAPIError, e:
+    except exc.DBAPIError as e:
         # an exception is raised, Connection is invalidated.
         if e.connection_invalidated:
             print("Connection was invalidated!")


### PR DESCRIPTION
### Description

As the title suggests, I have fixed an invalid syntax in the docs for an `except` statement while reading the unusual.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
