### PR TITLE
Update rel_1_4 to support changes to GitHub Actions

### DIFF
--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -129,6 +129,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
+          - "ubuntu-20.04"
         python-version:
           # the versions are <python tag>-<abi tag> as specified in PEP 425.
           - cp27-cp27m
@@ -147,6 +148,26 @@ jobs:
             extra-requires: "mock"
           - python-version: "cp27-cp27mu"
             extra-requires: "mock"
+
+        exclude:
+          # ubuntu-latest does not have: py27, py36
+          - os: "ubuntu-latest"
+            python-version: cp27-cp27m
+          - os: "ubuntu-latest"
+            python-version: cp27-cp27mu
+          - os: "ubuntu-latest"
+            python-version: cp36-cp36m
+          # ubuntu-20.04 does not need to test what ubuntu-latest supports
+          - os: "ubuntu-20.04"
+            python-version: cp37-cp37m
+          - os: "ubuntu-20.04"
+            python-version: cp38-cp38
+          - os: "ubuntu-20.04"
+            python-version: cp39-cp39
+          - os: "ubuntu-20.04"
+            python-version: cp310-cp310
+          - os: "ubuntu-20.04"
+            python-version: cp311-cp311
 
       fail-fast: false
 
@@ -287,6 +308,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
+          - "ubuntu-20.04"
         python-version:
           # the versions are <python tag>-<abi tag> as specified in PEP 425.
           - cp36-cp36m
@@ -295,6 +317,21 @@ jobs:
           - cp39-cp39
           - cp310-cp310
           - cp311-cp311
+        exclude:
+          # ubuntu-latest does not have: py27, py36
+          - os: "ubuntu-latest"
+            python-version: cp36-cp36m
+          # ubuntu-20.04 does not need to test what ubuntu-latest supports
+          - os: "ubuntu-20.04"
+            python-version: cp37-cp37m
+          - os: "ubuntu-20.04"
+            python-version: cp38-cp38
+          - os: "ubuntu-20.04"
+            python-version: cp39-cp39
+          - os: "ubuntu-20.04"
+            python-version: cp310-cp310
+          - os: "ubuntu-20.04"
+            python-version: cp311-cp311
 
       fail-fast: false
 

--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -123,175 +123,22 @@ jobs:
           twine upload --skip-existing dist/*
 
   make-wheel-linux:
-    # any changes should be duplicated in `make-wheel-linux-legacy`
     name: ${{ matrix.python-version }}-${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os:
           - "ubuntu-latest"
-        python-version:
-          # the versions are <python tag>-<abi tag> as specified in PEP 425.
-          - cp37-cp37m
-          - cp38-cp38
-          - cp39-cp39
-          - cp310-cp310
-          - cp311-cp311
-        architecture:
-          - x64
-
-        include:
-          - python-version: "cp27-cp27m"
-            extra-requires: "mock"
-          - python-version: "cp27-cp27mu"
-            extra-requires: "mock"
-
-      fail-fast: false
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Get python version
-        id: linux-py-version
-        env:
-          py_tag: ${{ matrix.python-version }}
-        # the command `echo "::set-output ...` is used to create an step output that can be used in following steps
-        # this is from https://github.community/t5/GitHub-Actions/Using-the-output-of-run-inside-of-if-condition/td-p/33920
-        run: |
-          version="`echo $py_tag | sed --regexp-extended 's/cp([0-9])([0-9]+)-.*/\1.\2/g'`"
-          version=$([[ $version = "3.11" ]] && echo 3.11.0-rc - 3.11 || echo $version )
-          echo $version
-          echo "::set-output name=python-version::$version"
-
-      - name: Remove tag_build from setup.cfg
-        # sqlalchemy has `tag_build` set to `dev` in setup.cfg. We need to remove it before creating the weel
-        # otherwise it gets tagged with `dev0`
-        shell: pwsh
-        # This is equivalent to the sed commands:
-        # `sed -i '/tag_build=dev/d' setup.cfg`
-        # `sed -i '/tag_build = dev/d' setup.cfg`
-
-        # `-replace` uses a regexp match
-        # alternative form: `(get-content setup.cfg) | foreach-object{$_ -replace "tag_build.=.dev",""} | set-content setup.cfg`
-        run: |
-          (cat setup.cfg) | %{$_ -replace "tag_build.?=.?dev",""} | set-content setup.cfg
-
-      - name: Create wheel for manylinux1 and manylinux2010 for py3
-        if: ${{ matrix.python-version != 'cp27-cp27m' && matrix.python-version != 'cp27-cp27mu' && matrix.python-version != 'cp311-cp311' }}
-        # this step uses the image provided by pypa here https://github.com/pypa/manylinux to generate the wheels on linux
-        # the action uses the image for manylinux2010 but can generate also a manylinux1 wheel
-        # change the tag of this image to change the image used
-        uses: RalfG/python-wheels-manylinux-build@v0.5.0-manylinux2010_x86_64
-        # this action generates 3 wheels in dist/. linux, manylinux1 and manylinux2010
-        with:
-          # python-versions is the output of the previous step and is in the form <python tag>-<abi tag>. Eg cp27-cp27mu
-          python-versions: ${{ matrix.python-version }}
-          build-requirements: "setuptools>=44 wheel>=0.34"
-          # Create the wheel using --no-use-pep517 since locally we have pyproject
-          # This flag should be removed once sqlalchemy supports pep517
-          # `--no-deps` is used to only generate the wheel for the current library. Redundant in sqlalchemy since it has no dependencies
-          pip-wheel-args: "-w ./dist --no-use-pep517 -v --no-deps"
-
-      - name: Create wheel for manylinux2014 for py3
-        if: ${{ matrix.python-version != 'cp27-cp27m' && matrix.python-version != 'cp27-cp27mu' }}
-        # this step uses the image provided by pypa here https://github.com/pypa/manylinux to generate the wheels on linux
-        # the action uses the image for manylinux2010 but can generate also a manylinux1 wheel
-        # change the tag of this image to change the image used
-        uses: RalfG/python-wheels-manylinux-build@v0.5.0-manylinux2014_x86_64
-        # this action generates 2 wheels in dist/. linux and manylinux2014
-        with:
-          # python-versions is the output of the previous step and is in the form <python tag>-<abi tag>. Eg cp27-cp27mu
-          python-versions: ${{ matrix.python-version }}
-          build-requirements: "setuptools>=44 wheel>=0.34"
-          # Create the wheel using --no-use-pep517 since locally we have pyproject
-          # This flag should be removed once sqlalchemy supports pep517
-          # `--no-deps` is used to only generate the wheel for the current library. Redundant in sqlalchemy since it has no dependencies
-          pip-wheel-args: "-w ./dist --no-use-pep517 -v --no-deps"
-
-      - name: Create wheel for manylinux py2
-        if: ${{ matrix.python-version == 'cp27-cp27m' || matrix.python-version == 'cp27-cp27mu' }}
-        # this step uses the image provided by pypa here https://github.com/pypa/manylinux to generate the wheels on linux
-        # the action uses the image for manylinux2010 but can generate also a manylinux1 wheel
-        # change the tag of this image to change the image used
-        uses: RalfG/python-wheels-manylinux-build@v0.5.0-manylinux1_x86_64
-        # this action generates 2 wheels in dist/. linux and manylinux1
-        with:
-          # python-versions is the output of the previous step and is in the form <python tag>-<abi tag>. Eg cp27-cp27mu
-          python-versions: ${{ matrix.python-version }}
-          build-requirements: "setuptools>=44 wheel>=0.34"
-          # Create the wheel using --no-use-pep517 since locally we have pyproject
-          # This flag should be removed once sqlalchemy supports pep517
-          # `--no-deps` is used to only generate the wheel for the current library. Redundant in sqlalchemy since it has no dependencies
-          pip-wheel-args: "-w ./dist --no-use-pep517 -v --no-deps"
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ steps.linux-py-version.outputs.python-version }}
-          architecture: ${{ matrix.architecture }}
-
-      - name: Check created wheel
-        # check that the wheel is compatible with the current installation.
-        # If it is then does:
-        # - install the created wheel without using the pypi index
-        # - check the c extension
-        # - runs the tests
-        run: |
-          pip install 'packaging>=20.4'
-          if python .github/workflows/scripts/can_install.py "${{ matrix.python-version }}"
-          then
-            pip install greenlet "importlib-metadata;python_version<'3.8'"
-            pip install -f dist --no-index sqlalchemy
-            python -c 'from sqlalchemy.util import has_compiled_ext; assert has_compiled_ext()'
-            pip install pytest pytest-xdist ${{ matrix.extra-requires }}
-            pytest -n2 -q test --nomemory --notimingintensive
-          else
-            echo Not compatible. Skipping install.
-          fi
-
-      - name: Upload wheels to release
-        # upload the generated wheels to the github release
-        uses: sqlalchemyorg/upload-release-assets@sa
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          files: 'dist/*manylinux*'
-
-      - name: Set up Python for twine
-        # twine on py2 is very old and is no longer updated, so we change to python 3.8 before upload
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.8"
-
-      - name: Publish wheel
-        # the action https://github.com/marketplace/actions/pypi-publish runs only on linux and we cannot specify
-        # additional options
-        # We upload both manylinux1 and manylinux2010 wheels. pip will download the appropriate one according to the system.
-        # manylinux1 is an older format and is now not very used since many environments can use manylinux2010
-        # currently (April 2020) manylinux2014 is still wip, so we do not generate it.
-        env:
-          TWINE_USERNAME: __token__
-          # replace TWINE_PASSWORD with token for real pypi
-          # TWINE_PASSWORD: ${{ secrets.test_pypi_token }}
-          TWINE_PASSWORD: ${{ secrets.pypi_token }}
-        run: |
-          pip install -U twine
-          twine upload --skip-existing dist/*manylinux*
-
-  make-wheel-linux-legacy:
-    # this is identical to `make-wheel-linux`, but pins ubuntu to 20.04
-    # ubuntu-20.04 is necessary to run: py27, py36
-    name: ${{ matrix.python-version }}-${{ matrix.architecture }}-${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - "ubuntu-20.04"
         python-version:
           # the versions are <python tag>-<abi tag> as specified in PEP 425.
           - cp27-cp27m
           - cp27-cp27mu
           - cp36-cp36m
+          - cp37-cp37m
+          - cp38-cp38
+          - cp39-cp39
+          - cp310-cp310
+          - cp311-cp311
         architecture:
           - x64
 
@@ -433,9 +280,7 @@ jobs:
           pip install -U twine
           twine upload --skip-existing dist/*manylinux*
 
-
   make-wheel-linux-arm64:
-    # any changes should be duplicated in `make-wheel-linux-arm64-legacy`
     name: ${{ matrix.python-version }}-arm64-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -444,104 +289,12 @@ jobs:
           - "ubuntu-latest"
         python-version:
           # the versions are <python tag>-<abi tag> as specified in PEP 425.
+          - cp36-cp36m
           - cp37-cp37m
           - cp38-cp38
           - cp39-cp39
           - cp310-cp310
           - cp311-cp311
-
-      fail-fast: false
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Remove tag_build from setup.cfg
-        # sqlalchemy has `tag_build` set to `dev` in setup.cfg. We need to remove it before creating the weel
-        # otherwise it gets tagged with `dev0`
-        shell: pwsh
-        # This is equivalent to the sed commands:
-        # `sed -i '/tag_build=dev/d' setup.cfg`
-        # `sed -i '/tag_build = dev/d' setup.cfg`
-
-        # `-replace` uses a regexp match
-        # alternative form: `(get-content setup.cfg) | foreach-object{$_ -replace "tag_build.=.dev",""} | set-content setup.cfg`
-        run: |
-          (cat setup.cfg) | %{$_ -replace "tag_build.?=.?dev",""} | set-content setup.cfg
-
-      - name: Set up emulation
-        run: |
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-
-      - name: Create wheel for manylinux2014
-        # this step uses the image provided by pypa here https://github.com/pypa/manylinux to generate the wheels on linux
-        # the action uses the image for manylinux2014 but can generate also a manylinux1 wheel
-        # change the tag of this image to change the image used
-        uses: RalfG/python-wheels-manylinux-build@v0.5.0-manylinux2014_aarch64
-        # this action generates 2 wheels in dist/. linux and manylinux2014
-        with:
-          # python-versions is the output of the previous step and is in the form <python tag>-<abi tag>. Eg cp37-cp37mu
-          python-versions: ${{ matrix.python-version }}
-          build-requirements: "setuptools>=44 wheel>=0.34"
-          # Create the wheel using --no-use-pep517 since locally we have pyproject
-          # This flag should be removed once sqlalchemy supports pep517
-          # `--no-deps` is used to only generate the wheel for the current library. Redundant in sqlalchemy since it has no dependencies
-          pip-wheel-args: "-w ./dist --no-use-pep517 -v --no-deps"
-
-      - name: Check created wheel
-        # check that the wheel is compatible with the current installation.
-        # - runs the tests
-        uses: docker://quay.io/pypa/manylinux2014_aarch64
-        with:
-          args: |
-            bash -c "
-            export PATH=/opt/python/${{ matrix.python-version }}/bin:$PATH &&
-            python --version &&
-            pip install greenlet \"importlib-metadata;python_version<'3.8'\" &&
-            pip install -f dist --no-index sqlalchemy &&
-            python -c 'from sqlalchemy.util import has_compiled_ext; assert has_compiled_ext()' &&
-            pip install pytest pytest-xdist ${{ matrix.extra-requires }} &&
-            pytest -n2 -q test --nomemory --notimingintensive"
-
-      - name: Upload wheels to release
-        # upload the generated wheels to the github release
-        uses: sqlalchemyorg/upload-release-assets@sa
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          files: 'dist/*manylinux*'
-
-      - name: Set up Python for twine
-        # Setup python after creating the wheel, otherwise LD_LIBRARY_PATH gets set and it will break wheel generation
-        # twine on py2 is very old and is no longer updated, so we change to python 3.8 before upload
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.8"
-
-      - name: Publish wheel
-        # the action https://github.com/marketplace/actions/pypi-publish runs only on linux and we cannot specify
-        # additional options
-        # We upload manylinux2014 arm64 wheels. pip will download the appropriate one according to the system.
-        env:
-          TWINE_USERNAME: __token__
-          # replace TWINE_PASSWORD with token for real pypi
-          # TWINE_PASSWORD: ${{ secrets.test_pypi_token }}
-          TWINE_PASSWORD: ${{ secrets.pypi_token }}
-        run: |
-          pip install -U twine
-          twine upload --skip-existing dist/*manylinux*
-
-  make-wheel-linux-arm64-legacy:
-    # this is identical to `make-wheel-linux-arm64`, but pins ubuntu to 20.04
-    # ubuntu-20.04 is necessary to run: py27, py36
-    name: ${{ matrix.python-version }}-arm64-${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - "ubuntu-20.04"
-        python-version:
-          # the versions are <python tag>-<abi tag> as specified in PEP 425.
-          - cp36-cp36m
 
       fail-fast: false
 

--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -15,7 +15,7 @@ jobs:
   # two jobs are defined make-wheel-win-osx and make-wheel-linux.
   # they do the the same steps, but linux wheels need to be build to target manylinux
   make-wheel-win-osx:
-    name: ${{ matrix.python-version }}-${{ matrix.architecture }}-${{ matrix.os }}
+    name: wheel-win-osx-${{ matrix.python-version }}-${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -123,7 +123,7 @@ jobs:
           twine upload --skip-existing dist/*
 
   make-wheel-linux:
-    name: ${{ matrix.python-version }}-${{ matrix.architecture }}-${{ matrix.os }}
+    name: wheel-linux-${{ matrix.python-version }}-${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -302,7 +302,7 @@ jobs:
           twine upload --skip-existing dist/*manylinux*
 
   make-wheel-linux-arm64:
-    name: ${{ matrix.python-version }}-arm64-${{ matrix.os }}
+    name: wheel-linux-arm64-${{ matrix.python-version }}-arm64-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/run-on-pr.yaml
+++ b/.github/workflows/run-on-pr.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   run-test-amd64:
-    name: ${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
+    name: test-amd64-${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       # run this job using this matrix, excluding some combinations below.

--- a/.github/workflows/run-on-pr.yaml
+++ b/.github/workflows/run-on-pr.yaml
@@ -17,7 +17,6 @@ permissions:
 
 jobs:
   run-test-amd64:
-    # any changes to this job should be duplicated in `run-mypy-legacy`
     name: ${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -26,47 +25,8 @@ jobs:
         os:
           - "ubuntu-latest"
         python-version:
-          - "3.10"
-        build-type:
-          - "cext"
-          - "nocext"
-        architecture:
-          - x64
-      # abort all jobs as soon as one fails
-      fail-fast: true
-
-    # steps to run in each job. Some are github actions, others run shell commands
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Set up python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.architecture }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade tox setuptools
-          pip list
-
-      - name: Run tests
-        run: tox -e github-${{ matrix.build-type }} -- -q --nomemory --notimingintensive ${{ matrix.pytest-args }}
-
-  run-test-amd64-legacy:
-    # this is identical to `run-test-amd64`, but pins ubuntu to 20.04
-    # ubuntu-20.04 is necessary to run: py27, py36
-    name: ${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      # run this job using this matrix, excluding some combinations below.
-      matrix:
-        os:
-          - "ubuntu-20.04"
-        python-version:
           - "2.7"
+          - "3.10"
         build-type:
           - "cext"
           - "nocext"

--- a/.github/workflows/run-on-pr.yaml
+++ b/.github/workflows/run-on-pr.yaml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-latest"
+          - "ubuntu-20.04"
         python-version:
           - "2.7"
           - "3.10"
@@ -32,6 +33,14 @@ jobs:
           - "nocext"
         architecture:
           - x64
+        exclude:
+          # ubuntu-latest does not have: py27, py36
+          - os: "ubuntu-latest"
+            python-version: "2.7"
+          # ubuntu-20.04 does not need to test what ubuntu-latest supports
+          - os: "ubuntu-20.04"
+            python-version: "3.10"
+
       # abort all jobs as soon as one fails
       fail-fast: true
 

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   run-test:
-    name: ${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
+    name: test-${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       # run this job using this matrix, excluding some combinations below.
@@ -100,7 +100,7 @@ jobs:
         run: tox -e github-${{ matrix.build-type }} -- -q --nomemory --notimingintensive ${{ matrix.pytest-args }}
 
   run-test-arm64:
-    name: ${{ matrix.python-version }}-${{ matrix.build-type }}-arm64-ubuntu-latest
+    name: arm64-${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -194,8 +194,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: "ubuntu-latest"
-        python-version: "3.10"
+        os:
+          - "ubuntu-latest"
+        python-version:
+          - "3.10"
 
       fail-fast: false
 

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -155,7 +155,7 @@ jobs:
             "
 
   run-mypy:
-    name: mypy-${{ matrix.python-version }}
+    name: mypy-${{ matrix.python-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       # run this job using this matrix, excluding some combinations below.
@@ -201,7 +201,7 @@ jobs:
         run: tox -e mypy ${{ matrix.pytest-args }}
 
   run-pep8:
-    name: pep8-${{ matrix.python-version }}
+    name: pep8-${{ matrix.python-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       # run this job using this matrix, excluding some combinations below.

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -27,6 +27,8 @@ jobs:
       # run this job using this matrix, excluding some combinations below.
       matrix:
         os:
+          - "ubuntu-latest"
+          - "ubuntu-20.04"
           - "windows-latest"
           - "macos-latest"
         python-version:
@@ -68,6 +70,9 @@ jobs:
           # linux and osx do not have x86 python
           - os: "ubuntu-latest"
             architecture: x86
+            python-version:
+              - "2.7"
+              - "3.6"
           - os: "macos-latest"
             architecture: x86
           # pypy does not have cext
@@ -104,6 +109,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os:
+          - "ubuntu-latest"
+          - "ubuntu-20.04"
         python-version:
           - cp36-cp36m
           - cp37-cp37m
@@ -115,8 +123,11 @@ jobs:
           - "cext"
           - "nocext"
         include:
-          - os: "ubuntu-latest"
           - os: "ubuntu-20.04"
+            python-version:
+              - cp36-cp36m
+        exclude:
+          - os: "ubuntu-latest"
             python-version:
               - cp36-cp36m
 
@@ -149,6 +160,9 @@ jobs:
     strategy:
       # run this job using this matrix, excluding some combinations below.
       matrix:
+        os:
+          - "ubuntu-latest"
+          - "ubuntu-20.04"
         python-version:
           - "3.6"
           - "3.7"
@@ -157,8 +171,11 @@ jobs:
           - "3.10"
           - "3.11.0-rc - 3.11"
         include:
-          - os: "ubuntu-latest"
           - os: "ubuntu-20.04"
+            python-version:
+              - "3.6"
+        exclude:
+          - os: "ubuntu-latest"
             python-version:
               - "3.6"
       fail-fast: false

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -27,7 +27,6 @@ jobs:
       # run this job using this matrix, excluding some combinations below.
       matrix:
         os:
-          - "ubuntu-latest"
           - "windows-latest"
           - "macos-latest"
         python-version:
@@ -55,6 +54,11 @@ jobs:
           # add aiosqlite on linux
           - os: "ubuntu-latest"
             pytest-args: "--dbdriver pysqlite --dbdriver aiosqlite"
+          - os: "ubuntu-20.04"
+            pytest-args: "--dbdriver pysqlite --dbdriver aiosqlite"
+            python-version:
+              - "2.7"
+              - "3.6"
 
         exclude:
           # c-extensions fail to build on windows for python 2.7
@@ -97,7 +101,7 @@ jobs:
 
   run-test-arm64:
     name: ${{ matrix.python-version }}-${{ matrix.build-type }}-arm64-ubuntu-latest
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version:
@@ -110,6 +114,11 @@ jobs:
         build-type:
           - "cext"
           - "nocext"
+        include:
+          - os: "ubuntu-latest"
+          - os: "ubuntu-20.04"
+            python-version:
+              - cp36-cp36m
 
       fail-fast: false
 
@@ -140,8 +149,6 @@ jobs:
     strategy:
       # run this job using this matrix, excluding some combinations below.
       matrix:
-        os:
-          - "ubuntu-latest"
         python-version:
           - "3.6"
           - "3.7"
@@ -149,6 +156,11 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11.0-rc - 3.11"
+        include:
+          - os: "ubuntu-latest"
+          - os: "ubuntu-20.04"
+            python-version:
+              - "3.6"
       fail-fast: false
 
     # steps to run in each job. Some are github actions, others run shell commands

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -58,9 +58,6 @@ jobs:
             pytest-args: "--dbdriver pysqlite --dbdriver aiosqlite"
           - os: "ubuntu-20.04"
             pytest-args: "--dbdriver pysqlite --dbdriver aiosqlite"
-            python-version:
-              - "2.7"
-              - "3.6"
 
         exclude:
           # c-extensions fail to build on windows for python 2.7
@@ -70,9 +67,11 @@ jobs:
           # linux and osx do not have x86 python
           - os: "ubuntu-latest"
             architecture: x86
-            python-version:
-              - "2.7"
-              - "3.6"
+          # ubuntu-latest does not have: py27, py36
+          - os: "ubuntu-latest"
+            python-version: "2.7"
+          - os: "ubuntu-latest"
+            python-version: "3.6"
           - os: "macos-latest"
             architecture: x86
           # pypy does not have cext
@@ -122,14 +121,9 @@ jobs:
         build-type:
           - "cext"
           - "nocext"
-        include:
-          - os: "ubuntu-20.04"
-            python-version:
-              - cp36-cp36m
         exclude:
           - os: "ubuntu-latest"
-            python-version:
-              - cp36-cp36m
+            python-version: cp36-cp36m
 
       fail-fast: false
 
@@ -170,14 +164,9 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11.0-rc - 3.11"
-        include:
-          - os: "ubuntu-20.04"
-            python-version:
-              - "3.6"
         exclude:
           - os: "ubuntu-latest"
-            python-version:
-              - "3.6"
+            python-version: "3.6"
       fail-fast: false
 
     # steps to run in each job. Some are github actions, others run shell commands
@@ -204,12 +193,9 @@ jobs:
     name: pep8-${{ matrix.python-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      # run this job using this matrix, excluding some combinations below.
       matrix:
-        os:
-          - "ubuntu-latest"
-        python-version:
-          - "3.10"
+        os: "ubuntu-latest"
+        python-version: "3.10"
 
       fail-fast: false
 

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -21,7 +21,6 @@ permissions:
 
 jobs:
   run-test:
-    # any changes to this job should be duplicated in `run-test-legacy`
     name: ${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -32,6 +31,8 @@ jobs:
           - "windows-latest"
           - "macos-latest"
         python-version:
+          - "2.7"
+          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
@@ -52,7 +53,7 @@ jobs:
           # - python-version: "pypy-3.9"
           #   pytest-args: "-k 'not test_autocommit_on and not test_turn_autocommit_off_via_default_iso_level and not test_autocommit_isolation_level'"
           # add aiosqlite on linux
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-latest"
             pytest-args: "--dbdriver pysqlite --dbdriver aiosqlite"
 
         exclude:
@@ -61,76 +62,7 @@ jobs:
             python-version: "2.7"
             build-type: "cext"
           # linux and osx do not have x86 python
-          - os: "ubuntu-20.04"
-            architecture: x86
-          - os: "macos-latest"
-            architecture: x86
-          # pypy does not have cext
-          # - python-version: "pypy-3.9"
-          #   build-type: "cext"
-          # - os: "windows-latest"
-          #   python-version: "pypy-3.9"
-          #   architecture: x86
-
-      fail-fast: false
-
-    # steps to run in each job. Some are github actions, others run shell commands
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Set up python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.architecture }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade tox setuptools
-          pip list
-
-      - name: Run tests
-        run: tox -e github-${{ matrix.build-type }} -- -q --nomemory --notimingintensive ${{ matrix.pytest-args }}
-
-  run-test-legacy:
-    # this is identical to `run-test`, but pins ubuntu to 20.04
-    # ubuntu-20.04 is necessary to run: py27, py36
-    name: ${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      # run this job using this matrix, excluding some combinations below.
-      matrix:
-        os:
-          - "ubuntu-20.04"
-          - "windows-latest"
-          - "macos-latest"
-        python-version:
-          - "2.7"
-          - "3.6"
-        build-type:
-          - "cext"
-          - "nocext"
-        architecture:
-          - x64
-          - x86
-
-        include:
-          # autocommit tests fail on the ci for some reason
-          # - python-version: "pypy-3.9"
-          #   pytest-args: "-k 'not test_autocommit_on and not test_turn_autocommit_off_via_default_iso_level and not test_autocommit_isolation_level'"
-          # add aiosqlite on linux
-          - os: "ubuntu-20.04"
-            pytest-args: "--dbdriver pysqlite --dbdriver aiosqlite"
-
-        exclude:
-          # c-extensions fail to build on windows for python 2.7
-          - os: "windows-latest"
-            python-version: "2.7"
-            build-type: "cext"
-          # linux and osx do not have x86 python
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-latest"
             architecture: x86
           - os: "macos-latest"
             architecture: x86
@@ -164,12 +96,12 @@ jobs:
         run: tox -e github-${{ matrix.build-type }} -- -q --nomemory --notimingintensive ${{ matrix.pytest-args }}
 
   run-test-arm64:
-    # any changes to this job should be duplicated in `run-test-arm64`
     name: ${{ matrix.python-version }}-${{ matrix.build-type }}-arm64-ubuntu-latest
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
+          - cp36-cp36m
           - cp37-cp37m
           - cp38-cp38
           - cp39-cp39
@@ -202,44 +134,7 @@ jobs:
             tox -e github-${{ matrix.build-type }} -- -q --nomemory --notimingintensive ${{ matrix.pytest-args }}
             "
 
-  run-test-arm64-legacy:
-    # this is identical to `run-test-arm64-legacy`, but pins ubuntu to 20.04
-    # ubuntu-20.04 is necessary to run: py27, py36
-    name: ${{ matrix.python-version }}-${{ matrix.build-type }}-arm64-ubuntu-20.04
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version:
-          - cp36-cp36m
-        build-type:
-          - "cext"
-          - "nocext"
-
-      fail-fast: false
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Set up emulation
-        run: |
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-
-      - name: Run tests
-        uses: docker://quay.io/pypa/manylinux2014_aarch64
-        with:
-          args: |
-            bash -c "
-            export PATH=/opt/python/${{ matrix.python-version }}/bin:$PATH &&
-            python --version &&
-            python -m pip install --upgrade pip &&
-            pip install --upgrade tox setuptools &&
-            pip list &&
-            tox -e github-${{ matrix.build-type }} -- -q --nomemory --notimingintensive ${{ matrix.pytest-args }}
-            "
-
   run-mypy:
-    # any changes to this job should be duplicated in `run-mypy-legacy`
     name: mypy-${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -248,45 +143,12 @@ jobs:
         os:
           - "ubuntu-latest"
         python-version:
+          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11.0-rc - 3.11"
-      fail-fast: false
-
-    # steps to run in each job. Some are github actions, others run shell commands
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Set up python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.architecture }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade tox setuptools
-          pip list
-
-      - name: Run tests
-        run: tox -e mypy ${{ matrix.pytest-args }}
-
-  run-mypy-legacy:
-    # this is identical to `run-mypy`, but pins ubuntu to 20.04
-    # ubuntu-20.04 is necessary to run: py27, py36
-    name: mypy-${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      # run this job using this matrix, excluding some combinations below.
-      matrix:
-        os:
-          - "ubuntu-20.04"
-        python-version:
-          - "3.6"
       fail-fast: false
 
     # steps to run in each job. Some are github actions, others run shell commands

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -67,6 +67,8 @@ jobs:
           # linux and osx do not have x86 python
           - os: "ubuntu-latest"
             architecture: x86
+          - os: "ubuntu-20.04"
+            architecture: x86
           - os: "macos-latest"
             architecture: x86
           # ubuntu-latest does not have: py27, py36

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -67,13 +67,24 @@ jobs:
           # linux and osx do not have x86 python
           - os: "ubuntu-latest"
             architecture: x86
+          - os: "macos-latest"
+            architecture: x86
           # ubuntu-latest does not have: py27, py36
           - os: "ubuntu-latest"
             python-version: "2.7"
           - os: "ubuntu-latest"
             python-version: "3.6"
-          - os: "macos-latest"
-            architecture: x86
+          # ubuntu-20.04 does not need to test what ubuntu-latest supports
+          - os: "ubuntu-20.04"
+            python-version: "3.7"
+          - os: "ubuntu-20.04"
+            python-version: "3.8"
+          - os: "ubuntu-20.04"
+            python-version: "3.9"
+          - os: "ubuntu-20.04"
+            python-version: "3.10"
+          - os: "ubuntu-20.04"
+            python-version: "3.11.0-rc - 3.11"
           # pypy does not have cext
           # - python-version: "pypy-3.9"
           #   build-type: "cext"
@@ -122,8 +133,20 @@ jobs:
           - "cext"
           - "nocext"
         exclude:
+          # ubuntu-latest does not have: py27, py36
           - os: "ubuntu-latest"
             python-version: cp36-cp36m
+          # ubuntu-20.04 does not need to test what ubuntu-latest supports
+          - os: "ubuntu-20.04"
+            python-version: cp37-cp37m
+          - os: "ubuntu-20.04"
+            python-version: cp38-cp38m
+          - os: "ubuntu-20.04"
+            python-version: cp39-cp39m
+          - os: "ubuntu-20.04"
+            python-version: cp310-cp310m
+          - os: "ubuntu-20.04"
+            python-version: cp311-cp311m
 
       fail-fast: false
 
@@ -165,8 +188,20 @@ jobs:
           - "3.10"
           - "3.11.0-rc - 3.11"
         exclude:
+          # ubuntu-latest does not have: py27, py36
           - os: "ubuntu-latest"
             python-version: "3.6"
+          # ubuntu-20.04 does not need to test what ubuntu-latest supports
+          - os: "ubuntu-20.04"
+            python-version: "3.7"
+          - os: "ubuntu-20.04"
+            python-version: "3.8"
+          - os: "ubuntu-20.04"
+            python-version: "3.9"
+          - os: "ubuntu-20.04"
+            python-version: "3.10"
+          - os: "ubuntu-20.04"
+            python-version: "3.11.0-rc - 3.11"
       fail-fast: false
 
     # steps to run in each job. Some are github actions, others run shell commands

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -160,6 +160,9 @@ jobs:
     strategy:
       # run this job using this matrix, excluding some combinations below.
       matrix:
+        os:
+          - "ubuntu-latest"
+          - "ubuntu-20.04"
         python-version:
           - "3.6"
           - "3.7"
@@ -168,7 +171,6 @@ jobs:
           - "3.10"
           - "3.11.0-rc - 3.11"
         include:
-          - os: "ubuntu-latest"
           - os: "ubuntu-20.04"
             python-version:
               - "3.6"

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -160,9 +160,6 @@ jobs:
     strategy:
       # run this job using this matrix, excluding some combinations below.
       matrix:
-        os:
-          - "ubuntu-latest"
-          - "ubuntu-20.04"
         python-version:
           - "3.6"
           - "3.7"
@@ -171,6 +168,7 @@ jobs:
           - "3.10"
           - "3.11.0-rc - 3.11"
         include:
+          - os: "ubuntu-latest"
           - os: "ubuntu-20.04"
             python-version:
               - "3.6"


### PR DESCRIPTION
GitHub recently began to roll-out an update to GitHub Actions in which the `ubuntu-latest` Operating System label now points to `ubuntu-22.04` instead of `ubuntu-20.04` :

* https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/
* https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04/

This creates a problem for SQLAlchemy 1.4 which is still under support and maintained under the `rel_1_4` branch, as `ubuntu-22.04` does not support Python2.7 or Python3.6, which are still support targets for the legacy SQLAlchemy release series.

### Description
This PR updates the GitHub actions files to continue support by doing the following:

* any actions targeting the Python 2.7/3.6 environments are extended to use both the `ubuntu-latest` and `ubuntu-20.04` operating systems.
  * the Py27/36 environments are excluded from `ubuntu-latest`
  * the remaining environments are excluded from `ubuntu-20.04`
* some tests have been slightly renamed, to use the test runner's job `name` as a prefix.  this greatly simplifies troubleshooting, by making it easier to correlate a failed action to a job name.

### Checklist
This pull request is:

- [x] A CI infrastructure change.  

Please note: This PR includes an erroneous commit that was pushed `rel_1_4` due to a client/developer error (that was me).  The first commit includes a rollback to undo that commit, as it used a totally different approach.
