### PR TITLE
Fix type hint of `key` on `Visitable.__class_getitem__()`

### DIFF
--- a/lib/sqlalchemy/orm/decl_api.py
+++ b/lib/sqlalchemy/orm/decl_api.py
@@ -1532,7 +1532,7 @@ class registry:
 
         if hasattr(cls, "__class_getitem__"):
 
-            def __class_getitem__(cls: Type[_T], key: str) -> Type[_T]:
+            def __class_getitem__(cls: Type[_T], key: Any) -> Type[_T]:
                 # allow generic classes in py3.9+
                 return cls
 

--- a/lib/sqlalchemy/sql/visitors.py
+++ b/lib/sqlalchemy/sql/visitors.py
@@ -146,7 +146,7 @@ class Visitable:
             cls._original_compiler_dispatch
         ) = _compiler_dispatch
 
-    def __class_getitem__(cls, key: str) -> Any:
+    def __class_getitem__(cls, key: Any) -> Any:
         # allow generic classes in py3.9+
         return cls
 


### PR DESCRIPTION
### Description
`Visitable.__class_getitem__()` is defined to allow parameterized generics in older versions of Python. (Issue #6759)
Previously, arg `key` of that function was type-hinted as `str`. This caused some type checkers, including PyCharm, to emit a warning if you tried to parameterize a function with the actual class it would return instead of a string reference to it.

Now the type hint has been changed to `Any`, fixing this issue.

The new type of `Any` was selected because:
- `Union[str, type]` would not allow parameterizing with an optional type or a union of types
- `Union[str, type, types.UnionType]` would not work in versions of Python older than 3.10 (when `UnionType` was added)

The definition of `__class_getitem__()` in `registry.generate_base()` has also been updated similarly.

Fixes: #9878

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
