### PR TITLE
Declare KEY_OBJECTS_ONLY as cdef variable

### DIFF
--- a/doc/build/changelog/unreleased_20/9343.rst
+++ b/doc/build/changelog/unreleased_20/9343.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: cextensions, performance
+    :tickets: 9343
+
+    Cython cdef optimized variable is used in the resultproxy.pyx file instead of the python global variable ``KEY_OBJECTS_ONLY``.
+    Using the cdef variable allows to avoid Python API calls during comparision yielding slightly faster getattr of the ``BaseRow`` class.

--- a/lib/sqlalchemy/cyextension/resultproxy.pyx
+++ b/lib/sqlalchemy/cyextension/resultproxy.pyx
@@ -3,9 +3,10 @@
 import operator
 
 cdef int MD_INDEX = 0  # integer index in cursor.description
+cdef int _KEY_OBJECTS_ONLY = 1
 
 KEY_INTEGER_ONLY = 0
-KEY_OBJECTS_ONLY = 1
+KEY_OBJECTS_ONLY = _KEY_OBJECTS_ONLY
 
 cdef class BaseRow:
     cdef readonly object _parent
@@ -76,7 +77,7 @@ cdef class BaseRow:
         if mdindex is None:
             self._parent._raise_for_ambiguous_column_name(rec)
         elif (
-            self._key_style == KEY_OBJECTS_ONLY
+            self._key_style == _KEY_OBJECTS_ONLY
             and isinstance(key, int)
         ):
             raise KeyError(key)


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
This PR adds `_KEY_OBJECTS_ONLY` cdef variable to optimize https://github.com/sqlalchemy/sqlalchemy/blob/fc57bafbae9d67b7ce95e26c939ca957c366b0f7/lib/sqlalchemy/cyextension/resultproxy.pyx#L79

main branch:
![image](https://user-images.githubusercontent.com/827060/220473698-84599ffa-6619-4867-8b84-ade883656b99.png)
pr:
![image](https://user-images.githubusercontent.com/827060/220473737-feaa2b80-9762-4ccd-824c-1f885a49b15a.png)


Fixes #9343

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
