### PR TITLE
Fix equality comparison between a PG Range and a different class instance

### DIFF
--- a/doc/build/changelog/unreleased_20/8984.rst
+++ b/doc/build/changelog/unreleased_20/8984.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: bug, postgresql
+    :tickets: 8984
+
+    The :meth:`_postgresql.Range.__eq___` will now return ``NotImplemented``
+    when comparing with an instance of a different class, instead of raising
+    an :exc:`AttributeError` exception.

--- a/lib/sqlalchemy/dialects/postgresql/ranges.py
+++ b/lib/sqlalchemy/dialects/postgresql/ranges.py
@@ -146,7 +146,7 @@ class Range(Generic[_T]):
         return AbstractRange()
 
     def _contains_value(self, value: _T) -> bool:
-        """return True if this range contains the given value."""
+        """Return True if this range contains the given value."""
 
         if self.empty:
             return False
@@ -681,7 +681,7 @@ class AbstractRange(sqltypes.TypeEngine[Range[_T]]):
         cls: Type[Union[TypeEngine[Any], TypeEngineMixin]],
         **kw: Any,
     ) -> TypeEngine[Any]:
-        """dynamically adapt a range type to an abstract impl.
+        """Dynamically adapt a range type to an abstract impl.
 
         For example ``INT4RANGE().adapt(_Psycopg2NumericRange)`` should
         produce a type that will have ``_Psycopg2NumericRange`` behaviors
@@ -808,7 +808,7 @@ class AbstractRange(sqltypes.TypeEngine[Range[_T]]):
 
 
 class AbstractRangeImpl(AbstractRange[Range[_T]]):
-    """marker for AbstractRange that will apply a subclass-specific
+    """Marker for AbstractRange that will apply a subclass-specific
     adaptation"""
 
 
@@ -821,7 +821,7 @@ class AbstractMultiRange(AbstractRange[Range[_T]]):
 class AbstractMultiRangeImpl(
     AbstractRangeImpl[Range[_T]], AbstractMultiRange[Range[_T]]
 ):
-    """marker for AbstractRange that will apply a subclass-specific
+    """Marker for AbstractRange that will apply a subclass-specific
     adaptation"""
 
 

--- a/lib/sqlalchemy/dialects/postgresql/ranges.py
+++ b/lib/sqlalchemy/dialects/postgresql/ranges.py
@@ -289,6 +289,9 @@ class Range(Generic[_T]):
         bounds inclusivity, returning ``True`` if they are equal.
         """
 
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+
         if self.empty and other.empty:
             return True
         elif self.empty != other.empty:

--- a/lib/sqlalchemy/dialects/postgresql/ranges.py
+++ b/lib/sqlalchemy/dialects/postgresql/ranges.py
@@ -289,7 +289,7 @@ class Range(Generic[_T]):
         bounds inclusivity, returning ``True`` if they are equal.
         """
 
-        if not isinstance(other, self.__class__):
+        if not isinstance(other, Range):
             return NotImplemented
 
         if self.empty and other.empty:

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -3996,6 +3996,10 @@ class _RangeComparisonFixtures(_RangeTests):
 
         is_false(range_.contains(values["rh"]))
 
+        is_true(range_ == range_)
+        is_false(range_ != range_)
+        is_false(range_ == None)
+
     def test_compatibility_accessors(self):
         range_ = self._data_obj()
 


### PR DESCRIPTION
This fixes issue #8984, making the method `Range.__eq__` return `NotImplemented` when the argument is an instance of a different class.