### PR TITLE
comment fix: QueuePool is now default for SQLite

### DIFF
--- a/lib/sqlalchemy/pool/impl.py
+++ b/lib/sqlalchemy/pool/impl.py
@@ -48,7 +48,7 @@ class QueuePool(Pool):
     that imposes a limit on the number of open connections.
 
     :class:`.QueuePool` is the default pooling implementation used for
-    all :class:`_engine.Engine` objects, unless the SQLite dialect is in use.
+    all :class:`_engine.Engine` objects.
 
     """
 


### PR DESCRIPTION
### Description
I removed a portion of the `QueuePool` class comment which indicated that `QueuePool` is not the default pool used by the SQLite dialect.

As of SqlAlchemy 2.0, `QueuePool` is the default for SQLite (https://github.com/sqlalchemy/sqlalchemy/commit/22ed657827b487df9012def07271aed01bd4ae12)

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

