### PR TITLE
docs: 📚 fix duplicate word typo in tutorial/metadata

### DIFF
--- a/doc/build/tutorial/metadata.rst
+++ b/doc/build/tutorial/metadata.rst
@@ -205,7 +205,7 @@ In the next section we will emit the completed DDL for the ``user`` and
 Emitting DDL to the Database
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We've constructed a an object structure that represents
+We've constructed an object structure that represents
 two database tables in a database, starting at the root :class:`_schema.MetaData`
 object, then into two :class:`_schema.Table` objects, each of which hold
 onto a collection of :class:`_schema.Column` and :class:`_schema.Constraint`


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
I have removed a duplicate word from the metadata section of the tutorial, thereby fixing the sentence. I hope creating a PR for this is not too silly, however the nice words in the contributing guidelines encouraged me to submit it.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
