### PR TITLE
Add psycopg binary to extras

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ postgresql_asyncpg =
 postgresql_psycopg2binary = psycopg2-binary
 postgresql_psycopg2cffi = psycopg2cffi
 postgresql_psycopg = psycopg>=3.0.7
+postgresql_psycopgbinary = psycopg[binary]>=3.0.7
 pymysql =
     pymysql
 aiomysql =


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Add a `postgresql_psycopgbinary` to extras similarly to `postgresql_psycopg2binary`. Accoring to psycopg docs, it's a recommended usage that doesn't require `libpq` to be installed, see https://www.psycopg.org/psycopg3/docs/basic/install.html.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
