### PR TITLE
Unify doc typing

### DIFF
--- a/doc/build/changelog/migration_20.rst
+++ b/doc/build/changelog/migration_20.rst
@@ -471,7 +471,7 @@ are subject to these errors, as would occur in the example below::
         id: int = Column(Integer, primary_key=True)
 
         # will raise
-        bars: List["Bar"] = relationship("Bar", back_populates="foo")
+        bars: list["Bar"] = relationship("Bar", back_populates="foo")
 
 
     class Bar(Base):
@@ -519,7 +519,7 @@ that descend from ``Base``::
 
         id: int = Column(Integer, primary_key=True)
 
-        bars: List["Bar"] = relationship("Bar", back_populates="foo")
+        bars: list["Bar"] = relationship("Bar", back_populates="foo")
 
 
     class Bar(Base):

--- a/doc/build/changelog/migration_20.rst
+++ b/doc/build/changelog/migration_20.rst
@@ -471,7 +471,7 @@ are subject to these errors, as would occur in the example below::
         id: int = Column(Integer, primary_key=True)
 
         # will raise
-        bars: list["Bar"] = relationship("Bar", back_populates="foo")
+        bars: List["Bar"] = relationship("Bar", back_populates="foo")
 
 
     class Bar(Base):
@@ -519,7 +519,7 @@ that descend from ``Base``::
 
         id: int = Column(Integer, primary_key=True)
 
-        bars: list["Bar"] = relationship("Bar", back_populates="foo")
+        bars: List["Bar"] = relationship("Bar", back_populates="foo")
 
 
     class Bar(Base):

--- a/doc/build/orm/basic_relationships.rst
+++ b/doc/build/orm/basic_relationships.rst
@@ -10,6 +10,7 @@ based on the use of the :class:`_orm.Mapped` annotation type.
 The setup for each of the following sections is as follows::
 
     from __future__ import annotations
+    from typing import List
 
     from sqlalchemy import ForeignKey
     from sqlalchemy import Integer
@@ -40,7 +41,7 @@ which is the most modern form of SQLAlchemy Declarative mapping::
         __tablename__ = "parent_table"
 
         id: Mapped[int] = mapped_column(primary_key=True)
-        children: Mapped[list["Child"]] = relationship(back_populates="parent")
+        children: Mapped[List["Child"]] = relationship(back_populates="parent")
 
 
     class Child(Base):
@@ -114,7 +115,7 @@ a collection of items represented by the child::
         __tablename__ = "parent_table"
 
         id: Mapped[int] = mapped_column(primary_key=True)
-        children: Mapped[list["Child"]] = relationship()
+        children: Mapped[List["Child"]] = relationship()
 
 
     class Child(Base):
@@ -134,7 +135,7 @@ as the value for :paramref:`_orm.relationship.back_populates` on the other::
         __tablename__ = "parent_table"
 
         id: Mapped[int] = mapped_column(primary_key=True)
-        children: Mapped[list["Child"]] = relationship(back_populates="parent")
+        children: Mapped[List["Child"]] = relationship(back_populates="parent")
 
 
     class Child(Base):
@@ -236,7 +237,7 @@ as the value for :paramref:`_orm.relationship.back_populates` on the other::
         __tablename__ = "child_table"
 
         id: Mapped[int] = mapped_column(primary_key=True)
-        parents: Mapped[list["Parent"]] = relationship(back_populates="child")
+        parents: Mapped[List["Parent"]] = relationship(back_populates="child")
 
 .. _relationship_patterns_nullable_m2o:
 
@@ -265,7 +266,7 @@ case the configuration would look like::
         __tablename__ = "child_table"
 
         id: Mapped[int] = mapped_column(primary_key=True)
-        parents: Mapped[list["Parent"]] = relationship(back_populates="child")
+        parents: Mapped[List["Parent"]] = relationship(back_populates="child")
 
 Above, the column for ``Parent.child_id`` will be created in DDL to allow
 ``NULL`` values. When using :func:`_orm.mapped_column` with explicit typing
@@ -297,7 +298,7 @@ for background on this behavior.
           __tablename__ = "child_table"
 
           id: Mapped[int] = mapped_column(primary_key=True)
-          parents: Mapped[list[Parent]] = relationship(back_populates="child")
+          parents: Mapped[List[Parent]] = relationship(back_populates="child")
 
 .. _relationships_one_to_one:
 
@@ -423,7 +424,7 @@ with which to link::
         __tablename__ = "left_table"
 
         id: Mapped[int] = mapped_column(primary_key=True)
-        children: Mapped[list[Child]] = relationship(secondary=association_table)
+        children: Mapped[List[Child]] = relationship(secondary=association_table)
 
 
     class Child(Base):
@@ -485,7 +486,7 @@ for each :func:`_orm.relationship` specify the common association table::
         __tablename__ = "left_table"
 
         id: Mapped[int] = mapped_column(primary_key=True)
-        children: Mapped[list[Child]] = relationship(
+        children: Mapped[List[Child]] = relationship(
             secondary=association_table, back_populates="parents"
         )
 
@@ -494,7 +495,7 @@ for each :func:`_orm.relationship` specify the common association table::
         __tablename__ = "right_table"
 
         id: Mapped[int] = mapped_column(primary_key=True)
-        parents: Mapped[list[Parent]] = relationship(
+        parents: Mapped[List[Parent]] = relationship(
             secondary=association_table, back_populates="children"
         )
 
@@ -650,7 +651,7 @@ from ``Parent`` to ``Child`` makes explicit use of ``Association``::
     class Parent(Base):
         __tablename__ = "left_table"
         id: Mapped[int] = mapped_column(primary_key=True)
-        children: Mapped[list["Association"]] = relationship()
+        children: Mapped[List["Association"]] = relationship()
 
 
     class Child(Base):
@@ -688,13 +689,13 @@ constructs, linked to the existing ones using :paramref:`_orm.relationship.back_
     class Parent(Base):
         __tablename__ = "left_table"
         id: Mapped[int] = mapped_column(primary_key=True)
-        children: Mapped[list["Association"]] = relationship(back_populates="parent")
+        children: Mapped[List["Association"]] = relationship(back_populates="parent")
 
 
     class Child(Base):
         __tablename__ = "right_table"
         id: Mapped[int] = mapped_column(primary_key=True)
-        parents: Mapped[list["Association"]] = relationship(back_populates="child")
+        parents: Mapped[List["Association"]] = relationship(back_populates="child")
 
 Working with the association pattern in its direct form requires that child
 objects are associated with an association instance before being appended to
@@ -789,12 +790,12 @@ and ``Child.parent_associations -> Association.parent``::
         id: Mapped[int] = mapped_column(primary_key=True)
 
         # many-to-many relationship to Child, bypassing the `Association` class
-        children: Mapped[list["Child"]] = relationship(
+        children: Mapped[List["Child"]] = relationship(
             secondary="association_table", back_populates="parents"
         )
 
         # association between Parent -> Association -> Child
-        child_associations: Mapped[list["Association"]] = relationship(
+        child_associations: Mapped[List["Association"]] = relationship(
             back_populates="parent"
         )
 
@@ -805,12 +806,12 @@ and ``Child.parent_associations -> Association.parent``::
         id: Mapped[int] = mapped_column(primary_key=True)
 
         # many-to-many relationship to Parent, bypassing the `Association` class
-        parents: Mapped[list["Parent"]] = relationship(
+        parents: Mapped[List["Parent"]] = relationship(
             secondary="association_table", back_populates="children"
         )
 
         # association between Child -> Association -> Parent
-        parent_associations: Mapped[list["Association"]] = relationship(
+        parent_associations: Mapped[List["Association"]] = relationship(
             back_populates="child"
         )
 
@@ -858,12 +859,12 @@ additional association columns, as below::
         id: Mapped[int] = mapped_column(primary_key=True)
 
         # many-to-many relationship to Child, bypassing the `Association` class
-        children: Mapped[list["Child"]] = relationship(
+        children: Mapped[List["Child"]] = relationship(
             secondary="association_table", back_populates="parents", viewonly=True
         )
 
         # association between Parent -> Association -> Child
-        child_associations: Mapped[list["Association"]] = relationship(
+        child_associations: Mapped[List["Association"]] = relationship(
             back_populates="parent"
         )
 
@@ -874,12 +875,12 @@ additional association columns, as below::
         id: Mapped[int] = mapped_column(primary_key=True)
 
         # many-to-many relationship to Parent, bypassing the `Association` class
-        parents: Mapped[list["Parent"]] = relationship(
+        parents: Mapped[List["Parent"]] = relationship(
             secondary="association_table", back_populates="children", viewonly=True
         )
 
         # association between Child -> Association -> Parent
-        parent_associations: Mapped[list["Association"]] = relationship(
+        parent_associations: Mapped[List["Association"]] = relationship(
             back_populates="child"
         )
 
@@ -919,7 +920,7 @@ at runtime only as a string::
     class Parent(Base):
         # ...
 
-        children: Mapped[list["Child"]] = relationship(back_populates="parent")
+        children: Mapped[List["Child"]] = relationship(back_populates="parent")
 
 
     class Child(Base):
@@ -971,7 +972,7 @@ package, including expression functions like :func:`_sql.desc` and
     class Parent(Base):
         # ...
 
-        children: Mapped[list["Child"]] = relationship(
+        children: Mapped[List["Child"]] = relationship(
             order_by="desc(Child.email_address)",
             primaryjoin="Parent.id == Child.parent_id",
         )
@@ -983,7 +984,7 @@ within any of these string expressions::
     class Parent(Base):
         # ...
 
-        children: Mapped[list["myapp.mymodel.Child"]] = relationship(
+        children: Mapped[List["myapp.mymodel.Child"]] = relationship(
             order_by="desc(myapp.mymodel.Child.email_address)",
             primaryjoin="myapp.mymodel.Parent.id == myapp.mymodel.Child.parent_id",
         )
@@ -1004,7 +1005,7 @@ name within the :class:`_orm.registry`::
     class Parent(Base):
         # ...
 
-        children: Mapped[list["Child"]] = relationship(
+        children: Mapped[List["Child"]] = relationship(
             "myapp.mymodel.Child",
             order_by="desc(myapp.mymodel.Child.email_address)",
             primaryjoin="myapp.mymodel.Parent.id == myapp.mymodel.Child.parent_id",
@@ -1018,7 +1019,7 @@ we can specify ``model1.Child`` or ``model2.Child``::
     class Parent(Base):
         # ...
 
-        children: Mapped[list["Child"]] = relationship(
+        children: Mapped[List["Child"]] = relationship(
             "model1.Child",
             order_by="desc(mymodel1.Child.email_address)",
             primaryjoin="Parent.id == model1.Child.parent_id",
@@ -1045,7 +1046,7 @@ like the following::
     class Parent(Base):
         # ...
 
-        children: Mapped[list["Child"]] = relationship(
+        children: Mapped[List["Child"]] = relationship(
             _resolve_child_model(),
             order_by=lambda: desc(_resolve_child_model().email_address),
             primaryjoin=lambda: Parent.id == _resolve_child_model().parent_id,
@@ -1151,7 +1152,7 @@ using a lambda as::
         __tablename__ = "left_table"
 
         id: Mapped[int] = mapped_column(primary_key=True)
-        children: Mapped[list["Child"]] = relationship(
+        children: Mapped[List["Child"]] = relationship(
             "Child", secondary=lambda: association_table
         )
 
@@ -1165,7 +1166,7 @@ the :class:`.MetaData` collection::
         __tablename__ = "left_table"
 
         id: Mapped[int] = mapped_column(primary_key=True)
-        children: Mapped[list["Child"]] = relationship(secondary="association_table")
+        children: Mapped[List["Child"]] = relationship(secondary="association_table")
 
 .. warning:: When passed as a string,
     :paramref:`_orm.relationship.secondary` argument is interpreted using Python's

--- a/doc/build/orm/basic_relationships.rst
+++ b/doc/build/orm/basic_relationships.rst
@@ -156,13 +156,13 @@ Using annotated Declarative mappings, the type of collection used for the
 :func:`_orm.relationship` is derived from the collection type passed to the
 :class:`_orm.Mapped` container type.  The example from the previous section
 may be written to use a ``set`` rather than a ``list`` for the
-``Parent.children`` collection using ``Mapped[set["Child"]]``::
+``Parent.children`` collection using ``Mapped[Set["Child"]]``::
 
     class Parent(Base):
         __tablename__ = "parent_table"
 
         id: Mapped[int] = mapped_column(primary_key=True)
-        children: Mapped[set["Child"]] = relationship(back_populates="parent")
+        children: Mapped[Set["Child"]] = relationship(back_populates="parent")
 
 When using non-annotated forms including imperative mappings, the Python
 class to use as a collection may be passed using the
@@ -523,7 +523,7 @@ such as ``set``::
         __tablename__ = "left_table"
 
         id: Mapped[int] = mapped_column(primary_key=True)
-        children: Mapped[set["Child"]] = relationship(secondary=association_table)
+        children: Mapped[Set["Child"]] = relationship(secondary=association_table)
 
 When using non-annotated forms including imperative mappings, as is
 the case with one-to-many, the Python

--- a/doc/build/orm/collection_api.rst
+++ b/doc/build/orm/collection_api.rst
@@ -47,7 +47,7 @@ below where ``list`` is used::
         parent_id: Mapped[int] = mapped_column(primary_key=True)
 
         # use a list
-        children: Mapped[list["Child"]] = relationship()
+        children: Mapped[List["Child"]] = relationship()
 
 
     class Child(Base):

--- a/doc/build/orm/collection_api.rst
+++ b/doc/build/orm/collection_api.rst
@@ -59,6 +59,7 @@ below where ``list`` is used::
 Or for a ``set``, illustrated in the same
 ``Parent.children`` collection::
 
+    from typing import Set
     from sqlalchemy import ForeignKey
 
     from sqlalchemy.orm import DeclarativeBase
@@ -77,7 +78,7 @@ Or for a ``set``, illustrated in the same
         parent_id: Mapped[int] = mapped_column(primary_key=True)
 
         # use a set
-        children: Mapped[set["Child"]] = relationship()
+        children: Mapped[Set["Child"]] = relationship()
 
 
     class Child(Base):

--- a/doc/build/orm/collection_api.rst
+++ b/doc/build/orm/collection_api.rst
@@ -155,6 +155,7 @@ the :paramref:`_orm.relationship.collection_class` parameter
 is required in this case so that the :func:`.attribute_keyed_dict`
 may be appropriately parametrized::
 
+    from typing import Dict
     from typing import Optional
 
     from sqlalchemy import ForeignKey
@@ -174,7 +175,7 @@ may be appropriately parametrized::
 
         id: Mapped[int] = mapped_column(primary_key=True)
 
-        notes: Mapped[dict[str, "Note"]] = relationship(
+        notes: Mapped[Dict[str, "Note"]] = relationship(
             collection_class=attribute_keyed_dict("keyword"),
             cascade="all, delete-orphan",
         )
@@ -221,7 +222,7 @@ of the ``Note.text`` field::
 
         id: Mapped[int] = mapped_column(primary_key=True)
 
-        notes: Mapped[dict[str, "Note"]] = relationship(
+        notes: Mapped[Dict[str, "Note"]] = relationship(
             collection_class=attribute_keyed_dict("note_key"),
             back_populates="item",
             cascade="all, delete-orphan",
@@ -269,7 +270,7 @@ object directly::
 
         id: Mapped[int] = mapped_column(primary_key=True)
 
-        notes: Mapped[dict[str, "Note"]] = relationship(
+        notes: Mapped[Dict[str, "Note"]] = relationship(
             collection_class=column_keyed_dict(Note.__table__.c.keyword),
             cascade="all, delete-orphan",
         )
@@ -286,7 +287,7 @@ with a ``@property`` as mentioned earlier::
 
         id: Mapped[int] = mapped_column(primary_key=True)
 
-        notes: Mapped[dict[str, "Note"]] = relationship(
+        notes: Mapped[Dict[str, "Note"]] = relationship(
             collection_class=mapped_collection(lambda note: note.text[0:10]),
             cascade="all, delete-orphan",
         )
@@ -312,7 +313,7 @@ to populate an attribute mapped collection.  Given the following::
 
         id: Mapped[int] = mapped_column(primary_key=True)
 
-        bs: Mapped[dict[str, "B"]] = relationship(
+        bs: Mapped[Dict[str, "B"]] = relationship(
             collection_class=attribute_keyed_dict("data"),
             back_populates="a",
         )

--- a/doc/build/orm/declarative_styles.rst
+++ b/doc/build/orm/declarative_styles.rst
@@ -75,7 +75,7 @@ of the base::
         nickname: Mapped[Optional[str]] = mapped_column(String(64))
         create_date: Mapped[datetime] = mapped_column(insert_default=func.now())
 
-        addresses: Mapped[list["Address"]] = relationship(back_populates="user")
+        addresses: Mapped[List["Address"]] = relationship(back_populates="user")
 
 
     class Address(Base):
@@ -126,6 +126,7 @@ previous section, using the :meth:`_orm.registry.mapped`
 decorator rather than using the :class:`_orm.DeclarativeBase` superclass::
 
     from datetime import datetime
+    from typing import List
     from typing import Optional
 
     from sqlalchemy import ForeignKey
@@ -150,7 +151,7 @@ decorator rather than using the :class:`_orm.DeclarativeBase` superclass::
         nickname: Mapped[Optional[str]] = mapped_column(String(64))
         create_date: Mapped[datetime] = mapped_column(insert_default=func.now())
 
-        addresses: Mapped[list["Address"]] = relationship(back_populates="user")
+        addresses: Mapped[List["Address"]] = relationship(back_populates="user")
 
 
     @mapper_registry.mapped

--- a/doc/build/orm/extensions/associationproxy.rst
+++ b/doc/build/orm/extensions/associationproxy.rst
@@ -52,13 +52,13 @@ exception of an extra attribute added to the ``User`` class called
         __tablename__ = "user"
         id: Mapped[int] = mapped_column(primary_key=True)
         name: Mapped[str] = mapped_column(String(64))
-        kw: Mapped[list[Keyword]] = relationship(secondary=lambda: user_keyword_table)
+        kw: Mapped[List[Keyword]] = relationship(secondary=lambda: user_keyword_table)
 
         def __init__(self, name: str):
             self.name = name
 
         # proxy the 'keyword' attribute from the 'kw' relationship
-        keywords: AssociationProxy[list[str]] = association_proxy("kw", "keyword")
+        keywords: AssociationProxy[List[str]] = association_proxy("kw", "keyword")
 
 
     class Keyword(Base):
@@ -150,7 +150,7 @@ using a lambda as is typical::
         ...
 
         # use Keyword(keyword=kw) on append() events
-        keywords: AssociationProxy[list[str]] = association_proxy(
+        keywords: AssociationProxy[List[str]] = association_proxy(
             "kw", "keyword", creator=lambda kw: Keyword(keyword=kw)
         )
 
@@ -203,14 +203,14 @@ collection of ``User`` to the ``.keyword`` attribute present on each
         id: Mapped[int] = mapped_column(primary_key=True)
         name: Mapped[str] = mapped_column(String(64))
 
-        user_keyword_associations: Mapped[list[UserKeywordAssociation]] = relationship(
+        user_keyword_associations: Mapped[List[UserKeywordAssociation]] = relationship(
             back_populates="user",
             cascade="all, delete-orphan",
         )
 
         # association proxy of "user_keyword_associations" collection
         # to "keyword" attribute
-        keywords: AssociationProxy[list[Keyword]] = association_proxy(
+        keywords: AssociationProxy[List[Keyword]] = association_proxy(
             "user_keyword_associations",
             "keyword",
             creator=lambda keyword: UserKeywordAssociation(keyword=Keyword(keyword)),
@@ -547,7 +547,7 @@ to a related object, as in the example mapping below::
         )
 
         # column-targeted association proxy
-        special_keys: AssociationProxy[list[str]] = association_proxy(
+        special_keys: AssociationProxy[List[str]] = association_proxy(
             "user_keyword_associations", "special_key"
         )
 

--- a/doc/build/orm/extensions/associationproxy.rst
+++ b/doc/build/orm/extensions/associationproxy.rst
@@ -315,6 +315,7 @@ argument to the ``User.keywords`` proxy so that these values are assigned approp
 when new elements are added to the dictionary::
 
     from __future__ import annotations
+    from typing import Dict
 
     from sqlalchemy import ForeignKey
     from sqlalchemy import String
@@ -338,7 +339,7 @@ when new elements are added to the dictionary::
 
         # user/user_keyword_associations relationship, mapping
         # user_keyword_associations with a dictionary against "special_key" as key.
-        user_keyword_associations: Mapped[dict[str, UserKeywordAssociation]] = relationship(
+        user_keyword_associations: Mapped[Dict[str, UserKeywordAssociation]] = relationship(
             back_populates="user",
             collection_class=attribute_keyed_dict("special_key"),
             cascade="all, delete-orphan",
@@ -346,7 +347,7 @@ when new elements are added to the dictionary::
         # proxy to 'user_keyword_associations', instantiating
         # UserKeywordAssociation assigning the new key to 'special_key',
         # values to 'keyword'.
-        keywords: AssociationProxy[dict[str, Keyword]] = association_proxy(
+        keywords: AssociationProxy[Dict[str, Keyword]] = association_proxy(
             "user_keyword_associations",
             "keyword",
             creator=lambda k, v: UserKeywordAssociation(special_key=k, keyword=v),
@@ -426,14 +427,14 @@ present on ``UserKeywordAssociation``::
         id: Mapped[int] = mapped_column(primary_key=True)
         name: Mapped[str] = mapped_column(String(64))
 
-        user_keyword_associations: Mapped[dict[str, UserKeywordAssociation]] = relationship(
+        user_keyword_associations: Mapped[Dict[str, UserKeywordAssociation]] = relationship(
             back_populates="user",
             collection_class=attribute_keyed_dict("special_key"),
             cascade="all, delete-orphan",
         )
         # the same 'user_keyword_associations'->'keyword' proxy as in
         # the basic dictionary example.
-        keywords: AssociationProxy[dict[str, str]] = association_proxy(
+        keywords: AssociationProxy[Dict[str, str]] = association_proxy(
             "user_keyword_associations",
             "keyword",
             creator=lambda k, v: UserKeywordAssociation(special_key=k, keyword=v),
@@ -458,7 +459,7 @@ present on ``UserKeywordAssociation``::
 
         # 'keyword' is changed to be a proxy to the
         # 'keyword' attribute of 'Keyword'
-        keyword: AssociationProxy[dict[str, str]] = association_proxy("kw", "keyword")
+        keyword: AssociationProxy[Dict[str, str]] = association_proxy("kw", "keyword")
 
 
     class Keyword(Base):

--- a/doc/build/orm/extensions/asyncio.rst
+++ b/doc/build/orm/extensions/asyncio.rst
@@ -150,6 +150,7 @@ illustrates a complete example including mapper and session configuration::
 
     import asyncio
     import datetime
+    from typing import List
 
     from sqlalchemy import ForeignKey
     from sqlalchemy import func
@@ -174,7 +175,7 @@ illustrates a complete example including mapper and session configuration::
         id: Mapped[int] = mapped_column(primary_key=True)
         data: Mapped[str]
         create_date: Mapped[datetime.datetime] = mapped_column(server_default=func.now())
-        bs: Mapped[list[B]] = relationship()
+        bs: Mapped[List[B]] = relationship()
 
 
     class B(Base):

--- a/doc/build/orm/inheritance.rst
+++ b/doc/build/orm/inheritance.rst
@@ -186,7 +186,7 @@ and ``Employee``::
         __tablename__ = "company"
         id: Mapped[int] = mapped_column(primary_key=True)
         name: Mapped[str]
-        employees: Mapped[list[Employee]] = relationship(back_populates="company")
+        employees: Mapped[List[Employee]] = relationship(back_populates="company")
 
 
     class Employee(Base):
@@ -220,7 +220,7 @@ established between the ``Manager`` and ``Company`` classes::
         __tablename__ = "company"
         id: Mapped[int] = mapped_column(primary_key=True)
         name: Mapped[str]
-        managers: Mapped[list[Manager]] = relationship(back_populates="company")
+        managers: Mapped[List[Manager]] = relationship(back_populates="company")
 
 
     class Employee(Base):
@@ -481,7 +481,7 @@ relationship::
         __tablename__ = "company"
         id: Mapped[int] = mapped_column(primary_key=True)
         name: Mapped[str]
-        employees: Mapped[list[Employee]] = relationship(back_populates="company")
+        employees: Mapped[List[Employee]] = relationship(back_populates="company")
 
 
     class Employee(Base):
@@ -522,7 +522,7 @@ or subclasses::
         __tablename__ = "company"
         id: Mapped[int] = mapped_column(primary_key=True)
         name: Mapped[str]
-        managers: Mapped[list[Manager]] = relationship(back_populates="company")
+        managers: Mapped[List[Manager]] = relationship(back_populates="company")
 
 
     class Employee(Base):

--- a/doc/build/orm/large_collections.rst
+++ b/doc/build/orm/large_collections.rst
@@ -631,7 +631,7 @@ emit a lazy load::
 
         # ...
 
-        children: Mapped[list[MyRelatedClass]] = relationship(lazy="raise")
+        children: Mapped[List[MyRelatedClass]] = relationship(lazy="raise")
 
 Above, attribute access on the ``children`` collection will raise an exception
 if it was not previously populated.  This includes read access but for

--- a/doc/build/orm/queryguide/_inheritance_setup.rst
+++ b/doc/build/orm/queryguide/_inheritance_setup.rst
@@ -11,6 +11,7 @@ the :ref:`queryguide_toplevel`.
 ..  sourcecode:: python
 
 
+    >>> from typing import List
     >>> from sqlalchemy import create_engine
     >>> from sqlalchemy import ForeignKey
     >>> from sqlalchemy.orm import DeclarativeBase
@@ -26,7 +27,7 @@ the :ref:`queryguide_toplevel`.
     ...     __tablename__ = "company"
     ...     id: Mapped[int] = mapped_column(primary_key=True)
     ...     name: Mapped[str]
-    ...     employees: Mapped[list["Employee"]] = relationship(back_populates="company")
+    ...     employees: Mapped[List["Employee"]] = relationship(back_populates="company")
     >>>
     >>> class Employee(Base):
     ...     __tablename__ = "employee"
@@ -48,7 +49,7 @@ the :ref:`queryguide_toplevel`.
     ...     __tablename__ = "manager"
     ...     id: Mapped[int] = mapped_column(ForeignKey("employee.id"), primary_key=True)
     ...     manager_name: Mapped[str]
-    ...     paperwork: Mapped[list["Paperwork"]] = relationship()
+    ...     paperwork: Mapped[List["Paperwork"]] = relationship()
     ...     __mapper_args__ = {
     ...         "polymorphic_identity": "manager",
     ...     }

--- a/doc/build/orm/queryguide/relationships.rst
+++ b/doc/build/orm/queryguide/relationships.rst
@@ -124,6 +124,8 @@ The example below illustrates the relationship example at
 relationship to use :ref:`selectin_eager_loading` when a SELECT
 statement for ``Parent`` objects is emitted::
 
+    from typing import List
+
     from sqlalchemy import ForeignKey
     from sqlalchemy.orm import DeclarativeBase
     from sqlalchemy.orm import Mapped
@@ -139,7 +141,7 @@ statement for ``Parent`` objects is emitted::
         __tablename__ = "parent"
 
         id: Mapped[int] = mapped_column(primary_key=True)
-        children: Mapped[list["Child"]] = relationship(lazy="selectin")
+        children: Mapped[List["Child"]] = relationship(lazy="selectin")
 
 
     class Child(Base):

--- a/doc/build/orm/quickstart.rst
+++ b/doc/build/orm/quickstart.rst
@@ -27,6 +27,7 @@ which we will be querying from the database.  This structure, known as a
 Python object model, as well as :term:`database metadata` that describes
 real SQL tables that exist, or will exist, in a particular database::
 
+    >>> from typing import List
     >>> from typing import Optional
     >>> from sqlalchemy import ForeignKey
     >>> from sqlalchemy import String
@@ -45,7 +46,7 @@ real SQL tables that exist, or will exist, in a particular database::
     ...     name: Mapped[str] = mapped_column(String(30))
     ...     fullname: Mapped[Optional[str]]
     ...
-    ...     addresses: Mapped[list["Address"]] = relationship(
+    ...     addresses: Mapped[List["Address"]] = relationship(
     ...         back_populates="user", cascade="all, delete-orphan"
     ...     )
     ...

--- a/doc/build/tutorial/orm_related_objects.rst
+++ b/doc/build/tutorial/orm_related_objects.rst
@@ -34,7 +34,7 @@ and other directives:
 
         # ... mapped_column() mappings
 
-        addresses: Mapped[list["Address"]] = relationship(back_populates="user")
+        addresses: Mapped[List["Address"]] = relationship(back_populates="user")
 
 
     class Address(Base):
@@ -400,7 +400,7 @@ the :paramref:`_orm.relationship.lazy` option, e.g.:
     class User(Base):
         __tablename__ = "user_account"
 
-        addresses: Mapped[list["Address"]] = relationship(
+        addresses: Mapped[List["Address"]] = relationship(
             back_populates="user", lazy="selectin"
         )
 
@@ -629,7 +629,7 @@ relationship will never try to emit SQL:
     >>> class User(Base):
     ...     __tablename__ = "user_account"
     ...     id: Mapped[int] = mapped_column(primary_key=True)
-    ...     addresses: Mapped[list["Address"]] = relationship(
+    ...     addresses: Mapped[List["Address"]] = relationship(
     ...         back_populates="user", lazy="raise_on_sql"
     ...     )
 


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail -->

Fixes #9168

This PR replaces common occurrences of [PEP 585](https://peps.python.org/pep-0585/) style type annotations with annotations compatible with older versions of Python.

I searched for instances of the following supported types from the PEP and replaced with their legacy typing couterparts.

* tuple # typing.Tuple
* list # typing.List
* dict # typing.Dict
* set # typing.Set
* frozenset # typing.FrozenSet
* type # typing.Type

```
grep -r "list\[.*\]" ./build --exclude-dir="./build/venv/*" --exclude-dir="./build/output/*" --exclude="changelog_[0-9]*\.rst"
```

I excluded changelog files from being altered, I think some of these could be changed if necessary but others are likely to require manual checking as the change may target the new typing style specifically.

For any examples that included imports, I tried to ensure that the correct typing imports were included and properly ordered.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

