### PR TITLE
Add compatibility properties to new PG Range class

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/ranges.py
+++ b/lib/sqlalchemy/dialects/postgresql/ranges.py
@@ -86,6 +86,40 @@ class Range(Generic[_T]):
         return not self.empty
 
     @property
+    def isempty(self):
+        "Compability accessor to this range emptiness."
+
+        return self.empty
+
+    @property
+    def lower_inc(self):
+        "Check whether the lower bound is inclusive or not."
+
+        return self.bounds[0] == "["
+
+    @property
+    def lower_inf(self):
+        """Check whether this range is not empty and its lower bound is
+        infinite or not.
+        """
+
+        return not self.empty and self.lower is None
+
+    @property
+    def upper_inc(self):
+        "Check whether the upper bound is inclusive or not."
+
+        return self.bounds[1] == "]"
+
+    @property
+    def upper_inf(self):
+        """Check whether this range is not empty and its upper bound is
+        infinite or not.
+        """
+
+        return not self.empty and self.upper is None
+
+    @property
     def __sa_type_engine__(self):
         return AbstractRange()
 

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -3996,6 +3996,24 @@ class _RangeComparisonFixtures(_RangeTests):
 
         is_false(range_.contains(values["rh"]))
 
+    def test_compatibility_accessors(self):
+        range_ = self._data_obj()
+
+        is_true(range_.lower_inc)
+        is_false(range_.upper_inc)
+        is_false(Range(lower=range_.lower, bounds="()").lower_inc)
+        is_true(Range(upper=range_.upper, bounds="(]").upper_inc)
+
+        is_false(range_.lower_inf)
+        is_false(range_.upper_inf)
+        is_false(Range(empty=True).lower_inf)
+        is_false(Range(empty=True).upper_inf)
+        is_true(Range().lower_inf)
+        is_true(Range().upper_inf)
+
+        is_false(range_.isempty)
+        is_true(Range(empty=True).isempty)
+
     def test_contains_value(
         self, connection, bounds_obj_combinations, value_combinations
     ):


### PR DESCRIPTION
This adds a bunch of properties to new PG Range class for compatibility with other implementations, providing a more similar API to access emptiness and bounds status.
