### PR TITLE
fix typo ('resemblence' -> 'resemblance')

### DIFF
--- a/doc/build/tutorial/metadata.rst
+++ b/doc/build/tutorial/metadata.rst
@@ -115,7 +115,7 @@ Components of ``Table``
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 We can observe that the :class:`_schema.Table` construct as written in Python
-has a resemblence to a SQL CREATE TABLE statement; starting with the table
+has a resemblance to a SQL CREATE TABLE statement; starting with the table
 name, then listing out each column, where each column has a name and a
 datatype. The objects we use above are:
 
@@ -655,7 +655,3 @@ Core and ORM table-oriented constructs that we can use to interact with
 these tables via a :class:`_engine.Connection` and/or ORM
 :class:`_orm.Session`.  In the following sections, we will illustrate
 how to create, manipulate, and select data using these structures.
-
-
-
-


### PR DESCRIPTION

### Description
Fixed a small spelling error. Reference sources for spelling of "resemblance":

- https://www.merriam-webster.com/dictionary/resemblance
- https://ahdictionary.com/word/search.html?q=resemblance
- https://www.dictionary.com/browse/resemblance

My background:
I'm a professional technical editor, so I spot these types of misspellings easily. Happy to help the wonderful SQLAlchemy project.

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.


