### PR TITLE
fix typo: `async_attrs` to `awaitable_attrs`

### DIFF
--- a/lib/sqlalchemy/ext/asyncio/session.py
+++ b/lib/sqlalchemy/ext/asyncio/session.py
@@ -121,9 +121,9 @@ class AsyncAttrs:
 
         a1 = (await async_session.scalars(select(A).where(A.id == 5))).one()
 
-        # use the lazy loader on ``a1.bs`` via the ``.async_attrs``
+        # use the lazy loader on ``a1.bs`` via the ``.awaitable_attrs``
         # interface, so that it may be awaited
-        for b1 in await a1.async_attrs.bs:
+        for b1 in await a1.awaitable_attrs.bs:
             print(b1)
 
     The :attr:`_asyncio.AsyncAttrs.awaitable_attrs` performs a call against the
@@ -160,8 +160,8 @@ class AsyncAttrs:
 
             a1 = (await async_session.scalars(select(A).where(A.id == 5))).one()
 
-            some_attribute = await a1.async_attrs.some_deferred_attribute
-            some_collection = await a1.async_attrs.some_collection
+            some_attribute = await a1.awaitable_attrs.some_deferred_attribute
+            some_collection = await a1.awaitable_attrs.some_collection
 
         """  # noqa: E501
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Fixes a typo: In the doc, references to `async_attrs` have been changed to `awaitable_attrs` to reflect the proper usage.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
