### PR TITLE
Fix type annotation of schema.MetaData.naming_convention

### DIFF
--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -5108,7 +5108,7 @@ class MetaData(HasSchemaAttr):
         self,
         schema: Optional[str] = None,
         quote_schema: Optional[bool] = None,
-        naming_convention: Optional[Dict[str, str]] = None,
+        naming_convention: Optional[Dict[str, str | Callable[Constraint, Table]]] = None,
         info: Optional[_InfoType] = None,
     ) -> None:
         """Create a new MetaData object.


### PR DESCRIPTION
According to the documentation, we should be able to use `Callable[Constraint, Table]]` as the value type for MetaData.naming_convention.

https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.MetaData.params.naming_convention

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description


I'm always using sqlalchemy just fine, Thank you! :)

Found and corrected the difference between the document and the type annotation.
https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.MetaData.params.naming_convention


So, I made the following changes on [sqlalchemy/sql/schema.py:5111](https://github.com/sqlalchemy/sqlalchemy/blob/main/lib/sqlalchemy/sql/schema.py#L5111)
```py
# As-is
naming_convention: Optional[Dict[str, str]] = None

# To-be
naming_convention: Optional[Dict[str, str | Callable[Constraint, Table]]] = None
```


Fixed #9600 


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
