### PR TITLE
Avoid reprocessing bytes for MySQL and SQLite engines

### DIFF
--- a/doc/build/changelog/unreleased_20/9680.rst
+++ b/doc/build/changelog/unreleased_20/9680.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: mysql, performance, sqlite
+    :tickets: 9680
+
+    Improved performance of processing rows that
+    return ``bytes`` objects with SQLite and MySQL.

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2397,7 +2397,7 @@ class MySQLDialect(default.DefaultDialect):
 
     supports_native_enum = True
 
-    supports_native_bytes = True
+    returns_native_bytes = True
 
     supports_sequences = False  # default for MySQL ...
     # ... may be updated to True for MariaDB 10.3+ in initialize()

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2397,6 +2397,8 @@ class MySQLDialect(default.DefaultDialect):
 
     supports_native_enum = True
 
+    supports_native_bytes = True
+
     supports_sequences = False  # default for MySQL ...
     # ... may be updated to True for MariaDB 10.3+ in initialize()
 

--- a/lib/sqlalchemy/dialects/sqlite/pysqlite.py
+++ b/lib/sqlalchemy/dialects/sqlite/pysqlite.py
@@ -486,6 +486,7 @@ class _SQLite_pysqliteDate(DATE):
 class SQLiteDialect_pysqlite(SQLiteDialect):
     default_paramstyle = "qmark"
     supports_statement_cache = True
+    supports_native_bytes = True
 
     colspecs = util.update_copy(
         SQLiteDialect.colspecs,

--- a/lib/sqlalchemy/dialects/sqlite/pysqlite.py
+++ b/lib/sqlalchemy/dialects/sqlite/pysqlite.py
@@ -486,7 +486,7 @@ class _SQLite_pysqliteDate(DATE):
 class SQLiteDialect_pysqlite(SQLiteDialect):
     default_paramstyle = "qmark"
     supports_statement_cache = True
-    supports_native_bytes = True
+    returns_native_bytes = True
 
     colspecs = util.update_copy(
         SQLiteDialect.colspecs,

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -155,6 +155,8 @@ class DefaultDialect(Dialect):
     supports_native_enum = False
     supports_native_boolean = False
     supports_native_uuid = False
+    supports_native_bytes = False
+
     non_native_boolean_check_constraint = True
 
     supports_simple_order_by_label = True

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -155,7 +155,7 @@ class DefaultDialect(Dialect):
     supports_native_enum = False
     supports_native_boolean = False
     supports_native_uuid = False
-    supports_native_bytes = False
+    returns_native_bytes = False
 
     non_native_boolean_check_constraint = True
 

--- a/lib/sqlalchemy/engine/interfaces.py
+++ b/lib/sqlalchemy/engine/interfaces.py
@@ -1013,6 +1013,13 @@ class Dialect(EventTarget):
     .. versionadded:: 2.0
 
     """
+    supports_native_bytes: bool
+    """indicates if Python bytes() objects are handled natively by the
+    driver for SQL bytes datatypes.
+
+    .. versionadded:: 2.0
+
+    """
 
     construct_arguments: Optional[
         List[Tuple[Type[Union[SchemaItem, ClauseElement]], Mapping[str, Any]]]

--- a/lib/sqlalchemy/engine/interfaces.py
+++ b/lib/sqlalchemy/engine/interfaces.py
@@ -1013,7 +1013,7 @@ class Dialect(EventTarget):
     .. versionadded:: 2.0
 
     """
-    supports_native_bytes: bool
+    returns_native_bytes: bool
     """indicates if Python bytes() objects are handled natively by the
     driver for SQL bytes datatypes.
 

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -934,6 +934,9 @@ class _Binary(TypeEngine[bytes]):
     # both sqlite3 and pg8000 seem to return it,
     # psycopg2 as of 2.5 returns 'memoryview'
     def result_processor(self, dialect, coltype):
+        if dialect.supports_native_bytes:
+            return None
+
         def process(value):
             if value is not None:
                 value = bytes(value)

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -934,7 +934,7 @@ class _Binary(TypeEngine[bytes]):
     # both sqlite3 and pg8000 seem to return it,
     # psycopg2 as of 2.5 returns 'memoryview'
     def result_processor(self, dialect, coltype):
-        if dialect.supports_native_bytes:
+        if dialect.returns_native_bytes:
             return None
 
         def process(value):

--- a/test/dialect/mysql/test_types.py
+++ b/test/dialect/mysql/test_types.py
@@ -749,7 +749,7 @@ class TypeRoundTripTest(fixtures.TestBase, AssertsExecutionResults):
         for col in bytes_table.c:
             self.assert_(repr(col))
         bytes_table.create(connection)
-        reflected = Table("thebytes", MetaData(), autoload_with=connection)
+        reflected = Table("mysql_bytes", MetaData(), autoload_with=connection)
 
         for table in bytes_table, reflected:
             connection.execute(table.insert().values([b"abc"]))

--- a/test/dialect/mysql/test_types.py
+++ b/test/dialect/mysql/test_types.py
@@ -752,9 +752,7 @@ class TypeRoundTripTest(fixtures.TestBase, AssertsExecutionResults):
         reflected = Table("thebytes", MetaData(), autoload_with=connection)
 
         for table in bytes_table, reflected:
-            connection.execute(
-                table.insert().values([b"abc"])
-            )
+            connection.execute(table.insert().values([b"abc"]))
             row = connection.execute(table.select()).first()
             eq_(list(row), [b"abc"])
 

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -300,7 +300,7 @@ class TestTypes(fixtures.TestBase, AssertsExecutionResults):
             connection.execute(
                 t.select().where(t.c.thebytes).order_by(t.c.id)
             ).fetchall(),
-            [(1, b'7\xe7\x9f')],
+            [(1, b"7\xe7\x9f")],
         )
 
 


### PR DESCRIPTION
Avoid reprocessing bytes for MySQL and SQLite engines

closes #9680
