### PR TITLE
Fix grammatical error in intro.rst

### DIFF
--- a/doc/build/intro.rst
+++ b/doc/build/intro.rst
@@ -22,7 +22,7 @@ Core contains the breadth of SQLAlchemy's SQL and database
 integration and description services, the most prominent part of this
 being the **SQL Expression Language**.
 
-The SQL Expression Language is a toolkit all its own, independent of the ORM
+The SQL Expression Language is a toolkit on its own, independent of the ORM
 package, which provides a system of constructing SQL expressions represented by
 composable objects, which can then be "executed" against a target database
 within the scope of a specific transaction, returning a result set.


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
The sentence "The SQL Expression Language is a toolkit all its own." is grammatically wrong.
The sentence should be " The SQL Expression Language is a toolkit all on its own."
### Description
<!-- Describe your changes in detail -->
This grammatical error is located in intro.rst.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ x ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
