### PR TITLE
Correct typo in async postgresql uri

### DIFF
--- a/lib/sqlalchemy/ext/asyncio/session.py
+++ b/lib/sqlalchemy/ext/asyncio/session.py
@@ -1408,7 +1408,7 @@ class async_sessionmaker(Generic[_AS]):
         async def main():
             # an AsyncEngine, which the AsyncSession will use for connection
             # resources
-            engine = create_async_engine('postgresql+asycncpg://scott:tiger@localhost/')
+            engine = create_async_engine('postgresql+asyncpg://scott:tiger@localhost/')
 
             AsyncSession = async_sessionmaker(engine)
 


### PR DESCRIPTION
### Description
Just a small typo to correct

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
