### PR TITLE
Add 'or' comment between code blocks in Migration docs

### DIFF
--- a/doc/build/changelog/migration_20.rst
+++ b/doc/build/changelog/migration_20.rst
@@ -1522,6 +1522,9 @@ following the table, and may include additional notes not summarized here.
             select(func.count()).
             select_from(User)
           ).one()
+
+          # or
+          
           session.scalars(
             select(func.count(User.id))
           ).one()


### PR DESCRIPTION
### Description
Code block did not have an 'or' comment between 2 different examples. This was in the docs for migration to version 2.0. Under the 2.0 Migration - ORM Usage [section](https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#migration-orm-usage).

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed

**Have a nice day!**
