### PR TITLE
[sqlite] Fix reflection of constraints in attached schemas

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2487,7 +2487,7 @@ class SQLiteDialect(default.DefaultDialect):
         # loop thru unique indexes to get the column names.
         for idx in list(indexes):
             pragma_index = self._get_table_pragma(
-                connection, "index_info", idx["name"]
+                connection, "index_info", idx["name"], schema=schema
             )
 
             for row in pragma_index:

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -827,7 +827,7 @@ class AttachedDBTest(fixtures.TestBase):
         Table(
             "another_created",
             meta,
-            Column("bat", Integer),
+            Column("bat", Integer, unique=True),
             Column("hoho", String),
             schema="test_schema",
         )
@@ -907,6 +907,28 @@ class AttachedDBTest(fixtures.TestBase):
         eq_(
             set(insp.get_table_names("test_schema")),
             {"created", "another_created"},
+        )
+
+    def test_unique_constraints(self):
+        self._fixture()
+        insp = inspect(self.conn)
+        eq_(
+            [
+                d["column_names"]
+                for d in insp.get_unique_constraints(
+                    "created", schema="test_schema"
+                )
+            ],
+            [],
+        )
+        eq_(
+            [
+                d["column_names"]
+                for d in insp.get_unique_constraints(
+                    "another_created", schema="test_schema"
+                )
+            ],
+            [["bat"]],
         )
 
     def test_schema_names(self):


### PR DESCRIPTION
### Description

The `index_info` pragma wasn't specifying the schema, which resulted in column names not being detected for unique constraints in other schemas.

Fixes: #8866

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
