### PR TITLE
Fix docs for `case` expression to match new syntax

### DIFF
--- a/lib/sqlalchemy/ext/compiler.py
+++ b/lib/sqlalchemy/ext/compiler.py
@@ -409,7 +409,7 @@ accommodates two arguments::
     @compiles(greatest, 'oracle')
     def case_greatest(element, compiler, **kw):
         arg1, arg2 = list(element.clauses)
-        return compiler.process(case([(arg1 > arg2, arg1)], else_=arg2), **kw)
+        return compiler.process(case((arg1 > arg2, arg1), else_=arg2), **kw)
 
 Example usage::
 

--- a/lib/sqlalchemy/orm/mapper.py
+++ b/lib/sqlalchemy/orm/mapper.py
@@ -565,10 +565,10 @@ class Mapper(
                 discriminator: Mapped[str] = mapped_column(String(50))
 
                 __mapper_args__ = {
-                    "polymorphic_on":case([
+                    "polymorphic_on":case(
                         (discriminator == "EN", "engineer"),
                         (discriminator == "MA", "manager"),
-                    ], else_="employee"),
+                        else_="employee"),
                     "polymorphic_identity":"employee"
                 }
 

--- a/lib/sqlalchemy/sql/_elements_constructors.py
+++ b/lib/sqlalchemy/sql/_elements_constructors.py
@@ -757,10 +757,9 @@ def case(
      .. versionchanged:: 1.4 the :func:`_sql.case`
         function now accepts the series of WHEN conditions positionally
 
-     In the first form, it accepts a list of 2-tuples; each 2-tuple
-     consists of ``(<sql expression>, <value>)``, where the SQL
-     expression is a boolean expression and "value" is a resulting value,
-     e.g.::
+     In the first form, it accepts multiple 2-tuples passed as positional arguments;
+     each 2-tuple consists of ``(<sql expression>, <value>)``, where the SQL expression
+     is a boolean expression and "value" is a resulting value, e.g.::
 
         case(
             (users_table.c.name == 'wendy', 'W'),

--- a/lib/sqlalchemy/sql/_elements_constructors.py
+++ b/lib/sqlalchemy/sql/_elements_constructors.py
@@ -757,9 +757,10 @@ def case(
      .. versionchanged:: 1.4 the :func:`_sql.case`
         function now accepts the series of WHEN conditions positionally
 
-     In the first form, it accepts multiple 2-tuples passed as positional arguments;
-     each 2-tuple consists of ``(<sql expression>, <value>)``, where the SQL expression
-     is a boolean expression and "value" is a resulting value, e.g.::
+     In the first form, it accepts multiple 2-tuples passed as positional
+     arguments; each 2-tuple consists of ``(<sql expression>, <value>)``,
+     where the SQL expression is a boolean expression and "value" is a
+     resulting value, e.g.::
 
         case(
             (users_table.c.name == 'wendy', 'W'),


### PR DESCRIPTION
### Description

Previously (before v1.4), the `whens` arg (when `value` is *not* used) used to be a list of conditions (a 2 item-tuple of condition + value). From v1.4, these are passed as positional args and the old syntax is not supported anymore.

A tiny contribution to this awesome project :)

### Checklist

This pull request is:

- [X] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
