### PR TITLE
Allow None as default values for MutableDict

### DIFF
--- a/lib/sqlalchemy/ext/mutable.py
+++ b/lib/sqlalchemy/ext/mutable.py
@@ -389,10 +389,13 @@ from ..orm.context import QueryContext
 from ..orm.decl_api import DeclarativeAttributeIntercept
 from ..orm.state import InstanceState
 from ..orm.unitofwork import UOWTransaction
+from ..sql.base import _NoArg
+from ..sql.base import NO_ARG
 from ..sql.base import SchemaEventTarget
 from ..sql.schema import Column
 from ..sql.type_api import TypeEngine
 from ..util import memoized_property
+from ..util.typing import Literal
 from ..util.typing import SupportsIndex
 from ..util.typing import TypeGuard
 
@@ -781,8 +784,10 @@ class MutableDict(Mutable, Dict[_KT, _VT]):
         super().__setitem__(key, value)
         self.changed()
 
-    def _exists(self, value: _T | None) -> TypeGuard[_T]:
-        return value is not None
+    def _exists(
+        self, value: _T | None | Literal[_NoArg.NO_ARG]
+    ) -> TypeGuard[_T]:
+        return value is not NO_ARG
 
     def _is_none(self, value: _T | None) -> TypeGuard[None]:
         return value is None
@@ -795,7 +800,9 @@ class MutableDict(Mutable, Dict[_KT, _VT]):
     def setdefault(self, key: _KT, value: _VT) -> _VT:
         ...
 
-    def setdefault(self, key: _KT, value: _VT | None = None) -> _VT | None:
+    def setdefault(
+        self, key: _KT, value: _VT | None | Literal[_NoArg.NO_ARG] = NO_ARG
+    ) -> _VT | None:
         if self._exists(value):
             result = super().setdefault(key, value)
         else:
@@ -820,7 +827,11 @@ class MutableDict(Mutable, Dict[_KT, _VT]):
     def pop(self, __key: _KT, __default: _VT | _T) -> _VT | _T:
         ...
 
-    def pop(self, __key: _KT, __default: _VT | _T | None = None) -> _VT | _T:
+    def pop(
+        self,
+        __key: _KT,
+        __default: _VT | _T | None | Literal[_NoArg.NO_ARG] = NO_ARG,
+    ) -> _VT | _T:
         if self._exists(__default):
             result = super().pop(__key, __default)
         else:

--- a/lib/sqlalchemy/ext/mutable.py
+++ b/lib/sqlalchemy/ext/mutable.py
@@ -789,9 +789,6 @@ class MutableDict(Mutable, Dict[_KT, _VT]):
     ) -> TypeGuard[_T]:
         return value is not NO_ARG
 
-    def _is_none(self, value: _T | None) -> TypeGuard[None]:
-        return value is None
-
     @overload
     def setdefault(self, key: _KT) -> _VT | None:
         ...

--- a/test/ext/test_mutable.py
+++ b/test/ext/test_mutable.py
@@ -349,6 +349,19 @@ class _MutableDictTestBase(_MutableDictTestFixture):
 
         eq_(f1.data, {"c": "d"})
 
+    def test_pop_default_none(self):
+        sess = fixture_session()
+
+        f1 = Foo(data={"a": "b", "c": "d"})
+        sess.add(f1)
+        sess.commit()
+
+        eq_(f1.data.pop("a", None), "b")
+        eq_(f1.data.pop("a", None), None)
+        sess.commit()
+
+        eq_(f1.data, {"c": "d"})
+
     def test_popitem(self):
         sess = fixture_session()
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

Previously, e.g. `MutableDict.pop(..., None)` wouldn’t return `None` if the key doesn’t exist. This worked in versions 1.4.x.

### Description
<!-- Describe your changes in detail -->

`MutableDict._exists()` uses `None` as a sentinel to check if callers specified a default value or not. However, this doesn’t work if `None` is desired as the default value and the specified key doesn’t exist.

Additionally, this PR removes the unused `MutableDict._is_none()` method.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix for issue #9380 
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
