### PR TITLE
Rectify PG Range.__bool__, inverting previous logic

### DIFF
--- a/doc/build/changelog/unreleased_20/8765.rst
+++ b/doc/build/changelog/unreleased_20/8765.rst
@@ -6,5 +6,11 @@
     ``adjacent_to()``, ``difference()``, ``union()``, etc., were added to the
     PG-specific range objects, bringing them in par with the standard
     operators implemented by the underlying
-    :attr:`_postgresql.AbstractRange.comparator_factory`. Pull request
-    courtesy Lele Gaifax.
+    :attr:`_postgresql.AbstractRange.comparator_factory`.
+
+    In addition, the ``__bool__()_`` method of the class has been corrected to
+    be consistent with the common Python *containers* behavior as well as how
+    other popular PostgreSQL drivers do: it now tells whether the range
+    instance is *not* empty, rather than the other way around.
+
+    Pull request courtesy Lele Gaifax.

--- a/lib/sqlalchemy/dialects/postgresql/ranges.py
+++ b/lib/sqlalchemy/dialects/postgresql/ranges.py
@@ -82,7 +82,7 @@ class Range(Generic[_T]):
             )
 
     def __bool__(self) -> bool:
-        return self.empty
+        return not self.empty
 
     def _contains_value(self, value: _T) -> bool:
         "Check whether this range contains the given `value`."

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -4410,6 +4410,10 @@ class _RangeComparisonFixtures(_RangeTests):
             f"{r1} != {r2}: got {r1 != r2}, expected {different}",
         )
 
+    def test_bool(self):
+        is_false(bool(Range(empty=True)))
+        is_true(bool(Range(1, 2)))
+
 
 class _RangeTypeRoundTrip(_RangeComparisonFixtures, fixtures.TablesTest):
     __requires__ = ("range_types",)


### PR DESCRIPTION
The boolness of the range was defined to be equal to its emptiness. As this has been identified as a typo rather than the intended, this inverts the logic, to match common Python behaviour as well as how other popular PG drivers do.
