### PR TITLE
Ref #9133 - handling single token bracketed schemas

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -2875,7 +2875,6 @@ def _owner_plus_db(dialect, schema):
         return _schema_elements(schema)
 
 
-
 _memoized_schema = util.LRUCache()
 
 

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -2871,10 +2871,9 @@ def _switch_db(dbname, connection, fn, *arg, **kw):
 def _owner_plus_db(dialect, schema):
     if not schema:
         return None, dialect.default_schema_name
-    elif "." in schema:
-        return _schema_elements(schema)
     else:
-        return None, schema
+        return _schema_elements(schema)
+
 
 
 _memoized_schema = util.LRUCache()

--- a/test/dialect/mssql/test_compiler.py
+++ b/test/dialect/mssql/test_compiler.py
@@ -599,20 +599,6 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             checkpositional=("bar",),
         )
 
-    def test_schema_single_token_bracketed(self):
-        metadata = MetaData()
-        tbl = Table(
-            "test",
-            metadata,
-            Column("id", Integer, primary_key=True),
-            schema="[abc]",
-        )
-
-        self.assert_compile(
-            select(tbl),
-            "SELECT abc.test.id FROM abc.test",
-        )
-
     def test_schema_many_tokens_one(self):
         metadata = MetaData()
         tbl = Table(

--- a/test/dialect/mssql/test_compiler.py
+++ b/test/dialect/mssql/test_compiler.py
@@ -599,6 +599,20 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             checkpositional=("bar",),
         )
 
+    def test_schema_single_token_bracketed(self):
+        metadata = MetaData()
+        tbl = Table(
+            "test",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            schema="[abc]",
+        )
+
+        self.assert_compile(
+            select(tbl),
+            "SELECT abc.test.id FROM abc.test",
+        )
+
     def test_schema_many_tokens_one(self):
         metadata = MetaData()
         tbl = Table(

--- a/test/dialect/mssql/test_reflection.py
+++ b/test/dialect/mssql/test_reflection.py
@@ -420,10 +420,7 @@ class ReflectionTest(fixtures.TestBase, ComparesTables, AssertsCompiledSQL):
     ):
         # Addresses bug #9133
         tt = Table(
-            'test',
-            metadata,
-            Column("id", Integer),
-            schema=schema_value
+            "test", metadata, Column("id", Integer), schema=schema_value
         )
         tt.create(connection)
         found_it = inspect(connection).has_table("test", schema=schema_value)

--- a/test/dialect/mssql/test_reflection.py
+++ b/test/dialect/mssql/test_reflection.py
@@ -410,6 +410,24 @@ class ReflectionTest(fixtures.TestBase, ComparesTables, AssertsCompiledSQL):
             )
             Table(tname, MetaData(), autoload_with=conn)
 
+    @testing.combinations(
+        ("test_schema"),
+        ("[test_schema]"),
+        argnames="schema_value",
+    )
+    def test_has_table_with_schema_token_comb(
+        self, metadata, connection, schema_value
+    ):
+        tt = Table(
+            'test',
+            metadata,
+            Column("id", Integer),
+            schema=schema_value
+        )
+        tt.create(connection)
+        found_it = inspect(connection).has_table("test", schema=schema_value)
+        eq_(found_it, True)
+
     def test_db_qualified_items(self, metadata, connection):
         Table("foo", metadata, Column("id", Integer, primary_key=True))
         Table(

--- a/test/dialect/mssql/test_reflection.py
+++ b/test/dialect/mssql/test_reflection.py
@@ -415,9 +415,10 @@ class ReflectionTest(fixtures.TestBase, ComparesTables, AssertsCompiledSQL):
         ("[test_schema]"),
         argnames="schema_value",
     )
-    def test_has_table_with_schema_token_comb(
+    def test_has_table_with_single_token_schema(
         self, metadata, connection, schema_value
     ):
+        # Addresses bug #9133
         tt = Table(
             'test',
             metadata,


### PR DESCRIPTION
As far as I understand, the _schema_elements function can be called regardless of whether a dot exists in the token or not.
References: https://github.com/sqlalchemy/sqlalchemy/issues/9133