### PR TITLE
Prebuild the row string to position lookup for Rows

### DIFF
--- a/lib/sqlalchemy/cyextension/collections.pyx
+++ b/lib/sqlalchemy/cyextension/collections.pyx
@@ -1,5 +1,4 @@
 cimport cython
-from cpython.dict cimport PyDict_Merge, PyDict_Update
 from cpython.long cimport PyLong_FromLongLong
 from cpython.set cimport PySet_Add
 

--- a/lib/sqlalchemy/engine/_py_row.py
+++ b/lib/sqlalchemy/engine/_py_row.py
@@ -93,7 +93,7 @@ class BaseRow:
     if not typing.TYPE_CHECKING:
         __getitem__ = _get_by_int_impl
 
-    def _get_by_key_impl_mapping(self, key):
+    def _get_by_key_impl_mapping(self, key: str) -> Any:
         cached_index = self._keymap_by_str.get(key, _MISSING_SENTINEL)
         if cached_index is not _MISSING_SENTINEL and cached_index is not None:
             return self._data[cached_index]

--- a/lib/sqlalchemy/engine/cursor.py
+++ b/lib/sqlalchemy/engine/cursor.py
@@ -149,7 +149,8 @@ class CursorResultMetaData(ResultMetaData):
         "_tuplefilter",
         "_translated_indexes",
         "_safe_for_cache",
-        "_unpickled"
+        "_unpickled",
+        "_name_cache"
         # don't need _unique_filters support here for now.  Can be added
         # if a need arises.
     )
@@ -193,6 +194,7 @@ class CursorResultMetaData(ResultMetaData):
         new_obj._translated_indexes = translated_indexes
         new_obj._safe_for_cache = safe_for_cache
         new_obj._keymap_by_result_column_idx = keymap_by_result_column_idx
+        new_obj._name_cache = {}
         return new_obj
 
     def _remove_processors(self) -> CursorResultMetaData:
@@ -490,6 +492,8 @@ class CursorResultMetaData(ResultMetaData):
                     if metadata_entry[MD_UNTRANSLATED]
                 }
             )
+
+        self._name_cache = {}
 
     def _merge_cursor_description(
         self,
@@ -921,6 +925,7 @@ class CursorResultMetaData(ResultMetaData):
         self._keymap = state["_keymap"]
 
         self._keymap_by_result_column_idx = None
+        self._name_cache = {}
         self._keys = state["_keys"]
         self._unpickled = True
         if state["_translated_indexes"]:

--- a/lib/sqlalchemy/engine/cursor.py
+++ b/lib/sqlalchemy/engine/cursor.py
@@ -150,7 +150,7 @@ class CursorResultMetaData(ResultMetaData):
         "_translated_indexes",
         "_safe_for_cache",
         "_unpickled",
-        "_name_cache"
+        "_keymap_by_str"
         # don't need _unique_filters support here for now.  Can be added
         # if a need arises.
     )
@@ -184,6 +184,7 @@ class CursorResultMetaData(ResultMetaData):
         translated_indexes: Optional[List[int]],
         safe_for_cache: bool,
         keymap_by_result_column_idx: Any,
+        keymap_by_str: Dict[_KeyType, _KeyMapRecType],
     ) -> CursorResultMetaData:
         new_obj = self.__class__.__new__(self.__class__)
         new_obj._unpickled = unpickled
@@ -194,23 +195,26 @@ class CursorResultMetaData(ResultMetaData):
         new_obj._translated_indexes = translated_indexes
         new_obj._safe_for_cache = safe_for_cache
         new_obj._keymap_by_result_column_idx = keymap_by_result_column_idx
-        new_obj._name_cache = {}
+        new_obj._keymap_by_str = keymap_by_str
         return new_obj
 
     def _remove_processors(self) -> CursorResultMetaData:
         assert not self._tuplefilter
+        keymap = {
+            key: value[0:5] + (None,) + value[6:]
+            for key, value in self._keymap.items()
+        }
+        keymap_by_str = {key: rec[MD_INDEX] for key, rec in keymap.items()}
         return self._make_new_metadata(
             unpickled=self._unpickled,
             processors=[None] * len(self._processors),
             tuplefilter=None,
             translated_indexes=None,
-            keymap={
-                key: value[0:5] + (None,) + value[6:]
-                for key, value in self._keymap.items()
-            },
+            keymap=keymap,
             keys=self._keys,
             safe_for_cache=self._safe_for_cache,
             keymap_by_result_column_idx=self._keymap_by_result_column_idx,
+            keymap_by_str=keymap_by_str,
         )
 
     def _splice_horizontally(
@@ -234,7 +238,7 @@ class CursorResultMetaData(ResultMetaData):
                 for key, value in other._keymap.items()
             }
         )
-
+        keymap_by_str = {key: rec[MD_INDEX] for key, rec in keymap.items()}
         return self._make_new_metadata(
             unpickled=self._unpickled,
             processors=self._processors + other._processors,  # type: ignore
@@ -247,6 +251,7 @@ class CursorResultMetaData(ResultMetaData):
                 metadata_entry[MD_RESULT_MAP_INDEX]: metadata_entry
                 for metadata_entry in keymap.values()
             },
+            keymap_by_str=keymap_by_str,
         )
 
     def _reduce(self, keys: Sequence[_KeyIndexType]) -> ResultMetaData:
@@ -269,6 +274,7 @@ class CursorResultMetaData(ResultMetaData):
             for new_rec in new_recs
             for e in new_rec[MD_OBJECTS] or ()
         )
+        keymap_by_str = {key: rec[MD_INDEX] for key, rec in keymap.items()}
 
         return self._make_new_metadata(
             unpickled=self._unpickled,
@@ -279,6 +285,7 @@ class CursorResultMetaData(ResultMetaData):
             keymap=keymap,
             safe_for_cache=self._safe_for_cache,
             keymap_by_result_column_idx=self._keymap_by_result_column_idx,
+            keymap_by_str=keymap_by_str,
         )
 
     def _adapt_to_context(self, context: ExecutionContext) -> ResultMetaData:
@@ -323,17 +330,19 @@ class CursorResultMetaData(ResultMetaData):
             }
 
         assert not self._tuplefilter
+        keymap = compat.dict_union(
+            self._keymap,
+            {
+                new: keymap_by_position[idx]
+                for idx, new in enumerate(
+                    invoked_statement._all_selected_columns
+                )
+                if idx in keymap_by_position
+            },
+        )
+        keymap_by_str = {key: rec[MD_INDEX] for key, rec in keymap.items()}
         return self._make_new_metadata(
-            keymap=compat.dict_union(
-                self._keymap,
-                {
-                    new: keymap_by_position[idx]
-                    for idx, new in enumerate(
-                        invoked_statement._all_selected_columns
-                    )
-                    if idx in keymap_by_position
-                },
-            ),
+            keymap=keymap,
             unpickled=self._unpickled,
             processors=self._processors,
             tuplefilter=None,
@@ -341,6 +350,7 @@ class CursorResultMetaData(ResultMetaData):
             keys=self._keys,
             safe_for_cache=self._safe_for_cache,
             keymap_by_result_column_idx=self._keymap_by_result_column_idx,
+            keymap_by_str=keymap_by_str,
         )
 
     def __init__(
@@ -493,7 +503,9 @@ class CursorResultMetaData(ResultMetaData):
                 }
             )
 
-        self._name_cache = {}
+        self._keymap_by_str = {
+            key: rec[MD_INDEX] for key, rec in self._keymap.items()
+        }
 
     def _merge_cursor_description(
         self,
@@ -902,19 +914,23 @@ class CursorResultMetaData(ResultMetaData):
 
     def __getstate__(self):
         # TODO: consider serializing this as SimpleResultMetaData
+        keymap = {
+            key: (
+                rec[MD_INDEX],
+                rec[MD_RESULT_MAP_INDEX],
+                [],
+                key,
+                rec[MD_RENDERED_NAME],
+                None,
+                None,
+            )
+            for key, rec in self._keymap.items()
+            if isinstance(key, (str, int))
+        }
         return {
-            "_keymap": {
-                key: (
-                    rec[MD_INDEX],
-                    rec[MD_RESULT_MAP_INDEX],
-                    [],
-                    key,
-                    rec[MD_RENDERED_NAME],
-                    None,
-                    None,
-                )
-                for key, rec in self._keymap.items()
-                if isinstance(key, (str, int))
+            "_keymap": keymap,
+            "_keymap_by_str": {
+                key: rec[MD_INDEX] for key, rec in keymap.items()
             },
             "_keys": self._keys,
             "_translated_indexes": self._translated_indexes,
@@ -923,9 +939,8 @@ class CursorResultMetaData(ResultMetaData):
     def __setstate__(self, state):
         self._processors = [None for _ in range(len(state["_keys"]))]
         self._keymap = state["_keymap"]
-
         self._keymap_by_result_column_idx = None
-        self._name_cache = {}
+        self._keymap_by_str = state["_keymap_by_str"]
         self._keys = state["_keys"]
         self._unpickled = True
         if state["_translated_indexes"]:
@@ -1376,6 +1391,14 @@ class _NoResultMetaData(ResultMetaData):
         self._we_dont_return_rows()
 
     @property
+    def _keymap_by_str(self):
+        self._we_dont_return_rows()
+
+    @property
+    def _processors(self):
+        self._we_dont_return_rows()
+
+    @property
     def keys(self):
         self._we_dont_return_rows()
 
@@ -1463,13 +1486,9 @@ class CursorResult(Result[_T]):
 
             metadata = self._init_metadata(context, cursor_description)
 
-            keymap = metadata._keymap
             processors = metadata._processors
             process_row = Row
-            key_style = process_row._default_key_style
-            _make_row = functools.partial(
-                process_row, metadata, processors, keymap, key_style
-            )
+            _make_row = functools.partial(process_row, metadata, processors)
             if log_row:
 
                 def _make_row_2(row):

--- a/lib/sqlalchemy/engine/cursor.py
+++ b/lib/sqlalchemy/engine/cursor.py
@@ -914,7 +914,7 @@ class CursorResultMetaData(ResultMetaData):
 
     def __getstate__(self):
         # TODO: consider serializing this as SimpleResultMetaData
-        keymap = {
+        keymap: _CursorKeyMapType = {
             key: (
                 rec[MD_INDEX],
                 rec[MD_RESULT_MAP_INDEX],

--- a/lib/sqlalchemy/engine/cursor.py
+++ b/lib/sqlalchemy/engine/cursor.py
@@ -24,7 +24,6 @@ from typing import List
 from typing import Mapping
 from typing import NoReturn
 from typing import Optional
-from typing import overload
 from typing import Sequence
 from typing import Tuple
 from typing import TYPE_CHECKING
@@ -811,41 +810,25 @@ class CursorResultMetaData(ResultMetaData):
                 untranslated,
             )
 
-    @overload
-    def _key_fallback(
-        self, key: Any, err: Exception, raiseerr: Literal[True] = ...
-    ) -> NoReturn:
-        ...
+    if not TYPE_CHECKING:
 
-    @overload
-    def _key_fallback(
-        self, key: Any, err: Exception, raiseerr: Literal[False] = ...
-    ) -> None:
-        ...
+        def _key_fallback(
+            self, key: Any, err: Optional[Exception], raiseerr: bool = True
+        ) -> Optional[NoReturn]:
 
-    @overload
-    def _key_fallback(
-        self, key: Any, err: Exception, raiseerr: bool = ...
-    ) -> Optional[NoReturn]:
-        ...
-
-    def _key_fallback(
-        self, key: Any, err: Exception, raiseerr: bool = True
-    ) -> Optional[NoReturn]:
-
-        if raiseerr:
-            if self._unpickled and isinstance(key, elements.ColumnElement):
-                raise exc.NoSuchColumnError(
-                    "Row was unpickled; lookup by ColumnElement "
-                    "is unsupported"
-                ) from err
+            if raiseerr:
+                if self._unpickled and isinstance(key, elements.ColumnElement):
+                    raise exc.NoSuchColumnError(
+                        "Row was unpickled; lookup by ColumnElement "
+                        "is unsupported"
+                    ) from err
+                else:
+                    raise exc.NoSuchColumnError(
+                        "Could not locate column in row for column '%s'"
+                        % util.string_or_unprintable(key)
+                    ) from err
             else:
-                raise exc.NoSuchColumnError(
-                    "Could not locate column in row for column '%s'"
-                    % util.string_or_unprintable(key)
-                ) from err
-        else:
-            return None
+                return None
 
     def _raise_for_ambiguous_column_name(self, rec):
         raise exc.InvalidRequestError(

--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -99,7 +99,7 @@ class ResultMetaData:
     _keymap: _KeyMapType
     _keys: Sequence[str]
     _processors: Optional[_ProcessorsType]
-    _name_cache: Dict[_KeyType, _KeyMapRecType]
+    _keymap_by_str: Dict[_KeyType, _KeyMapRecType]
 
     @property
     def keys(self) -> RMKeyView:
@@ -223,7 +223,7 @@ class SimpleResultMetaData(ResultMetaData):
         "_tuplefilter",
         "_translated_indexes",
         "_unique_filters",
-        "_name_cache",
+        "_keymap_by_str",
     )
 
     _keys: Sequence[str]
@@ -259,7 +259,9 @@ class SimpleResultMetaData(ResultMetaData):
 
         self._processors = _processors
 
-        self._name_cache = {}
+        self._keymap_by_str = {
+            key: rec[0] for key, rec in self._keymap.items()
+        }
 
     def _has_key(self, key: object) -> bool:
         return key in self._keymap
@@ -362,9 +364,7 @@ def result_tuple(
     fields: Sequence[str], extra: Optional[Any] = None
 ) -> Callable[[Iterable[Any]], Row[Any]]:
     parent = SimpleResultMetaData(fields, extra)
-    return functools.partial(
-        Row, parent, parent._processors, parent._keymap, Row._default_key_style
-    )
+    return functools.partial(Row, parent, parent._processors)
 
 
 # a symbol that indicates to internal Result methods that
@@ -428,21 +428,15 @@ class ResultInternal(InPlaceGenerative, Generic[_R]):
                 def process_row(  # type: ignore
                     metadata: ResultMetaData,
                     processors: _ProcessorsType,
-                    keymap: _KeyMapType,
-                    key_style: Any,
                     scalar_obj: Any,
                 ) -> Row[Any]:
-                    return _proc(
-                        metadata, processors, keymap, key_style, (scalar_obj,)
-                    )
+                    return _proc(metadata, processors, (scalar_obj,))
 
         else:
             process_row = Row  # type: ignore
 
-        key_style = Row._default_key_style
         metadata = self._metadata
 
-        keymap = metadata._keymap
         processors = metadata._processors
         tf = metadata._tuplefilter
 
@@ -451,7 +445,7 @@ class ResultInternal(InPlaceGenerative, Generic[_R]):
                 processors = tf(processors)
 
             _make_row_orig: Callable[..., _R] = functools.partial(  # type: ignore  # noqa E501
-                process_row, metadata, processors, keymap, key_style
+                process_row, metadata, processors
             )
 
             fixed_tf = tf
@@ -461,7 +455,7 @@ class ResultInternal(InPlaceGenerative, Generic[_R]):
 
         else:
             make_row = functools.partial(  # type: ignore
-                process_row, metadata, processors, keymap, key_style
+                process_row, metadata, processors
             )
 
         fns: Tuple[Any, ...] = ()

--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -99,6 +99,7 @@ class ResultMetaData:
     _keymap: _KeyMapType
     _keys: Sequence[str]
     _processors: Optional[_ProcessorsType]
+    _name_cache: Dict[_KeyType, _KeyMapRecType]
 
     @property
     def keys(self) -> RMKeyView:
@@ -222,6 +223,7 @@ class SimpleResultMetaData(ResultMetaData):
         "_tuplefilter",
         "_translated_indexes",
         "_unique_filters",
+        "_name_cache",
     )
 
     _keys: Sequence[str]
@@ -256,6 +258,8 @@ class SimpleResultMetaData(ResultMetaData):
         self._keymap = {key: rec for keys, rec in recs_names for key in keys}
 
         self._processors = _processors
+
+        self._name_cache = {}
 
     def _has_key(self, key: object) -> bool:
         return key in self._keymap

--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -120,7 +120,10 @@ class ResultMetaData:
 
     @overload
     def _key_fallback(
-        self, key: Any, err: Optional[Exception], raiseerr: Literal[False] = ...
+        self,
+        key: Any,
+        err: Optional[Exception],
+        raiseerr: Literal[False] = ...,
     ) -> None:
         ...
 
@@ -198,7 +201,7 @@ class ResultMetaData:
                 try:
                     self._key_fallback(key, None)
                 except KeyError as ke:
-                    raise AttributeError(key) from ke
+                    raise AttributeError(ke.args[0]) from ke
             else:
                 self._key_fallback(key, None)
 

--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -114,24 +114,24 @@ class ResultMetaData:
 
     @overload
     def _key_fallback(
-        self, key: Any, err: Exception, raiseerr: Literal[True] = ...
+        self, key: Any, err: Optional[Exception], raiseerr: Literal[True] = ...
     ) -> NoReturn:
         ...
 
     @overload
     def _key_fallback(
-        self, key: Any, err: Exception, raiseerr: Literal[False] = ...
+        self, key: Any, err: Optional[Exception], raiseerr: Literal[False] = ...
     ) -> None:
         ...
 
     @overload
     def _key_fallback(
-        self, key: Any, err: Exception, raiseerr: bool = ...
+        self, key: Any, err: Optional[Exception], raiseerr: bool = ...
     ) -> Optional[NoReturn]:
         ...
 
     def _key_fallback(
-        self, key: Any, err: Exception, raiseerr: bool = True
+        self, key: Any, err: Optional[Exception], raiseerr: bool = True
     ) -> Optional[NoReturn]:
         assert raiseerr
         raise KeyError(key) from err
@@ -191,16 +191,16 @@ class ResultMetaData:
     def _key_not_found(self, key: Any, attr_error: bool) -> NoReturn:
         if key in self._keymap:
             # the index must be none in this case
-            if attr_error:
-                try:
-                    self._key_fallback(key, KeyError(key))
-                except KeyError as ke:
-                    raise AttributeError(ke.args[0]) from ke
-            else:
-                self._key_fallback(key, KeyError(key))
+            self._raise_for_ambiguous_column_name(self._keymap[key])
         else:
             # unknown key
-            self._raise_for_ambiguous_column_name(self._keymap[key])
+            if attr_error:
+                try:
+                    self._key_fallback(key, None)
+                except KeyError as ke:
+                    raise AttributeError(key) from ke
+            else:
+                self._key_fallback(key, None)
 
 
 class RMKeyView(typing.KeysView[Any]):

--- a/lib/sqlalchemy/engine/row.py
+++ b/lib/sqlalchemy/engine/row.py
@@ -34,12 +34,8 @@ from ..util._has_cy import HAS_CYEXTENSION
 
 if TYPE_CHECKING or not HAS_CYEXTENSION:
     from ._py_row import BaseRow as BaseRow
-    from ._py_row import KEY_INTEGER_ONLY
-    from ._py_row import KEY_OBJECTS_ONLY
 else:
     from sqlalchemy.cyextension.resultproxy import BaseRow as BaseRow
-    from sqlalchemy.cyextension.resultproxy import KEY_INTEGER_ONLY
-    from sqlalchemy.cyextension.resultproxy import KEY_OBJECTS_ONLY
 
 if TYPE_CHECKING:
     from .result import _KeyType
@@ -79,8 +75,6 @@ class Row(BaseRow, Sequence[Any], Generic[_TP]):
     """
 
     __slots__ = ()
-
-    _default_key_style = KEY_INTEGER_ONLY
 
     def __setattr__(self, name: str, value: Any) -> NoReturn:
         raise AttributeError("can't set attribute")
@@ -137,8 +131,6 @@ class Row(BaseRow, Sequence[Any], Generic[_TP]):
         return RowMapping(
             self._parent,
             None,
-            self._keymap,
-            RowMapping._default_key_style,
             self._data,
         )
 
@@ -148,8 +140,6 @@ class Row(BaseRow, Sequence[Any], Generic[_TP]):
         return Row(
             self._parent,
             filters,
-            self._keymap,
-            self._key_style,
             self._data,
         )
 
@@ -334,8 +324,6 @@ class RowMapping(BaseRow, typing.Mapping[str, Any]):
     """
 
     __slots__ = ()
-
-    _default_key_style = KEY_OBJECTS_ONLY
 
     if TYPE_CHECKING:
 

--- a/lib/sqlalchemy/engine/row.py
+++ b/lib/sqlalchemy/engine/row.py
@@ -128,20 +128,12 @@ class Row(BaseRow, Sequence[Any], Generic[_TP]):
         .. versionadded:: 1.4
 
         """
-        return RowMapping(
-            self._parent,
-            None,
-            self._data,
-        )
+        return RowMapping(self._parent, None, self._data)
 
     def _filter_on_values(
         self, filters: Optional[Sequence[Optional[_ResultProcessorType[Any]]]]
     ) -> Row[Any]:
-        return Row(
-            self._parent,
-            filters,
-            self._data,
-        )
+        return Row(self._parent, filters, self._data)
 
     if not TYPE_CHECKING:
 
@@ -188,9 +180,7 @@ class Row(BaseRow, Sequence[Any], Generic[_TP]):
         def __getitem__(self, index: slice) -> Sequence[Any]:
             ...
 
-        def __getitem__(
-            self, index: Union[int, slice]
-        ) -> Union[Any, Sequence[Any]]:
+        def __getitem__(self, index: Union[int, slice]) -> Any:
             ...
 
     def __lt__(self, other: Any) -> bool:

--- a/test/aaa_profiling/test_resultset.py
+++ b/test/aaa_profiling/test_resultset.py
@@ -212,7 +212,7 @@ class RowTest(fixtures.TestBase):
     def _rowproxy_fixture(self, keys, processors, row, row_cls):
         class MockMeta:
             def __init__(self):
-                pass
+                self._name_cache = {}
 
             def _warn_for_nonint(self, arg):
                 pass

--- a/test/aaa_profiling/test_resultset.py
+++ b/test/aaa_profiling/test_resultset.py
@@ -210,23 +210,25 @@ class RowTest(fixtures.TestBase):
     __backend__ = True
 
     def _rowproxy_fixture(self, keys, processors, row, row_cls):
-        class MockMeta:
-            def __init__(self):
-                self._name_cache = {}
-
-            def _warn_for_nonint(self, arg):
-                pass
-
-        metadata = MockMeta()
 
         keymap = {}
         for index, (keyobjs, values) in enumerate(list(zip(keys, row))):
             for key in keyobjs:
                 keymap[key] = (index, key)
             keymap[index] = (index, key)
-        return row_cls(
-            metadata, processors, keymap, row_cls._default_key_style, row
-        )
+
+        class MockMeta:
+            def __init__(self):
+                self._keymap = keymap
+                self._keymap_by_str = {
+                    key: rec[0] for key, rec in self._keymap.items()
+                }
+
+            def _warn_for_nonint(self, arg):
+                pass
+
+        metadata = MockMeta()
+        return row_cls(metadata, processors, row)
 
     def _test_getitem_value_refcounts_new(self, seq_factory):
         col1, col2 = object(), object()

--- a/test/aaa_profiling/test_resultset.py
+++ b/test/aaa_profiling/test_resultset.py
@@ -220,7 +220,7 @@ class RowTest(fixtures.TestBase):
         class MockMeta:
             def __init__(self):
                 self._keymap = keymap
-                self._keymap_by_str = {
+                self._key_to_index = {
                     key: rec[0] for key, rec in self._keymap.items()
                 }
 

--- a/test/base/test_result.py
+++ b/test/base/test_result.py
@@ -206,11 +206,9 @@ class ResultTupleTest(fixtures.TestBase):
 
         if direction.py_to_cy:
             dump_cls = _py_row.BaseRow
-            num = _py_row.KEY_INTEGER_ONLY
             load_cls = _cy_row.BaseRow
         elif direction.cy_to_py:
             dump_cls = _cy_row.BaseRow
-            num = _cy_row.KEY_INTEGER_ONLY
             load_cls = _py_row.BaseRow
         else:
             direction.fail()
@@ -220,7 +218,7 @@ class ResultTupleTest(fixtures.TestBase):
             class Row(dump_cls):
                 pass
 
-            row = Row(p, p._processors, p._keymap, num, (1, 2, 3))
+            row = Row(p, p._processors, (1, 2, 3))
 
             state = dumps(row)
 

--- a/test/perf/compiled_extensions.py
+++ b/test/perf/compiled_extensions.py
@@ -996,6 +996,84 @@ class BaseRow(Case):
         self.row_long.x
         self.row_long.y
 
+    @test_case
+    def getattr_repeats(self):
+        row = self.row
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+        row.a
+
+
+
 
 class CacheAnonMap(Case):
     @staticmethod

--- a/test/perf/compiled_extensions.py
+++ b/test/perf/compiled_extensions.py
@@ -876,16 +876,12 @@ class BaseRow(Case):
         self.row_args = (
             self.parent,
             self.parent._processors,
-            self.parent._keymap,
-            0,
             (1, 2, 3),
         )
         self.parent_long = SimpleResultMetaData(tuple(ascii_letters))
         self.row_long_args = (
             self.parent_long,
             self.parent_long._processors,
-            self.parent_long._keymap,
-            0,
             tuple(range(len(ascii_letters))),
         )
         self.row = self.impl(*self.row_args)

--- a/test/perf/compiled_extensions.py
+++ b/test/perf/compiled_extensions.py
@@ -1073,8 +1073,6 @@ class BaseRow(Case):
         row.a
 
 
-
-
 class CacheAnonMap(Case):
     @staticmethod
     def python():

--- a/test/perf/compiled_extensions.py
+++ b/test/perf/compiled_extensions.py
@@ -10,9 +10,17 @@ from sqlalchemy import bindparam
 from sqlalchemy import column
 
 
-def test_case(fn):
-    fn.__test_case__ = True
-    return fn
+def test_case(fn=None, *, number=None):
+    def wrap(fn):
+        fn.__test_case__ = True
+        if number is not None:
+            fn.__number__ = number
+        return fn
+
+    if fn is None:
+        return wrap
+    else:
+        return wrap(fn)
 
 
 class Case:
@@ -90,7 +98,11 @@ class Case:
             for m in methods:
                 call = getattr(impl_case, m)
                 try:
-                    value = timeit(call, number=number)
+                    t_num = number
+                    fn_num = getattr(call, "__number__", None)
+                    if fn_num is not None:
+                        t_num = max(1, int(fn_num * factor))
+                    value = timeit(call, number=t_num)
                     print(".", end="", flush=True)
                 except Exception as e:
                     fails.append(f"{name}::{m} error: {e}")
@@ -810,7 +822,7 @@ class TupleGetter(Case):
             def __init__(self, data):
                 self.data = data
 
-            def _get_by_int_impl(self, index):
+            def __getitem__(self, index):
                 # called by python
                 return self.data[index]
 
@@ -924,11 +936,6 @@ class BaseRow(Case):
         self.impl.__new__(self.impl).__setstate__(self.row_long_state)
 
     @test_case
-    def row_filter(self):
-        self.row._filter_on_values(None)
-        self.row_long._filter_on_values(None)
-
-    @test_case
     def row_values_impl(self):
         self.row._values_impl()
         self.row_long._values_impl()
@@ -965,25 +972,11 @@ class BaseRow(Case):
         self.row_long[1:-1]
 
     @test_case
-    def get_by_int(self):
-        self.row._get_by_int_impl(0)
-        self.row._get_by_int_impl(1)
-        self.row_long._get_by_int_impl(0)
-        self.row_long._get_by_int_impl(1)
-
-    @test_case
     def get_by_key(self):
-        self.row._get_by_key_impl(0)
-        self.row._get_by_key_impl(1)
-        self.row_long._get_by_key_impl(0)
-        self.row_long._get_by_key_impl(1)
-
-    @test_case
-    def get_by_key_slice(self):
-        self.row._get_by_key_impl(slice(0, 1))
-        self.row._get_by_key_impl(slice(1, -1))
-        self.row_long._get_by_key_impl(slice(0, 1))
-        self.row_long._get_by_key_impl(slice(1, -1))
+        self.row._get_by_key_impl_mapping("a")
+        self.row._get_by_key_impl_mapping("b")
+        self.row_long._get_by_key_impl_mapping("s")
+        self.row_long._get_by_key_impl_mapping("a")
 
     @test_case
     def getattr(self):
@@ -992,81 +985,39 @@ class BaseRow(Case):
         self.row_long.x
         self.row_long.y
 
-    @test_case
-    def getattr_repeats(self):
+    @test_case(number=50_000)
+    def get_by_key_recreate(self):
+        self.init_objects()
         row = self.row
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
-        row.a
+        for _ in range(25):
+            row._get_by_key_impl_mapping("a")
+        l_row = self.row_long
+        for _ in range(25):
+            l_row._get_by_key_impl_mapping("f")
+            l_row._get_by_key_impl_mapping("o")
+            l_row._get_by_key_impl_mapping("r")
+            l_row._get_by_key_impl_mapping("t")
+            l_row._get_by_key_impl_mapping("y")
+            l_row._get_by_key_impl_mapping("t")
+            l_row._get_by_key_impl_mapping("w")
+            l_row._get_by_key_impl_mapping("o")
+
+    @test_case(number=50_000)
+    def getattr_recreate(self):
+        self.init_objects()
+        row = self.row
+        for _ in range(25):
+            row.a
+        l_row = self.row_long
+        for _ in range(25):
+            l_row.f
+            l_row.o
+            l_row.r
+            l_row.t
+            l_row.y
+            l_row.t
+            l_row.w
+            l_row.o
 
 
 class CacheAnonMap(Case):

--- a/test/sql/test_resultset.py
+++ b/test/sql/test_resultset.py
@@ -201,7 +201,6 @@ class CursorResultTest(fixtures.TablesTest):
             rows[0].user_id
 
     def test_keys_no_rows(self, connection):
-
         for i in range(2):
             r = connection.execute(
                 text("update users set user_name='new' where user_id=10")
@@ -378,7 +377,6 @@ class CursorResultTest(fixtures.TablesTest):
                 operator.ge,
                 operator.le,
             ]:
-
                 try:
                     control = op(equal, compare)
                 except TypeError:
@@ -1709,8 +1707,12 @@ class CursorResultTest(fixtures.TablesTest):
             def __getitem__(self, i):
                 return list.__getitem__(self.internal_list, i)
 
+        class MockMeta:
+            def __init__(self):
+                self._name_cache = {}
+
         proxy = Row(
-            object(),
+            MockMeta(),
             [None],
             {"key": (0, None, "key"), 0: (0, None, "key")},
             Row._default_key_style,
@@ -1760,9 +1762,12 @@ class CursorResultTest(fixtures.TablesTest):
                 eq_(len(mock_rowcount.__get__.mock_calls), 2)
 
     def test_row_is_sequence(self):
+        class MockMeta:
+            def __init__(self):
+                self._name_cache = {}
 
         row = Row(
-            object(),
+            MockMeta(),
             [None],
             {"key": (None, 0), 0: (None, 0)},
             Row._default_key_style,
@@ -1841,9 +1846,12 @@ class CursorResultTest(fixtures.TablesTest):
         eq_(list(row._mapping), ["a", "b", "count"])
 
     def test_row_is_hashable(self):
+        class MockMeta:
+            def __init__(self):
+                self._name_cache = {}
 
         row = Row(
-            object(),
+            MockMeta(),
             [None, None, None],
             {"key": (None, 0), 0: (None, 0)},
             Row._default_key_style,
@@ -3450,7 +3458,6 @@ class AlternateCursorResultTest(fixtures.TablesTest):
                 r = conn.execute(select(self.table))
                 assert isinstance(r.cursor_strategy, strategy_cls)
                 with mock.patch.object(r, "cursor", cursor()):
-
                     with testing.expect_raises_message(
                         IOError, "random non-DBAPI"
                     ):
@@ -3514,7 +3521,6 @@ class MergeCursorResultTest(fixtures.TablesTest):
         users = self.tables.users
 
         def results(connection):
-
             r1 = connection.execute(
                 users.select()
                 .where(users.c.user_id.in_([7, 8]))

--- a/test/sql/test_resultset.py
+++ b/test/sql/test_resultset.py
@@ -1709,7 +1709,7 @@ class CursorResultTest(fixtures.TablesTest):
         class MockMeta:
             def __init__(self):
                 self._keymap = {"key": (0, None, "key"), 0: (0, None, "key")}
-                self._keymap_by_str = {
+                self._key_to_index = {
                     key: rec[0] for key, rec in self._keymap.items()
                 }
 
@@ -1765,7 +1765,7 @@ class CursorResultTest(fixtures.TablesTest):
         class MockMeta:
             def __init__(self):
                 self._keymap = {"key": (None, 0), 0: (None, 0)}
-                self._keymap_by_str = {
+                self._key_to_index = {
                     key: rec[0] for key, rec in self._keymap.items()
                 }
 
@@ -1844,7 +1844,7 @@ class CursorResultTest(fixtures.TablesTest):
         class MockMeta:
             def __init__(self):
                 self._keymap = {"key": (None, 0), 0: (None, 0)}
-                self._keymap_by_str = {
+                self._key_to_index = {
                     key: rec[0] for key, rec in self._keymap.items()
                 }
 

--- a/test/sql/test_resultset.py
+++ b/test/sql/test_resultset.py
@@ -991,18 +991,14 @@ class CursorResultTest(fixtures.TablesTest):
 
     def test_column_accessor_err(self, connection):
         r = connection.execute(select(1)).first()
-        assert_raises_message(
-            AttributeError,
-            "Could not locate column in row for column 'foo'",
-            getattr,
-            r,
-            "foo",
-        )
-        assert_raises_message(
-            KeyError,
-            "Could not locate column in row for column 'foo'",
-            lambda: r._mapping["foo"],
-        )
+        with expect_raises_message(
+            AttributeError, "Could not locate column in row for column 'foo'"
+        ):
+            r.foo
+        with expect_raises_message(
+            KeyError, "Could not locate column in row for column 'foo'"
+        ):
+            r._mapping["foo"],
 
     def test_graceful_fetch_on_non_rows(self):
         """test that calling fetchone() etc. on a result that doesn't


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

Merge checklist

- [ ] the row and result getstate should accept the current 2.0 serialization even after these changes. It's fine to change the serialization so the new format can't be loaded in older 2.0 versions (best if we don't).

### Description

While I've tried to switch all the performance sensitive places in Home Assistant to use `getitem`, there is some code that can't be easily refactored that deals with large datasets and orm objects. This is a small speed up to the `getattr` implementation.

`python3 test/perf/compiled_extensions.py BaseRow`

Python 3.11.2 Darwin 22.4.0 Darwin Kernel Version 22.4.0: Mon Mar  6 20:59:58 PST 2023; root:xnu-8796.101.5~3/RELEASE_ARM64_T6020 arm64

Before
```
                    | python      | cython      | cy / py     |
getattr             | 1.440994000 | 0.899872834 | 0.624480625 |
getattr_repeats     | 24.36904329 | 14.56666258 | 0.597752748 |
```
After
```
                    | python      | cython      | cy / py     |
getattr             | 1.113157333 | 0.816836375 | 0.733801369 |
getattr_repeats     | 18.37744700 | 13.53884533 | 0.736709802 |
```

~24.58% speed up pure python
~7.05% speed up cython


Python 3.10.5 Linux 4.4.59+ #25556 SMP PREEMPT Sat Aug 28 02:17:25 CST 2021 x86_64 Linux

Before
```
                    | python      | cython      | cy / py     |
getattr             | 5.148779137 | 2.282829123 | 0.443372897 |
getattr_repeats     | 85.49036448 | 34.70639851 | 0.405968541 |
```

After

```
                    | python      | cython      | cy / py     |
getattr             | 3.705751788 | 2.123954093 | 0.573150663 |
getattr_repeats     | 59.90764300 | 31.99583192 | 0.534085975 |
```

~29.92% speed up pure python
~7.80% speed up cython

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

Fixes #9678

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
