### PR TITLE
Fix Typo In Tutorial

### DIFF
--- a/doc/build/tutorial/metadata.rst
+++ b/doc/build/tutorial/metadata.rst
@@ -40,7 +40,7 @@ Setting up MetaData with Table objects
 ---------------------------------------
 
 When we work with a relational database, the basic data-holding structure
-in the database which we query from is known a **table**.
+in the database which we query from is known as a **table**.
 In SQLAlchemy, the database "table" is ultimately represented
 by a Python object similarly named :class:`_schema.Table`.
 


### PR DESCRIPTION
Missing a word on the page `Working with Database Metadata`.
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
First paragraph under section: 'Setting up MetaData with Table objects'.
"...the database which we query from is know [as] a table."

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
