### PR TITLE
typing: fix hybrid property setter

### DIFF
--- a/lib/sqlalchemy/ext/hybrid.py
+++ b/lib/sqlalchemy/ext/hybrid.py
@@ -764,7 +764,7 @@ class _HybridGetterType(Protocol[_T_co]):
 
 
 class _HybridSetterType(Protocol[_T_con]):
-    def __call__(self, instance: Any, value: _T_con) -> None:
+    def __call__(s, self: Any, value: _T_con) -> None:
         ...
 
 


### PR DESCRIPTION
This fix the mypy error for hybrid_property setter callable

error: Argument 2 to "hybrid_property" has incompatible type "Callable[[MyClass, bool], None]"; expected "Optional[_HybridSetterType[bool]]"  [arg-type])

Fixes #9268


This pull request is:

- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**