### PR TITLE
Create a compiler hook to pick up custom objects in expressions

### DIFF
--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -3682,6 +3682,10 @@ _type_map_get = _type_map.get
 
 def _resolve_value_to_type(value: Any) -> TypeEngine[Any]:
     _result_type = _type_map_get(type(value), False)
+
+    if _result_type is False:
+        _result_type = getattr(value, "__sa_type_engine__", False)
+
     if _result_type is False:
         # use inspect() to detect SQLAlchemy built-in
         # objects.


### PR DESCRIPTION
This simply applies what has been suggested by Mike in issue #8884, and seems to work. I guess more work is needed, for example mentioning and/or documenting the new __sa_type_engine__ hook.
