### PR TITLE
rename some GitHub actions to use test names as prefix

### DIFF
--- a/.github/workflows/run-on-pr.yaml
+++ b/.github/workflows/run-on-pr.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   run-test-amd64:
-    name: ${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
+    name: test-amd64-${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       # run this job using this matrix, excluding some combinations below.

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   run-test:
-    name: ${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
+    name: test-${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.architecture }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       # run this job using this matrix, excluding some combinations below.
@@ -95,7 +95,7 @@ jobs:
         continue-on-error: ${{ matrix.python-version == 'pypy-3.9' }}
 
   run-test-arm64:
-    name: ${{ matrix.python-version }}-${{ matrix.build-type }}-arm64-ubuntu-latest
+    name: test-arm64-${{ matrix.python-version }}-${{ matrix.build-type }}-${{ matrix.os }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This just standardizes the  job `name` into the test `name` as a prefix, so it's easier to tell which job failed

Change-Id: I7f3aa96447ade605becbdef01bc19f3b78dbd6d1