### PR TITLE
add partial index predicate to SQLiteDialect.get_indexes() result

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2684,11 +2684,21 @@ class SQLiteDialect(default.DefaultDialect):
                     "AND type = 'index'" % {"schema": schema_expr}
                 )
                 rs = connection.exec_driver_sql(s, (row[1],))
-                index_sql = rs.scalar()
-                predicate = partial_pred_re.search(index_sql).group(1)
-                indexes[-1]["dialect_options"]["sqlite_where"] = text(
-                    predicate
-                )
+                try:
+                    # in theory the code below shouldn't happen because
+                    # we know this is a partial index, so the definition
+                    # sql should be there and match the regex
+                    index_sql = rs.scalar()
+                    predicate = partial_pred_re.search(index_sql).group(1)
+                    indexes[-1]["dialect_options"]["sqlite_where"] = text(
+                        predicate
+                    )
+                except Exception:
+                    util.warn(
+                        "Failed to look up filter predicate of "
+                        "partial index %s" % row[1]
+                    )
+                    indexes.pop()
 
         # loop thru unique indexes to get the column names.
         for idx in list(indexes):

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2644,11 +2644,12 @@ class SQLiteDialect(default.DefaultDialect):
         )
         indexes = []
 
-        # regular expression to extract the filter predicate of a partial index.
-        # this could fail to extract the predicate correctly on indexes created like
+        # regular expression to extract the filter predicate of a partial
+        # index. this could fail to extract the predicate correctly on
+        # indexes created like
         #   CREATE INDEX i ON t (col || ') where') WHERE col <> ''
-        # but as this function does not support expression-based indexes this case
-        # does not occur.
+        # but as this function does not support expression-based indexes
+        # this case does not occur.
         partial_pred_re = re.compile(r"\)\s+where\s+(.+)", re.IGNORECASE)
 
         if schema:

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2651,7 +2651,11 @@ class SQLiteDialect(default.DefaultDialect):
                 "sqlite_autoindex"
             ):
                 continue
-            indexes.append(dict(name=row[1], column_names=[], unique=row[2]))
+            indexes.append(
+                dict(
+                    name=row[1], column_names=[], unique=row[2], partial=row[4]
+                )
+            )
 
         # loop thru unique indexes to get the column names.
         for idx in list(indexes):

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -893,6 +893,7 @@ from .json import JSONPathType
 from ... import exc
 from ... import schema as sa_schema
 from ... import sql
+from ... import text
 from ... import types as sqltypes
 from ... import util
 from ...engine import default
@@ -2684,7 +2685,9 @@ class SQLiteDialect(default.DefaultDialect):
                 rs = connection.exec_driver_sql(s, (row[1],))
                 index_sql = rs.scalar()
                 predicate = partial_pred_re.search(index_sql).group(1)
-                indexes[-1]["dialect_options"]["sqlite_where"] = predicate
+                indexes[-1]["dialect_options"]["sqlite_where"] = text(
+                    predicate
+                )
 
         # loop thru unique indexes to get the column names.
         for idx in list(indexes):

--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -2393,7 +2393,12 @@ class ComponentReflectionTestExtra(ComparesIndexes, fixtures.TestBase):
         insp = inspect(connection)
 
         expected = [
-            {"name": "t_idx_2", "column_names": ["x"], "unique": False}
+            {
+                "name": "t_idx_2",
+                "column_names": ["x"],
+                "unique": False,
+                "dialect_options": {},
+            }
         ]
 
         def completeIndex(entry):

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -2310,7 +2310,8 @@ class ConstraintReflectionTest(fixtures.TestBase):
                 "create table foo_with_partial_index (x integer, y integer)"
             )
             conn.exec_driver_sql(
-                "create unique index ix_partial on foo_with_partial_index (x) where y > 10"
+                "create unique index ix_partial on "
+                "foo_with_partial_index (x) where y > 10"
             )
 
             inspector = inspect(conn)

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -2313,6 +2313,15 @@ class ConstraintReflectionTest(fixtures.TestBase):
                 "create unique index ix_partial on "
                 "foo_with_partial_index (x) where y > 10"
             )
+            conn.exec_driver_sql(
+                "create unique index ix_no_partial on "
+                "foo_with_partial_index (x)"
+            )
+            conn.exec_driver_sql(
+                "create unique index ix_partial2 on "
+                "foo_with_partial_index (x, y) where "
+                "y = 10 or abs(x) < 5"
+            )
 
             inspector = inspect(conn)
             indexes = inspector.get_indexes("foo_with_partial_index")
@@ -2321,14 +2330,30 @@ class ConstraintReflectionTest(fixtures.TestBase):
                 [
                     {
                         "unique": 1,
+                        "name": "ix_no_partial",
+                        "column_names": ["x"],
+                        "dialect_options": {},
+                    },
+                    {
+                        "unique": 1,
                         "name": "ix_partial",
                         "column_names": ["x"],
                         "dialect_options": {"sqlite_where": ANY},
-                    }
+                    },
+                    {
+                        "unique": 1,
+                        "name": "ix_partial2",
+                        "column_names": ["x", "y"],
+                        "dialect_options": {"sqlite_where": ANY},
+                    },
                 ],
             )
             assert (
-                indexes[0]["dialect_options"]["sqlite_where"].text == "y > 10"
+                indexes[1]["dialect_options"]["sqlite_where"].text == "y > 10"
+            )
+            assert (
+                indexes[2]["dialect_options"]["sqlite_where"].text
+                == "y = 10 or abs(x) < 5"
             )
 
     def test_unique_constraint_named(self):

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -2282,7 +2282,7 @@ class ConstraintReflectionTest(fixtures.TestBase):
                     "unique": 1,
                     "name": "sqlite_autoindex_o_1",
                     "column_names": ["foo"],
-                    "partial": False,
+                    "dialect_options": {},
                 }
             ],
         )
@@ -2298,7 +2298,7 @@ class ConstraintReflectionTest(fixtures.TestBase):
                     "unique": 0,
                     "name": "ix_main_l_bar",
                     "column_names": ["bar"],
-                    "partial": False,
+                    "dialect_options": {},
                 }
             ],
         )
@@ -2323,13 +2323,13 @@ class ConstraintReflectionTest(fixtures.TestBase):
                         "unique": 1,
                         "name": "ix_no_partial",
                         "column_names": ["x"],
-                        "partial": False,
+                        "dialect_options": {},
                     },
                     {
                         "unique": 1,
                         "name": "ix_partial",
                         "column_names": ["x"],
-                        "partial": True,
+                        "dialect_options": {"sqlite_where": "y > 10"},
                     },
                 ],
             )

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -4,7 +4,6 @@
 import datetime
 import json
 import os
-from unittest.mock import ANY
 
 from sqlalchemy import and_
 from sqlalchemy import bindparam
@@ -2338,13 +2337,13 @@ class ConstraintReflectionTest(fixtures.TestBase):
                         "unique": 1,
                         "name": "ix_partial",
                         "column_names": ["x"],
-                        "dialect_options": {"sqlite_where": ANY},
+                        "dialect_options": {"sqlite_where": mock.ANY},
                     },
                     {
                         "unique": 1,
                         "name": "ix_partial2",
                         "column_names": ["x", "y"],
-                        "dialect_options": {"sqlite_where": ANY},
+                        "dialect_options": {"sqlite_where": mock.ANY},
                     },
                 ],
             )


### PR DESCRIPTION
This fixes #8804 by populating the `dialect_options`'s `sqlite_where` field inside `SQLiteDialect.get_indexes()` for an index where the `index_list()` pragma indicates that it is a partial index.

### Description
For an index where the fifth column of the corresponding row in the `index_list()` return value is true (see https://www.sqlite.org/pragma.html#pragma_index_list), we get the exact SQL used to create that index from the `sqlite_master` table and look for the `WHERE` keyword, then use the string after that as the `sqlite_where` predicate.

Remark: I use a simple regular expression scanning for the string `)\s+where\s+` (case-insensitive) to find the predicate. As written in a comment in the code, this can easily fail if the definition of the index contains a matching string such as
```sql
CREATE INDEX i ON t (col || ') where') WHERE col <> ''         -- case 1
CREATE INDEX i ON t (col)              WHERE col <> ') where'  -- case 2
```
but case 1 can be neglected because `get_indexes()` currently does not support expression-based indexes, and case 2 can be neglected because the regex finds the first match.

@CaselIT suggested in https://github.com/sqlalchemy/sqlalchemy/issues/8804#issuecomment-1314899834 to attack expression-based indexes as well, but to be honest I am not sure what is a good way to parse the `CREATE INDEX` statement with reasonable effort in that case, so I didn't work on it. (Is there a parser somewhere in the codebase already?)

I have verified that in my local environment, the case I reported in https://github.com/sqlalchemy/alembic/issues/1112#issue-1439662864 works well, so the partial index is kept across migrations and this PR also fixes https://github.com/sqlalchemy/alembic/issues/1112.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
