### PR TITLE
MyPy extention: Support for setters - Handling functions defined in SQLAlchemy classes

### DIFF
--- a/lib/sqlalchemy/ext/mypy/decl_class.py
+++ b/lib/sqlalchemy/ext/mypy/decl_class.py
@@ -15,6 +15,7 @@ from mypy.nodes import AssignmentStmt
 from mypy.nodes import CallExpr
 from mypy.nodes import ClassDef
 from mypy.nodes import Decorator
+from mypy.nodes import FuncDef
 from mypy.nodes import LambdaExpr
 from mypy.nodes import ListExpr
 from mypy.nodes import MemberExpr
@@ -381,6 +382,8 @@ def _scan_declarative_assignment_stmt(
     node = sym.node
 
     if isinstance(node, PlaceholderNode):
+        return
+    if isinstance(node, FuncDef):
         return
 
     assert node is lvalue.node


### PR DESCRIPTION

### Description

When trying to run MyPy with SQLAlchemy plugin, I got the following stacktrace when running with "--show-traceback":

```
    /home/somewhere/someproject/models.py:82: error: INTERNAL ERROR -- Please try using mypy master on GitHub:
    https://mypy.readthedocs.io/en/stable/common_issues.html#using-a-development-mypy-build
    Please report a bug at https://github.com/python/mypy/issues
    version: 0.991
    Traceback (most recent call last):
      File "mypy/semanal.py", line 6047, in accept
      File "mypy/nodes.py", line 1143, in accept
      File "mypy/semanal.py", line 1435, in visit_class_def
      File "mypy/semanal.py", line 1511, in analyze_class
      File "mypy/semanal.py", line 1538, in analyze_class_body_common
      File "mypy/semanal.py", line 1616, in apply_class_plugin_hooks
      File "/home/somewhere/.cache/pypoetry/virtualenvs/env-name-py3.11/lib/python3.11/site-packages/sqlalchemy/ext/mypy/plugin.py", line 258, in _base_cls_hook
        decl_class.scan_declarative_assignments_and_apply_types(ctx.cls, ctx.api)
      File "/home/somewhere/.cache/pypoetry/virtualenvs/env-name-py3.11/lib/python3.11/site-packages/sqlalchemy/ext/mypy/decl_class.py", line 96, in scan_declarative_assignments_and_apply_types
        _scan_declarative_assignment_stmt(
      File "/home/somewhere/.cache/pypoetry/virtualenvs/env-name-py3.11/lib/python3.11/site-packages/sqlalchemy/ext/mypy/decl_class.py", line 386, in _scan_declarative_assignment_stmt
        assert isinstance(node, Var)
    AssertionError:
    /home/somewhere/someproject/models.py:82: : note: use --pdb to drop into pdb
```

The code at line 82 is

```
    # setter that sets a value automatically based on another field
    def account_number(self, account_number):
        self.previous_account_number = account_number - 1
```

Checking if node is mypy.nodes.FuncDef fixes the issue.


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
