### PR TITLE
Move try_cast() from mssql to base

### DIFF
--- a/doc/build/changelog/unreleased_20/9752.rst
+++ b/doc/build/changelog/unreleased_20/9752.rst
@@ -1,0 +1,14 @@
+.. change::
+    :tags: usecase, sql
+    :tickets: 9752
+
+
+    Added new :func:`.try_cast` factory function and corresponding
+    :class:`.TryCast` SQL Element, which implements a cast where
+    un-castable values are returned as NULL, instead of raising an error.
+
+    This is currently implemented as ``TRY_CAST`` in Microsoft SQL Server.
+    and could be implemented in other backends:
+    * ``SAFE_CAST`` in Google BigQuery, and
+    * ``TRY_CAST`` in DuckDB.
+    * ``TRY_CAST`` in Snowflake.

--- a/doc/build/changelog/unreleased_20/9752.rst
+++ b/doc/build/changelog/unreleased_20/9752.rst
@@ -14,3 +14,5 @@
     * ``SAFE_CAST`` in Google BigQuery
     * ``TRY_CAST`` in DuckDB
     * ``TRY_CAST`` in Snowflake
+
+    Pull request courtesy Nick Crews.

--- a/doc/build/changelog/unreleased_20/9752.rst
+++ b/doc/build/changelog/unreleased_20/9752.rst
@@ -3,11 +3,13 @@
     :tickets: 9752
 
 
-    Generalized the MSSQL :func:`.try_cast` function to any dialect.
+    Generalized the MSSQL :func:`.try_cast` function so that other
+    extension dialects can use it (MSSQL is the only builtin dialect
+    that currently supports it).
+
     This implements a cast where
     un-castable values are returned as NULL, instead of raising an error.
-    Now this function can be taken advantage of by third party dialects
-    that also support this function, such as
+    These are a few third party dialects that could implement this:
 
     * ``SAFE_CAST`` in Google BigQuery
     * ``TRY_CAST`` in DuckDB

--- a/doc/build/changelog/unreleased_20/9752.rst
+++ b/doc/build/changelog/unreleased_20/9752.rst
@@ -3,12 +3,12 @@
     :tickets: 9752
 
 
-    Added new :func:`.try_cast` factory function and corresponding
-    :class:`.TryCast` SQL Element, which implements a cast where
+    Generalized the MSSQL :func:`.try_cast` function to any dialect.
+    This implements a cast where
     un-castable values are returned as NULL, instead of raising an error.
+    Now this function can be taken advantage of by third party dialects
+    that also support this function, such as
 
-    This is currently implemented as ``TRY_CAST`` in Microsoft SQL Server.
-    and could be implemented in other backends:
-    * ``SAFE_CAST`` in Google BigQuery, and
-    * ``TRY_CAST`` in DuckDB.
-    * ``TRY_CAST`` in Snowflake.
+    * ``SAFE_CAST`` in Google BigQuery
+    * ``TRY_CAST`` in DuckDB
+    * ``TRY_CAST`` in Snowflake

--- a/doc/build/changelog/unreleased_20/9752.rst
+++ b/doc/build/changelog/unreleased_20/9752.rst
@@ -3,13 +3,13 @@
     :tickets: 9752
 
 
-    Generalized the MSSQL :func:`.try_cast` function so that other
-    extension dialects can use it (MSSQL is the only builtin dialect
-    that currently supports it).
+    Generalized the MSSQL :func:`.try_cast` function so that other extension
+    dialects can use it (MSSQL is the only builtin dialect that currently
+    supports it).
 
-    This implements a cast where
-    un-castable values are returned as NULL, instead of raising an error.
-    These are a few third party dialects that could implement this:
+    This implements a cast where un-castable values are returned as NULL,
+    instead of raising an error. These are a few third party dialects that
+    could implement this:
 
     * ``SAFE_CAST`` in Google BigQuery
     * ``TRY_CAST`` in DuckDB

--- a/lib/sqlalchemy/__init__.py
+++ b/lib/sqlalchemy/__init__.py
@@ -99,6 +99,8 @@ from .sql.expression import Case as Case
 from .sql.expression import case as case
 from .sql.expression import Cast as Cast
 from .sql.expression import cast as cast
+from .sql.expression import TryCast as TryCast
+from .sql.expression import try_cast as try_cast
 from .sql.expression import ClauseElement as ClauseElement
 from .sql.expression import ClauseList as ClauseList
 from .sql.expression import collate as collate

--- a/lib/sqlalchemy/__init__.py
+++ b/lib/sqlalchemy/__init__.py
@@ -99,8 +99,6 @@ from .sql.expression import Case as Case
 from .sql.expression import case as case
 from .sql.expression import Cast as Cast
 from .sql.expression import cast as cast
-from .sql.expression import TryCast as TryCast
-from .sql.expression import try_cast as try_cast
 from .sql.expression import ClauseElement as ClauseElement
 from .sql.expression import ClauseList as ClauseList
 from .sql.expression import collate as collate
@@ -201,6 +199,8 @@ from .sql.expression import TextClause as TextClause
 from .sql.expression import TextualSelect as TextualSelect
 from .sql.expression import true as true
 from .sql.expression import True_ as True_
+from .sql.expression import try_cast as try_cast
+from .sql.expression import TryCast as TryCast
 from .sql.expression import Tuple as Tuple
 from .sql.expression import tuple_ as tuple_
 from .sql.expression import type_coerce as type_coerce

--- a/lib/sqlalchemy/dialects/mssql/__init__.py
+++ b/lib/sqlalchemy/dialects/mssql/__init__.py
@@ -6,7 +6,7 @@
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
 # mypy: ignore-errors
 
-
+from ...sql._elements_constructors import try_cast
 from . import base  # noqa
 from . import pymssql  # noqa
 from . import pyodbc  # noqa
@@ -39,7 +39,6 @@ from .base import TEXT
 from .base import TIME
 from .base import TIMESTAMP
 from .base import TINYINT
-from .base import try_cast
 from .base import UNIQUEIDENTIFIER
 from .base import VARBINARY
 from .base import VARCHAR

--- a/lib/sqlalchemy/dialects/mssql/__init__.py
+++ b/lib/sqlalchemy/dialects/mssql/__init__.py
@@ -42,7 +42,7 @@ from .base import UNIQUEIDENTIFIER
 from .base import VARBINARY
 from .base import VARCHAR
 from .base import XML
-from ...sql._elements_constructors import try_cast
+from ...sql import try_cast
 
 
 base.dialect = dialect = pyodbc.dialect

--- a/lib/sqlalchemy/dialects/mssql/__init__.py
+++ b/lib/sqlalchemy/dialects/mssql/__init__.py
@@ -6,7 +6,6 @@
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
 # mypy: ignore-errors
 
-from ...sql._elements_constructors import try_cast
 from . import base  # noqa
 from . import pymssql  # noqa
 from . import pyodbc  # noqa
@@ -43,6 +42,7 @@ from .base import UNIQUEIDENTIFIER
 from .base import VARBINARY
 from .base import VARCHAR
 from .base import XML
+from ...sql._elements_constructors import try_cast
 
 
 base.dialect = dialect = pyodbc.dialect

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -2145,6 +2145,12 @@ class MSSQLCompiler(compiler.SQLCompiler):
         else:
             return ""
 
+    def visit_try_cast(self, element, **kw):
+        return "TRY_CAST (%s AS %s)" % (
+            self.process(element.clause, **kw),
+            self.process(element.typeclause, **kw),
+        )
+
     def translate_select_structure(self, select_stmt, **kwargs):
         """Look for ``LIMIT`` and OFFSET in a select statement, and if
         so tries to wrap it in a subquery with ``row_number()`` criterion.

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -939,10 +939,10 @@ from ...sql import quoted_name
 from ...sql import roles
 from ...sql import sqltypes
 from ...sql import util as sql_util
-from ...sql._elements_constructors import try_cast
+from ...sql._elements_constructors import try_cast as try_cast
 from ...sql._typing import is_sql_compiler
 from ...sql.compiler import InsertmanyvaluesSentinelOpts
-from ...sql.elements import TryCast
+from ...sql.elements import TryCast as TryCast
 from ...types import BIGINT
 from ...types import BINARY
 from ...types import CHAR

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -939,10 +939,10 @@ from ...sql import quoted_name
 from ...sql import roles
 from ...sql import sqltypes
 from ...sql import util as sql_util
-from ...sql._elements_constructors import try_cast as try_cast
+from ...sql._elements_constructors import try_cast as try_cast  # noqa: F401
 from ...sql._typing import is_sql_compiler
 from ...sql.compiler import InsertmanyvaluesSentinelOpts
-from ...sql.elements import TryCast as TryCast
+from ...sql.elements import TryCast as TryCast  # noqa: F401
 from ...types import BIGINT
 from ...types import BINARY
 from ...types import CHAR

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -941,6 +941,7 @@ from ...sql import sqltypes
 from ...sql import util as sql_util
 from ...sql._typing import is_sql_compiler
 from ...sql.compiler import InsertmanyvaluesSentinelOpts
+from ...sql.elements import TryCast
 from ...types import BIGINT
 from ...types import BINARY
 from ...types import CHAR
@@ -1604,38 +1605,12 @@ class SQL_VARIANT(sqltypes.TypeEngine):
 
 
 def try_cast(*arg, **kw):
-    """Create a TRY_CAST expression.
-
-    :class:`.TryCast` is a subclass of SQLAlchemy's :class:`.Cast`
-    construct, and works in the same way, except that the SQL expression
-    rendered is "TRY_CAST" rather than "CAST"::
-
-        from sqlalchemy import select
-        from sqlalchemy import Numeric
-        from sqlalchemy.dialects.mssql import try_cast
-
-        stmt = select(
-            try_cast(product_table.c.unit_price, Numeric(10, 4))
-        )
-
-    The above would render::
-
-        SELECT TRY_CAST (product_table.unit_price AS NUMERIC(10, 4))
-        FROM product_table
-
-    .. versionadded:: 1.3.7
-
-    """
+    util.warn_deprecated(
+        "`sqlalchemy.dialects.mssql.base.try_cast` is deprecated. "
+        "Use directly from sqlalchemy instead, i.e. `sa.try_cast(...)`",
+        "2.1",
+    )
     return TryCast(*arg, **kw)
-
-
-class TryCast(sql.elements.Cast):
-    """Represent a SQL Server TRY_CAST expression."""
-
-    __visit_name__ = "try_cast"
-
-    stringify_dialect = "mssql"
-    inherit_cache = True
 
 
 # old names.

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -939,6 +939,7 @@ from ...sql import quoted_name
 from ...sql import roles
 from ...sql import sqltypes
 from ...sql import util as sql_util
+from ...sql._elements_constructors import try_cast
 from ...sql._typing import is_sql_compiler
 from ...sql.compiler import InsertmanyvaluesSentinelOpts
 from ...sql.elements import TryCast
@@ -1604,15 +1605,6 @@ class SQL_VARIANT(sqltypes.TypeEngine):
     __visit_name__ = "SQL_VARIANT"
 
 
-def try_cast(*arg, **kw):
-    util.warn_deprecated(
-        "`sqlalchemy.dialects.mssql.base.try_cast` is deprecated. "
-        "Use directly from sqlalchemy instead, i.e. `sa.try_cast(...)`",
-        "2.1",
-    )
-    return TryCast(*arg, **kw)
-
-
 # old names.
 MSDateTime = _MSDateTime
 MSDate = _MSDate
@@ -2152,12 +2144,6 @@ class MSSQLCompiler(compiler.SQLCompiler):
 
         else:
             return ""
-
-    def visit_try_cast(self, element, **kw):
-        return "TRY_CAST (%s AS %s)" % (
-            self.process(element.clause, **kw),
-            self.process(element.typeclause, **kw),
-        )
 
     def translate_select_structure(self, select_stmt, **kwargs):
         """Look for ``LIMIT`` and OFFSET in a select statement, and if

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -938,8 +938,8 @@ from ...sql import func
 from ...sql import quoted_name
 from ...sql import roles
 from ...sql import sqltypes
+from ...sql import try_cast as try_cast  # noqa: F401
 from ...sql import util as sql_util
-from ...sql._elements_constructors import try_cast as try_cast  # noqa: F401
 from ...sql._typing import is_sql_compiler
 from ...sql.compiler import InsertmanyvaluesSentinelOpts
 from ...sql.elements import TryCast as TryCast  # noqa: F401

--- a/lib/sqlalchemy/sql/__init__.py
+++ b/lib/sqlalchemy/sql/__init__.py
@@ -93,6 +93,7 @@ from .expression import tablesample as tablesample
 from .expression import text as text
 from .expression import true as true
 from .expression import True_ as True_
+from .expression import try_cast as try_cast
 from .expression import tuple_ as tuple_
 from .expression import type_coerce as type_coerce
 from .expression import union as union

--- a/lib/sqlalchemy/sql/_elements_constructors.py
+++ b/lib/sqlalchemy/sql/_elements_constructors.py
@@ -908,8 +908,8 @@ def cast(
 
 
 def try_cast(
-        expression: _ColumnExpressionOrLiteralArgument[Any],
-        type_: _TypeEngineArgument[_T],
+    expression: _ColumnExpressionOrLiteralArgument[Any],
+    type_: _TypeEngineArgument[_T],
 ) -> TryCast[_T]:
     """Produce a ``TRY_CAST`` expression.
 

--- a/lib/sqlalchemy/sql/_elements_constructors.py
+++ b/lib/sqlalchemy/sql/_elements_constructors.py
@@ -938,8 +938,9 @@ def try_cast(
         SELECT TRY_CAST (product_table.unit_price AS NUMERIC(10, 4))
         FROM product_table
 
-    .. versionadded:: 2.0.14
-
+    .. versionadded:: 2.0.14  The :func:.try_cast construct has been
+       generalized from the SQL Server dialect into a general use
+       construct that may be supported by additional dialects.
     """
     return TryCast(expression, type_)
 

--- a/lib/sqlalchemy/sql/_elements_constructors.py
+++ b/lib/sqlalchemy/sql/_elements_constructors.py
@@ -40,6 +40,7 @@ from .elements import Null
 from .elements import Over
 from .elements import TextClause
 from .elements import True_
+from .elements import TryCast
 from .elements import Tuple
 from .elements import TypeCoerce
 from .elements import UnaryExpression
@@ -893,6 +894,9 @@ def cast(
 
         :ref:`tutorial_casts`
 
+        :func:`.try_cast` - an alternative to CAST that results in
+        NULLs when the cast fails, instead of raising an error.
+
         :func:`.type_coerce` - an alternative to CAST that coerces the type
         on the Python side only, which is often sufficient to generate the
         correct SQL and data coercion.
@@ -900,6 +904,30 @@ def cast(
 
     """
     return Cast(expression, type_)
+
+
+def try_cast(*arg, **kw):
+    """Create a TRY_CAST expression.
+
+    :class:`.TryCast` is a subclass of SQLAlchemy's :class:`.Cast`
+    construct, and works in the same way, except that the SQL expression
+    rendered is "TRY_CAST" rather than "CAST"::
+
+        from sqlalchemy import select, try_cast, Numeric
+
+        stmt = select(
+            try_cast(product_table.c.unit_price, Numeric(10, 4))
+        )
+
+    The above would render with mssql as::
+
+        SELECT TRY_CAST (product_table.unit_price AS NUMERIC(10, 4))
+        FROM product_table
+
+    .. versionadded:: 2.1.0
+
+    """
+    return TryCast(*arg, **kw)
 
 
 def column(

--- a/lib/sqlalchemy/sql/_elements_constructors.py
+++ b/lib/sqlalchemy/sql/_elements_constructors.py
@@ -907,7 +907,10 @@ def cast(
     return Cast(expression, type_)
 
 
-def try_cast(*arg, **kw):
+def try_cast(
+        expression: _ColumnExpressionOrLiteralArgument[Any],
+        type_: _TypeEngineArgument[_T],
+    ) -> TryCast[_T]:
     """Produce a ``TRY_CAST`` expression.
 
     :func:`.try_cast` returns an instance of :class:`.TryCast`.
@@ -938,7 +941,7 @@ def try_cast(*arg, **kw):
     .. versionadded:: 2.0.14
 
     """
-    return TryCast(*arg, **kw)
+    return TryCast(expression, type_)
 
 
 def column(

--- a/lib/sqlalchemy/sql/_elements_constructors.py
+++ b/lib/sqlalchemy/sql/_elements_constructors.py
@@ -919,7 +919,7 @@ def try_cast(*arg, **kw):
     construct, and works in the same way, except in regards to error
     handling. If the function encounters an un-castable value
     (for instance when trying to convert the string "hi" to an INT)
-    then normal :class:`.Cast` raises an error. :class:`.TryCast`
+    then normal :class:`.Cast` raises an error, :class:`.TryCast`
     instead returns a NULL value.
 
     E.g.::

--- a/lib/sqlalchemy/sql/_elements_constructors.py
+++ b/lib/sqlalchemy/sql/_elements_constructors.py
@@ -896,6 +896,7 @@ def cast(
 
         :func:`.try_cast` - an alternative to CAST that results in
         NULLs when the cast fails, instead of raising an error.
+        Only supported by some dialects.
 
         :func:`.type_coerce` - an alternative to CAST that coerces the type
         on the Python side only, which is often sufficient to generate the
@@ -907,11 +908,21 @@ def cast(
 
 
 def try_cast(*arg, **kw):
-    """Create a TRY_CAST expression.
+    """Produce a ``TRY_CAST`` expression.
+
+    :func:`.try_cast` returns an instance of :class:`.TryCast`.
+
+    The only builtin dialect that supports :class:`.TryCast` is
+    Microsoft SQL (other third party dialects may support it as well).
 
     :class:`.TryCast` is a subclass of SQLAlchemy's :class:`.Cast`
-    construct, and works in the same way, except that the SQL expression
-    rendered is "TRY_CAST" rather than "CAST"::
+    construct, and works in the same way, except in regards to error
+    handling. If the function encounters an un-castable value
+    (for instance when trying to convert the string "hi" to an INT)
+    then normal :class:`.Cast` raises an error. :class:`.TryCast`
+    instead returns a NULL value.
+
+    E.g.::
 
         from sqlalchemy import select, try_cast, Numeric
 
@@ -919,12 +930,12 @@ def try_cast(*arg, **kw):
             try_cast(product_table.c.unit_price, Numeric(10, 4))
         )
 
-    The above would render with mssql as::
+    The above would render with Microsoft SQL as::
 
         SELECT TRY_CAST (product_table.unit_price AS NUMERIC(10, 4))
         FROM product_table
 
-    .. versionadded:: 2.1.0
+    .. versionadded:: 2.0.14
 
     """
     return TryCast(*arg, **kw)

--- a/lib/sqlalchemy/sql/_elements_constructors.py
+++ b/lib/sqlalchemy/sql/_elements_constructors.py
@@ -910,7 +910,7 @@ def cast(
 def try_cast(
         expression: _ColumnExpressionOrLiteralArgument[Any],
         type_: _TypeEngineArgument[_T],
-    ) -> TryCast[_T]:
+) -> TryCast[_T]:
     """Produce a ``TRY_CAST`` expression.
 
     :func:`.try_cast` returns an instance of :class:`.TryCast`.

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -2777,12 +2777,6 @@ class SQLCompiler(Compiled):
             cast.typeclause._compiler_dispatch(self, **kwargs),
         )
 
-    def visit_try_cast(self, cast, **kwargs):
-        return "TRY_CAST(%s AS %s)" % (
-            cast.clause._compiler_dispatch(self, **kwargs),
-            cast.typeclause._compiler_dispatch(self, **kwargs),
-        )
-
     def _format_frame_clause(self, range_, **kw):
 
         return "%s AND %s" % (
@@ -6348,6 +6342,12 @@ class StrSQLCompiler(SQLCompiler):
             binary.left._compiler_dispatch(self, **kw),
             binary.right._compiler_dispatch(self, **kw),
             replacement._compiler_dispatch(self, **kw),
+        )
+
+    def visit_try_cast(self, cast, **kwargs):
+        return "TRY_CAST(%s AS %s)" % (
+            cast.clause._compiler_dispatch(self, **kwargs),
+            cast.typeclause._compiler_dispatch(self, **kwargs),
         )
 
 

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -2777,6 +2777,12 @@ class SQLCompiler(Compiled):
             cast.typeclause._compiler_dispatch(self, **kwargs),
         )
 
+    def visit_try_cast(self, cast, **kwargs):
+        return "TRY_CAST(%s AS %s)" % (
+            cast.clause._compiler_dispatch(self, **kwargs),
+            cast.typeclause._compiler_dispatch(self, **kwargs),
+        )
+
     def _format_frame_clause(self, range_, **kw):
 
         return "%s AND %s" % (

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -3372,6 +3372,8 @@ class Cast(WrapsColumnExpression[_T]):
 
         :func:`.cast`
 
+        :func:`.try_cast`
+
         :func:`.type_coerce` - an alternative to CAST that coerces the type
         on the Python side only, which is often sufficient to generate the
         correct SQL and data coercion.
@@ -3410,6 +3412,23 @@ class Cast(WrapsColumnExpression[_T]):
     @property
     def wrapped_column_expression(self):
         return self.clause
+
+
+
+class TryCast(Cast):
+    """Represent a TRY_CAST expression.
+
+    Details on :class:`.TryCast` usage is at :func:`.try_cast`.
+
+    .. seealso::
+
+        :func:`.try_cast`
+
+        :ref:`tutorial_casts`
+    """
+
+    __visit_name__ = "try_cast"
+    inherit_cache = True
 
 
 class TypeCoerce(WrapsColumnExpression[_T]):

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -3414,7 +3414,6 @@ class Cast(WrapsColumnExpression[_T]):
         return self.clause
 
 
-
 class TryCast(Cast):
     """Represent a TRY_CAST expression.
 

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -3414,7 +3414,7 @@ class Cast(WrapsColumnExpression[_T]):
         return self.clause
 
 
-class TryCast(Cast):
+class TryCast(Cast[_T]):
     """Represent a TRY_CAST expression.
 
     Details on :class:`.TryCast` usage is at :func:`.try_cast`.

--- a/lib/sqlalchemy/sql/expression.py
+++ b/lib/sqlalchemy/sql/expression.py
@@ -42,6 +42,7 @@ from ._elements_constructors import outparam as outparam
 from ._elements_constructors import over as over
 from ._elements_constructors import text as text
 from ._elements_constructors import true as true
+from ._elements_constructors import try_cast as try_cast
 from ._elements_constructors import tuple_ as tuple_
 from ._elements_constructors import type_coerce as type_coerce
 from ._elements_constructors import within_group as within_group
@@ -99,6 +100,7 @@ from .elements import SavepointClause as SavepointClause
 from .elements import SQLColumnExpression as SQLColumnExpression
 from .elements import TextClause as TextClause
 from .elements import True_ as True_
+from .elements import TryCast as TryCast
 from .elements import Tuple as Tuple
 from .elements import TypeClause as TypeClause
 from .elements import TypeCoerce as TypeCoerce

--- a/test/dialect/mssql/test_compiler.py
+++ b/test/dialect/mssql/test_compiler.py
@@ -20,7 +20,6 @@ from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy import testing
 from sqlalchemy import text
-from sqlalchemy import try_cast
 from sqlalchemy import union
 from sqlalchemy import UniqueConstraint
 from sqlalchemy import update
@@ -1471,15 +1470,6 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         self.assert_compile(
             schema.CreateIndex(idx),
             "CREATE INDEX foo ON test (x) INCLUDE (y) WHERE y > 1",
-        )
-
-    def test_try_cast(self):
-        metadata = MetaData()
-        t1 = Table("t1", metadata, Column("id", Integer, primary_key=True))
-
-        self.assert_compile(
-            select(try_cast(t1.c.id, Integer)),
-            "SELECT TRY_CAST (t1.id AS INTEGER) AS id FROM t1",
         )
 
     @testing.combinations(

--- a/test/dialect/mssql/test_compiler.py
+++ b/test/dialect/mssql/test_compiler.py
@@ -26,7 +26,6 @@ from sqlalchemy import UniqueConstraint
 from sqlalchemy import update
 from sqlalchemy.dialects import mssql
 from sqlalchemy.dialects.mssql import base as mssql_base
-from sqlalchemy.dialects.mssql.base import try_cast
 from sqlalchemy.sql import column
 from sqlalchemy.sql import quoted_name
 from sqlalchemy.sql import table
@@ -1478,15 +1477,10 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         metadata = MetaData()
         t1 = Table("t1", metadata, Column("id", Integer, primary_key=True))
 
-        def call(func):
-            self.assert_compile(
-                select(func(t1.c.id, Integer)),
-                "SELECT TRY_CAST (t1.id AS INTEGER) AS id FROM t1",
-            )
-
-        with testing.expect_deprecated(".*try_cast.*"):
-            call(mssql_base.try_cast)
-        call(try_cast)
+        self.assert_compile(
+            select(try_cast(t1.c.id, Integer)),
+            "SELECT TRY_CAST (t1.id AS INTEGER) AS id FROM t1",
+        )
 
     @testing.combinations(
         ("no_persisted", "", "ignore"),

--- a/test/dialect/mssql/test_compiler.py
+++ b/test/dialect/mssql/test_compiler.py
@@ -20,6 +20,7 @@ from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy import testing
 from sqlalchemy import text
+from sqlalchemy import try_cast
 from sqlalchemy import union
 from sqlalchemy import UniqueConstraint
 from sqlalchemy import update
@@ -1470,6 +1471,13 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         self.assert_compile(
             schema.CreateIndex(idx),
             "CREATE INDEX foo ON test (x) INCLUDE (y) WHERE y > 1",
+        )
+
+    def test_try_cast(self):
+        t1 = Table("t1", MetaData(), Column("id", Integer, primary_key=True))
+        self.assert_compile(
+            select(try_cast(t1.c.id, Integer)),
+            "SELECT TRY_CAST (t1.id AS INTEGER) AS id FROM t1",
         )
 
     @testing.combinations(

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -6046,12 +6046,12 @@ class StringifySpecialTest(fixtures.TestBase):
         )
 
     def test_try_cast(self):
-        metadata = MetaData()
-        t1 = Table("t1", metadata, Column("id", Integer, primary_key=True))
+        t1 = Table("t1", MetaData(), Column("id", Integer, primary_key=True))
+        expr = select(try_cast(t1.c.id, Integer))
 
-        self.assert_compile(
-            select(try_cast(t1.c.id, Integer)),
-            "SELECT TRY_CAST (t1.id AS INTEGER) AS id FROM t1",
+        eq_ignore_whitespace(
+            str(expr),
+            "SELECT TRY_CAST(t1.id AS INTEGER) AS id FROM t1",
         )
 
 

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -57,9 +57,9 @@ from sqlalchemy import Table
 from sqlalchemy import testing
 from sqlalchemy import Text
 from sqlalchemy import text
-from sqlalchemy import try_cast
 from sqlalchemy import TIMESTAMP
 from sqlalchemy import true
+from sqlalchemy import try_cast
 from sqlalchemy import tuple_
 from sqlalchemy import type_coerce
 from sqlalchemy import types

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -57,6 +57,7 @@ from sqlalchemy import Table
 from sqlalchemy import testing
 from sqlalchemy import Text
 from sqlalchemy import text
+from sqlalchemy import try_cast
 from sqlalchemy import TIMESTAMP
 from sqlalchemy import true
 from sqlalchemy import tuple_
@@ -6042,6 +6043,15 @@ class StringifySpecialTest(fixtures.TestBase):
         eq_ignore_whitespace(
             str(schema.AddConstraint(cons)),
             "ALTER TABLE testtbl ADD EXCLUDE USING gist " "(room WITH =)",
+        )
+
+    def test_try_cast(self):
+        metadata = MetaData()
+        t1 = Table("t1", metadata, Column("id", Integer, primary_key=True))
+
+        self.assert_compile(
+            select(try_cast(t1.c.id, Integer)),
+            "SELECT TRY_CAST (t1.id AS INTEGER) AS id FROM t1",
         )
 
 


### PR DESCRIPTION
Other backends besides mssql support an operation like try_cast. Move it
to a common place so they can all implement it.

Fixes: #9752
Closes: #9752

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
