### PR TITLE
Fix the count example in ORM migration doc

### DIFF
--- a/doc/build/changelog/migration_20.rst
+++ b/doc/build/changelog/migration_20.rst
@@ -1518,16 +1518,16 @@ following the table, and may include additional notes not summarized here.
 
       - ::
 
-          session.scalars(
+          session.scalar(
             select(func.count()).
             select_from(User)
-          ).one()
+          )
 
           # or
           
-          session.scalars(
+          session.scalar(
             select(func.count(User.id))
-          ).one()
+          )
 
       - :meth:`_orm.Session.scalar`
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Based on the ref method (`_orm.Session.scalar`), I think the count example should use `session.scalar` instead of `session.scalars().one()`. And the former usage is shorter.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
