### PR TITLE
Change hash implementation for `_sql.custom_op`

### DIFF
--- a/doc/build/changelog/unreleased_20/9506.rst
+++ b/doc/build/changelog/unreleased_20/9506.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: bug, sql
+    :tickets: 9506
+
+    Change hash implementation for :class:`_sql.custom_op`.
+    Pull request courtesy Yurii Karabas.

--- a/lib/sqlalchemy/sql/operators.py
+++ b/lib/sqlalchemy/sql/operators.py
@@ -418,7 +418,17 @@ class custom_op(OperatorType, Generic[_T]):
         return isinstance(other, custom_op) and other.opstring == self.opstring
 
     def __hash__(self) -> int:
-        return id(self)
+        return hash(
+            (
+                self.opstring,
+                self.precedence,
+                self.is_comparison,
+                self.natural_self_precedent,
+                self.eager_grouping,
+                self.return_type,
+                self.python_impl,
+            )
+        )
 
     def __call__(
         self,

--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -4255,6 +4255,15 @@ class CustomOpTest(fixtures.TestBase):
         ):
             op1(3, 5)
 
+    def test_hash(self):
+        c1 = column("x")
+        c2 = column("y")
+
+        op1 = c1.op("+")(c2).operator
+        op2 = c1.op("+")(c2).operator
+
+        assert hash(op1) == hash(op2)
+
 
 class TupleTypingTest(fixtures.TestBase):
     def _assert_types(self, expr):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
Fixes: #9506 
### Description
<!-- Describe your changes in detail -->
Change hash implementation for `_sql.custom_op`.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

