### PR TITLE
fix: allow escape value to be an empty string

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1789,7 +1789,7 @@ class PGCompiler(compiler.SQLCompiler):
             self.process(binary.right, **kw),
         ) + (
             " ESCAPE " + self.render_literal_value(escape, sqltypes.STRINGTYPE)
-            if escape
+            if escape is not None
             else ""
         )
 
@@ -1800,7 +1800,7 @@ class PGCompiler(compiler.SQLCompiler):
             self.process(binary.right, **kw),
         ) + (
             " ESCAPE " + self.render_literal_value(escape, sqltypes.STRINGTYPE)
-            if escape
+            if escape is not None
             else ""
         )
 

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -3482,7 +3482,7 @@ class SQLCompiler(Compiled):
             binary.right._compiler_dispatch(self, **kw),
         ) + (
             " ESCAPE " + self.render_literal_value(escape, sqltypes.STRINGTYPE)
-            if escape
+            if escape is not None
             else ""
         )
 
@@ -3493,7 +3493,7 @@ class SQLCompiler(Compiled):
             binary.right._compiler_dispatch(self, **kw),
         ) + (
             " ESCAPE " + self.render_literal_value(escape, sqltypes.STRINGTYPE)
-            if escape
+            if escape is not None
             else ""
         )
 

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -24,6 +24,7 @@ from sqlalchemy import schema
 from sqlalchemy import select
 from sqlalchemy import Sequence
 from sqlalchemy import SmallInteger
+from sqlalchemy import sql
 from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy import testing
@@ -2581,6 +2582,30 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         self.assert_compile(
             select(c1.bitwise_xor(c2)),
             "SELECT c1 # c2 AS anon_1",
+        )
+
+    def test_ilike_escaping(self):
+        dialect = postgresql.dialect()
+        self.assert_compile(
+            sql.column("foo").ilike("bar", escape="\\"),
+            "foo ILIKE %(foo_1)s ESCAPE '\\\\'",
+        )
+
+        self.assert_compile(
+            sql.column("foo").ilike("bar", escape=""),
+            "foo ILIKE %(foo_1)s ESCAPE ''",
+            dialect=dialect,
+        )
+
+        self.assert_compile(
+            sql.column("foo").notilike("bar", escape="\\"),
+            "foo NOT ILIKE %(foo_1)s ESCAPE '\\\\'",
+        )
+
+        self.assert_compile(
+            sql.column("foo").notilike("bar", escape=""),
+            "foo NOT ILIKE %(foo_1)s ESCAPE ''",
+            dialect=dialect,
         )
 
 

--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -3533,6 +3533,13 @@ class ComposedLikeOperatorsTest(fixtures.TestBase, testing.AssertsCompiledSQL):
             checkparams={"x_1": "a%b_c"},
         )
 
+    def test_like_escape_empty(self):
+        self.assert_compile(
+            column("x").like("y", escape=""),
+            "x LIKE :x_1 ESCAPE ''",
+            checkparams={"x_1": "y"},
+        )
+
     def test_ilike(self):
         self.assert_compile(
             column("x").ilike("y"),
@@ -3545,6 +3552,13 @@ class ComposedLikeOperatorsTest(fixtures.TestBase, testing.AssertsCompiledSQL):
             column("x").ilike("a%b_c", escape="\\"),
             "lower(x) LIKE lower(:x_1) ESCAPE '\\'",
             checkparams={"x_1": "a%b_c"},
+        )
+
+    def test_ilike_escape_empty(self):
+        self.assert_compile(
+            column("x").ilike("y", escape=""),
+            "lower(x) LIKE lower(:x_1) ESCAPE ''",
+            checkparams={"x_1": "y"},
         )
 
     def test_not_like(self):
@@ -3561,6 +3575,13 @@ class ComposedLikeOperatorsTest(fixtures.TestBase, testing.AssertsCompiledSQL):
             checkparams={"x_1": "a%b_c"},
         )
 
+    def test_not_like_escape_empty(self):
+        self.assert_compile(
+            column("x").not_like("y", escape=""),
+            "x NOT LIKE :x_1 ESCAPE ''",
+            checkparams={"x_1": "y"},
+        )
+
     def test_not_ilike(self):
         self.assert_compile(
             column("x").not_ilike("y"),
@@ -3573,6 +3594,13 @@ class ComposedLikeOperatorsTest(fixtures.TestBase, testing.AssertsCompiledSQL):
             column("x").not_ilike("a%b_c", escape="\\"),
             "lower(x) NOT LIKE lower(:x_1) ESCAPE '\\'",
             checkparams={"x_1": "a%b_c"},
+        )
+
+    def test_not_ilike_escape_empty(self):
+        self.assert_compile(
+            column("x").not_ilike("y", escape=""),
+            "lower(x) NOT LIKE lower(:x_1) ESCAPE ''",
+            checkparams={"x_1": "y"},
         )
 
     def test_startswith(self):


### PR DESCRIPTION
### Description
PostgreSQL allows specifying an empty string as the ESCAPE clause for the LIKE/ILIKE operator to turn off escaping.
https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE

However, SQLAlchemy treats the empty string passed as an argument to like/ilike functions as None.
### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
