### PR TITLE
Fix minor documentation glitch, replace "row" with "column"

### DIFF
--- a/doc/build/orm/inheritance.rst
+++ b/doc/build/orm/inheritance.rst
@@ -130,7 +130,7 @@ subclasses introduce a second identity are not supported.
 The ORM uses the value set up by :paramref:`_orm.Mapper.polymorphic_identity` in
 order to determine which class a row belongs towards when loading rows
 polymorphically.  In the example above, every row which represents an
-``Employee`` will have the value ``'employee'`` in its ``type`` row; similarly,
+``Employee`` will have the value ``'employee'`` in its ``type`` column; similarly,
 every ``Engineer`` will get the value ``'engineer'``, and each ``Manager`` will
 get the value ``'manager'``. Regardless of whether the inheritance mapping uses
 distinct joined tables for subclasses as in joined table inheritance, or all


### PR DESCRIPTION
### Description

The documentation that explains the _inheritance_ functionalities, at some point says

```
In the example above, every row which represents an
``Employee`` will have the value ``'employee'`` in its ``type`` row; similarly,
every ``Engineer`` will get the value ``'engineer'``, and each ``Manager`` will
get the value ``'manager'``.
```

but clearly it meant to say `... in its "type" column"` instead.

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
