### PR TITLE
[asyncpg] Extract rowcount for SELECT statements

### DIFF
--- a/doc/build/changelog/unreleased_14/9048.rst
+++ b/doc/build/changelog/unreleased_14/9048.rst
@@ -1,0 +1,9 @@
+.. change::
+    :tags: bug, postgresql
+    :tickets: 9048
+    :versions: 2.0.0
+
+    Added support to the asyncpg dialect to return the ``cursor.rowcount``
+    value for SELECT statements when available. While this is not a typical use
+    for ``cursor.rowcount``, the other PostgreSQL dialects generally provide
+    this value. Pull request courtesy Michael Gorven.

--- a/lib/sqlalchemy/dialects/postgresql/asyncpg.py
+++ b/lib/sqlalchemy/dialects/postgresql/asyncpg.py
@@ -483,7 +483,7 @@ class AsyncAdapt_asyncpg_cursor:
                     status = prepared_stmt.get_statusmsg()
 
                     reg = re.match(
-                        r"(?:UPDATE|DELETE|INSERT \d+) (\d+)", status
+                        r"(?:SELECT|UPDATE|DELETE|INSERT \d+) (\d+)", status
                     )
                     if reg:
                         self.rowcount = int(reg.group(1))

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -1140,6 +1140,11 @@ $$ LANGUAGE plpgsql;
                 TransactionStatus.INTRANS,
             )
 
+    def test_select_rowcount(self):
+        conn = testing.db.connect()
+        cursor = conn.exec_driver_sql("SELECT 1")
+        eq_(cursor.rowcount, 1)
+
 
 class Psycopg3Test(fixtures.TestBase):
     __only_on__ = ("postgresql+psycopg",)


### PR DESCRIPTION
### Description
Postgres does return a rowcount for `SELECT` statements.
https://www.postgresql.org/docs/current/protocol-message-formats.html#PROTOCOL-MESSAGE-FORMATS-COMMANDCOMPLETE

Closes: #9048

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
