### PR TITLE
Update check constraint docs for MySQL support

### DIFF
--- a/doc/build/core/constraints.rst
+++ b/doc/build/core/constraints.rst
@@ -357,7 +357,7 @@ constraints generally should only refer to the column to which they are
 placed, while table level constraints can refer to any columns in the table.
 
 Note that some databases do not actively support check constraints such as
-MySQL.
+older versions of MySQL (prior to 8.0.16).
 
 .. sourcecode:: python+sql
 


### PR DESCRIPTION
### Description

The `CHECK` constraint is now supported by MySQL as of version 8.0.16.

[MySQL Docs](https://dev.mysql.com/doc/refman/8.0/en/create-table-check-constraints.html)
[W3Schools](https://www.w3schools.com/mysql/mysql_check.asp)

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
