### PR TITLE
Fix docs for `Column.default` (in PyCharm)

### DIFF
--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -1613,12 +1613,11 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_T]):
             "fast insertmany" feature.  Such features are very new and
             may not yet be well covered in documentation.
 
-        :param default: A scalar, Python callable, or
-            :class:`_expression.ColumnElement` expression representing the
-            *default value* for this column, which will be invoked upon insert
-            if this column is otherwise not specified in the VALUES clause of
-            the insert. This is a shortcut to using :class:`.ColumnDefault` as
-            a positional argument; see that class for full detail on the
+        :param default: A scalar, Python callable, or :class:`_expression.ColumnElement`
+            expression representing the *default value* for this column, 
+            which will be invoked upon insert if this column is otherwise not specified
+            in the VALUES clause of the insert. This is a shortcut to using :class:`.ColumnDefault`
+            as a positional argument; see that class for full detail on the
             structure of the argument.
 
             Contrast this argument to


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

In PyCharm there is a problem with displaying the docs when a new line starts with `:class:` or any word that is not standard text.

This is how it looked before the fix:

![image](https://user-images.githubusercontent.com/42866208/230603196-c8387375-88a1-4076-a1ef-a60eef25ab17.png)

And after:
![image](https://user-images.githubusercontent.com/42866208/230603002-31126fc2-e2b7-406d-a244-1557daa81ec5.png)

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
