### PR TITLE
Fix typos in PostgreSQL dialect’s DOMAIN docs

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/named_types.py
+++ b/lib/sqlalchemy/dialects/postgresql/named_types.py
@@ -374,11 +374,11 @@ class DOMAIN(NamedType, sqltypes.SchemaType):
     A domain is essentially a data type with optional constraints
     that restrict the allowed set of values. E.g.::
 
-        PositiveInt = Domain(
+        PositiveInt = DOMAIN(
             "pos_int", Integer, check="VALUE > 0", not_null=True
         )
 
-        UsPostalCode = Domain(
+        UsPostalCode = DOMAIN(
             "us_postal_code",
             Text,
             check="VALUE ~ '^\d{5}$' OR VALUE ~ '^\d{5}-\d{4}$'"


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Fix typos in PostgreSQL DOMAIN docs, see issue https://github.com/sqlalchemy/sqlalchemy/issues/9599.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
