### PR TITLE
Fix create_row_processor to handle missing loadopt

### DIFF
--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -1161,7 +1161,7 @@ class LazyLoader(
                     self,
                     loadopt,
                     loadopt._generate_extra_criteria(context)
-                    if loadopt._extra_criteria
+                    if loadopt and loadopt._extra_criteria
                     else None,
                 ),
                 key,


### PR DESCRIPTION
In create_row_processor, we check for either `self.is_class_level or (loadopt and loadopt._extra_criteria)`, but when loading the lazy attribute we assume that loadopt != None and the if statement doesn't guarantee that, leading to a traceback if loadopt is None.

### Description
This PR fixes that assumption by doing the exact same check in the if statement when setting the extra criteria

Fixes: #9118 

### Checklist

This pull request is:

- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.