### PR TITLE
Add reserved word 'groups'

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1526,6 +1526,7 @@ RESERVED_WORDS = {
     "from",
     "grant",
     "group",
+    "groups",
     "having",
     "in",
     "initially",

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1526,7 +1526,6 @@ RESERVED_WORDS = {
     "from",
     "grant",
     "group",
-    "groups",
     "having",
     "in",
     "initially",

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -170,6 +170,7 @@ RESERVED_WORDS = {
     "full",
     "grant",
     "group",
+    "groups",
     "having",
     "ilike",
     "in",


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Unable to create a simple table called "groups" because it's not in the reserved word list.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ x] A short code fix
	- https://github.com/sqlalchemy/sqlalchemy/issues/9793
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
