### PR TITLE
Fix incorrect literal value in tutorial documentation

### DIFF
--- a/doc/build/tutorial/data_select.rst
+++ b/doc/build/tutorial/data_select.rst
@@ -274,7 +274,7 @@ SQL that's quicker to write literally.
 The :func:`_sql.text` construct introduced at
 :ref:`tutorial_working_with_transactions` can in fact be embedded into a
 :class:`_sql.Select` construct directly, such as below where we manufacture
-a hardcoded string literal ``'some label'`` and embed it within the
+a hardcoded string literal ``'some phrase'`` and embed it within the
 SELECT statement::
 
   >>> from sqlalchemy import text


### PR DESCRIPTION
In the [Selecting with Textual Column Expressions](https://docs.sqlalchemy.org/en/20/tutorial/data_select.html#setting-the-columns-and-from-clause) I noticed the example and the description text differ.

### Description

The explanation text uses `some label`:
>  such as below where we manufacture a hardcoded string literal 'some label'

But the example uses `some phrase` instead

```python
>>> from sqlalchemy import text
>>> stmt = select(text("'some phrase'"),
```

Please ignore if I'm reading this wrong.


### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
