### PR TITLE
Add support for SQL string aggregation function :class:`.string_agg`

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -2057,6 +2057,9 @@ class MSSQLCompiler(compiler.SQLCompiler):
     def visit_char_length_func(self, fn, **kw):
         return "LEN%s" % self.function_argspec(fn, **kw)
 
+    def visit_aggregate_strings_func(self, fn, **kw):
+        return "string_agg%s" % self.function_argspec(fn, **kw)
+
     def visit_concat_op_expression_clauselist(
         self, clauselist, operator, **kw
     ):

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1208,6 +1208,15 @@ class MySQLCompiler(compiler.SQLCompiler):
         )
         return f"{clause} WITH ROLLUP"
 
+    def visit_string_agg_func(self, fn, **kw):
+        if len(fn.clauses) > 1:
+            return "group_concat(%s SEPARATOR %s)" % (
+                fn.clauses[0]._compiler_dispatch(self, **kw),
+                fn.clauses[-1]._compiler_dispatch(self, **kw),
+            )
+        else:
+            return "group_concat%s" % self.function_argspec(fn)
+
     def visit_sequence(self, seq, **kw):
         return "nextval(%s)" % self.preparer.format_sequence(seq)
 

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1208,15 +1208,9 @@ class MySQLCompiler(compiler.SQLCompiler):
         )
         return f"{clause} WITH ROLLUP"
 
-    def visit_string_agg_func(self, fn, **kw):
-        if len(fn.clauses) > 1:
-            clauses = [
-                elem._compiler_dispatch(self, **kw) for elem in fn.clauses
-            ]
-            clause = ", ".join(clauses[:-1])
-            return "group_concat(%s SEPARATOR %s)" % (clause, clauses[-1])
-        else:
-            return "group_concat%s" % self.function_argspec(fn)
+    def visit_aggregate_strings_func(self, fn, **kw):
+        expr, delimeter = fn.clauses
+        return "group_concat(%s SEPARATOR %s)" % (expr, delimeter)
 
     def visit_sequence(self, seq, **kw):
         return "nextval(%s)" % self.preparer.format_sequence(seq)

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1210,13 +1210,11 @@ class MySQLCompiler(compiler.SQLCompiler):
 
     def visit_string_agg_func(self, fn, **kw):
         if len(fn.clauses) > 1:
-            clause = ", ".join(
-                elem._compiler_dispatch(self, **kw) for elem in fn.clauses[:-1]
-            )
-            return "group_concat(%s SEPARATOR %s)" % (
-                clause,
-                fn.clauses[-1]._compiler_dispatch(self, **kw),
-            )
+            clauses = [
+                elem._compiler_dispatch(self, **kw) for elem in fn.clauses
+            ]
+            clause = ", ".join(clauses[:-1])
+            return "group_concat(%s SEPARATOR %s)" % (clause, clauses[-1])
         else:
             return "group_concat%s" % self.function_argspec(fn)
 

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1210,8 +1210,11 @@ class MySQLCompiler(compiler.SQLCompiler):
 
     def visit_string_agg_func(self, fn, **kw):
         if len(fn.clauses) > 1:
+            clause = ", ".join(
+                elem._compiler_dispatch(self, **kw) for elem in fn.clauses[:-1]
+            )
             return "group_concat(%s SEPARATOR %s)" % (
-                fn.clauses[0]._compiler_dispatch(self, **kw),
+                clause,
                 fn.clauses[-1]._compiler_dispatch(self, **kw),
             )
         else:

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1868,6 +1868,9 @@ class PGCompiler(compiler.SQLCompiler):
             value = value.replace("\\", "\\\\")
         return value
 
+    def visit_aggregate_strings_func(self, fn, **kw):
+        return "string_agg%s" % self.function_argspec(fn)
+
     def visit_sequence(self, seq, **kw):
         return "nextval('%s')" % self.preparer.format_sequence(seq)
 

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -1318,6 +1318,9 @@ class SQLiteCompiler(compiler.SQLCompiler):
     def visit_char_length_func(self, fn, **kw):
         return "length%s" % self.function_argspec(fn)
 
+    def visit_string_agg_func(self, fn, **kw):
+        return "group_concat%s" % self.function_argspec(fn)
+
     def visit_cast(self, cast, **kwargs):
         if self.dialect.supports_cast:
             return super().visit_cast(cast, **kwargs)

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -1318,7 +1318,7 @@ class SQLiteCompiler(compiler.SQLCompiler):
     def visit_char_length_func(self, fn, **kw):
         return "length%s" % self.function_argspec(fn)
 
-    def visit_string_agg_func(self, fn, **kw):
+    def visit_aggregate_strings_func(self, fn, **kw):
         return "group_concat%s" % self.function_argspec(fn)
 
     def visit_cast(self, cast, **kwargs):

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -2766,6 +2766,9 @@ class ClauseList(
         self._is_implicitly_boolean = False
         return self
 
+    def __getitem__(self, item) -> ColumnElement[Any]:
+        return self.clauses[item]
+
     def __iter__(self) -> Iterator[ColumnElement[Any]]:
         return iter(self.clauses)
 

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -2766,9 +2766,6 @@ class ClauseList(
         self._is_implicitly_boolean = False
         return self
 
-    def __getitem__(self, item) -> ColumnElement[Any]:
-        return self.clauses[item]
-
     def __iter__(self) -> Iterator[ColumnElement[Any]]:
         return iter(self.clauses)
 

--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -1045,6 +1045,10 @@ class _FunctionGenerator:
             ...
 
         @property
+        def string_agg(self) -> Type[string_agg[Any]]:
+            ...
+
+        @property
         def sum(self) -> Type[sum[Any]]:  # noqa: A001
             ...
 
@@ -1795,3 +1799,20 @@ class grouping_sets(GenericFunction[_T]):
     """
     _has_args = True
     inherit_cache = True
+
+
+class string_agg(GenericFunction[_T]):
+    r"""Implement the ``STRING_AGG`` aggregation function
+
+    This function will concatenate non-null values into a string and
+    separate the values by a delimeter.
+
+    The return type of this function is :class:`.String`.
+
+    """
+    type = sqltypes.String()
+    _has_args = True
+    inherit_cache = True
+
+    def __init__(self, sep=",", *args, **kwargs):
+        super().__init__(sep, *args, **kwargs)

--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -1045,7 +1045,7 @@ class _FunctionGenerator:
             ...
 
         @property
-        def string_agg(self) -> Type[string_agg[Any]]:
+        def aggregate_strings(self) -> Type[aggregate_strings[Any]]:
             ...
 
         @property
@@ -1801,15 +1801,15 @@ class grouping_sets(GenericFunction[_T]):
     inherit_cache = True
 
 
-class string_agg(GenericFunction[_T]):
+class aggregate_strings(GenericFunction[_T]):
     r"""Implement the ``STRING_AGG`` aggregation function
 
     This function will concatenate non-null values into a string and
     separate the values by a delimeter.
 
-    e.g. Example usage with delimeter '.' as the last argument
+    e.g. Example usage with delimeter '.'
 
-    stmt = select(func.string_agg(table.c.str_col, "."))
+    stmt = select(func.aggregate_strings(table.c.str_col, "."))
 
     The return type of this function is :class:`.String`.
 

--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -1807,12 +1807,13 @@ class string_agg(GenericFunction[_T]):
     This function will concatenate non-null values into a string and
     separate the values by a delimeter.
 
+    e.g. Example usage with delimeter '.' as the last argument
+
+    stmt = select(func.string_agg(table.c.str_col, "."))
+
     The return type of this function is :class:`.String`.
 
     """
     type = sqltypes.String()
     _has_args = True
     inherit_cache = True
-
-    def __init__(self, sep=",", *args, **kwargs):
-        super().__init__(sep, *args, **kwargs)

--- a/test/sql/test_compare.py
+++ b/test/sql/test_compare.py
@@ -378,6 +378,10 @@ class CoreFixtures:
         lambda: (tuple_(1, 2), tuple_(3, 4)),
         lambda: (func.array_agg([1, 2]), func.array_agg([3, 4])),
         lambda: (
+            func.string_agg(table_a.c.b),
+            func.string_agg(table_b_like_a.c.b),
+        ),
+        lambda: (
             func.percentile_cont(0.5).within_group(table_a.c.a),
             func.percentile_cont(0.5).within_group(table_a.c.b),
             func.percentile_cont(0.5).within_group(table_a.c.a, table_a.c.b),

--- a/test/sql/test_compare.py
+++ b/test/sql/test_compare.py
@@ -378,8 +378,8 @@ class CoreFixtures:
         lambda: (tuple_(1, 2), tuple_(3, 4)),
         lambda: (func.array_agg([1, 2]), func.array_agg([3, 4])),
         lambda: (
-            func.string_agg(table_a.c.b),
-            func.string_agg(table_b_like_a.c.b),
+            func.aggregate_strings(table_a.c.b, ","),
+            func.aggregate_strings(table_b_like_a.c.b, ","),
         ),
         lambda: (
             func.percentile_cont(0.5).within_group(table_a.c.a),

--- a/test/sql/test_functions.py
+++ b/test/sql/test_functions.py
@@ -242,6 +242,14 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             literal_binds=True,
             render_postcompile=True,
         )
+        self.assert_compile(
+            stmt,
+            "SELECT group_concat(t.value SEPARATOR ',') "
+            "AS string_agg_1 FROM t",
+            dialect=mysql.dialect(),
+            literal_binds=True,
+            render_postcompile=True,
+        )
 
     def test_cube_operators(self):
         t = table(


### PR DESCRIPTION
Returns a :class:`.String` with support for PostgreSQL, SQLite, and MSSQL. fixes #9873

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Implements the `STRING_AGG` (MSSQL, PostgreSQL) and `GROUP_CONCAT` (SQLite) generic functions, to concatenate non-null values and separate them with a delimiter (`,` by default). Fixes #9873

Named `string_agg` as per discussion on the linked issue, and supports only the RDBMS mentioned on the issue (MSSQL, PostgreSQL, SQLite)

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
