### PR TITLE
Add override hook PGDialect.set_backslash_escapes()

### DIFF
--- a/doc/build/changelog/unreleased_20/9442.rst
+++ b/doc/build/changelog/unreleased_20/9442.rst
@@ -1,0 +1,7 @@
+.. change::
+      :tags: usecase, postgresql
+      :tickets: 9442
+
+      Modifications to the base PostgreSQL dialect to allow for better integration with the
+      sqlalchemy-redshift third party dialect for SQLAlchemy 2.0. Pull request courtesy
+      matthewgdv.

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3030,16 +3030,21 @@ class PGDialect(default.DefaultDialect):
         # https://www.postgresql.org/docs/9.3/static/release-9-2.html#AEN116689
         self.supports_smallserial = self.server_version_info >= (9, 2)
 
-        std_string = connection.exec_driver_sql(
-            "show standard_conforming_strings"
-        ).scalar()
-        self._backslash_escapes = std_string == "off"
+        self.set_backslash_escapes()
 
         self._supports_drop_index_concurrently = self.server_version_info >= (
             9,
             2,
         )
         self.supports_identity_columns = self.server_version_info >= (10,)
+
+    def set_backslash_escapes(self):
+        # this method is provided as an override hook for descendant
+        # dialects (e.g. Redshift), so removing it may break them
+        std_string = connection.exec_driver_sql(
+            "show standard_conforming_strings"
+        ).scalar()
+        self._backslash_escapes = std_string == "off"
 
     def get_isolation_level_values(self, dbapi_conn):
         # note the generic dialect doesn't have AUTOCOMMIT, however

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3030,21 +3030,13 @@ class PGDialect(default.DefaultDialect):
         # https://www.postgresql.org/docs/9.3/static/release-9-2.html#AEN116689
         self.supports_smallserial = self.server_version_info >= (9, 2)
 
-        self.set_backslash_escapes()
+        self._set_backslash_escapes(connection)
 
         self._supports_drop_index_concurrently = self.server_version_info >= (
             9,
             2,
         )
         self.supports_identity_columns = self.server_version_info >= (10,)
-
-    def set_backslash_escapes(self):
-        # this method is provided as an override hook for descendant
-        # dialects (e.g. Redshift), so removing it may break them
-        std_string = connection.exec_driver_sql(
-            "show standard_conforming_strings"
-        ).scalar()
-        self._backslash_escapes = std_string == "off"
 
     def get_isolation_level_values(self, dbapi_conn):
         # note the generic dialect doesn't have AUTOCOMMIT, however
@@ -4704,3 +4696,11 @@ class PGDialect(default.DefaultDialect):
             domains.append(domain_rec)
 
         return domains
+
+    def _set_backslash_escapes(self, connection):
+        # this method is provided as an override hook for descendant
+        # dialects (e.g. Redshift), so removing it may break them
+        std_string = connection.exec_driver_sql(
+            "show standard_conforming_strings"
+        ).scalar()
+        self._backslash_escapes = std_string == "off"


### PR DESCRIPTION
### Description
Refactor out the lines in `PGDialect.initialize()` that set backslash escapes into their own method to provide an override hook for [`sqlalchemy-redshift`](https://github.com/sqlalchemy-redshift/sqlalchemy-redshift) to use.

Fixes #9442

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.
