### PR TITLE
pg8000: Support range and multirange types

### DIFF
--- a/doc/build/changelog/unreleased_20/9965.rst
+++ b/doc/build/changelog/unreleased_20/9965.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: pg8000
+    :tickets: 9965
+
+    The pg8000 dialect now supports :class:`_postgresql.Range` types and multirange
+    types. Range and multirange types are supported in the pg8000 driver from version
+    1.29.8.

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -4636,7 +4636,7 @@ class _RangeTypeRoundTrip(_RangeComparisonFixtures, fixtures.TablesTest):
         )
         self._assert_data(connection)
 
-    @testing.requires.any_psycopg_compatibility
+    @testing.requires.psycopg_or_pg8000_compatibility
     def test_insert_text(self, connection):
         connection.execute(
             self.tables.data_table.insert(), {"range": self._data_str()}
@@ -4653,7 +4653,7 @@ class _RangeTypeRoundTrip(_RangeComparisonFixtures, fixtures.TablesTest):
         data = connection.execute(select(range_ + range_)).fetchall()
         eq_(data, [(self._data_obj(),)])
 
-    @testing.requires.any_psycopg_compatibility
+    @testing.requires.psycopg_or_pg8000_compatibility
     def test_union_result_text(self, connection):
         # insert
         connection.execute(
@@ -4674,7 +4674,7 @@ class _RangeTypeRoundTrip(_RangeComparisonFixtures, fixtures.TablesTest):
         data = connection.execute(select(range_ * range_)).fetchall()
         eq_(data, [(self._data_obj(),)])
 
-    @testing.requires.any_psycopg_compatibility
+    @testing.requires.psycopg_or_pg8000_compatibility
     def test_intersection_result_text(self, connection):
         # insert
         connection.execute(
@@ -4695,7 +4695,7 @@ class _RangeTypeRoundTrip(_RangeComparisonFixtures, fixtures.TablesTest):
         data = connection.execute(select(range_ - range_)).fetchall()
         eq_(data, [(self._data_obj().__class__(empty=True),)])
 
-    @testing.requires.any_psycopg_compatibility
+    @testing.requires.psycopg_or_pg8000_compatibility
     def test_difference_result_text(self, connection):
         # insert
         connection.execute(
@@ -5146,14 +5146,14 @@ class _MultiRangeTypeRoundTrip(fixtures.TablesTest):
         )
         self._assert_data(connection)
 
-    @testing.requires.any_psycopg_compatibility
+    @testing.requires.psycopg_or_pg8000_compatibility
     def test_insert_text(self, connection):
         connection.execute(
             self.tables.data_table.insert(), {"range": self._data_str()}
         )
         self._assert_data(connection)
 
-    @testing.requires.any_psycopg_compatibility
+    @testing.requires.psycopg_or_pg8000_compatibility
     def test_union_result_text(self, connection):
         # insert
         connection.execute(
@@ -5164,7 +5164,7 @@ class _MultiRangeTypeRoundTrip(fixtures.TablesTest):
         data = connection.execute(select(range_ + range_)).fetchall()
         eq_(data, [(self._data_obj(),)])
 
-    @testing.requires.any_psycopg_compatibility
+    @testing.requires.psycopg_or_pg8000_compatibility
     def test_intersection_result_text(self, connection):
         # insert
         connection.execute(
@@ -5175,7 +5175,7 @@ class _MultiRangeTypeRoundTrip(fixtures.TablesTest):
         data = connection.execute(select(range_ * range_)).fetchall()
         eq_(data, [(self._data_obj(),)])
 
-    @testing.requires.any_psycopg_compatibility
+    @testing.requires.psycopg_or_pg8000_compatibility
     def test_difference_result_text(self, connection):
         # insert
         connection.execute(

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -1484,11 +1484,13 @@ class DefaultRequirements(SuiteRequirements):
 
     @property
     def range_types(self):
-        return only_on(["+psycopg2", "+psycopg", "+asyncpg"])
+        return only_on(["+psycopg2", "+psycopg", "+asyncpg", "+pg8000"])
 
     @property
     def multirange_types(self):
-        return only_on(["+psycopg", "+asyncpg"]) + only_on("postgresql >= 14")
+        return only_on(["+psycopg", "+asyncpg", "+pg8000"]) + only_on(
+            "postgresql >= 14"
+        )
 
     @property
     def async_dialect(self):


### PR DESCRIPTION
### Description

From version 1.29.7, pg8000 supports `range` and `multirange` types. This change to the pg8000 dialect enables these range types in SQLAlchemy.

### Checklist

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x ] A short code fix
	- This fixes https://github.com/sqlalchemy/sqlalchemy/issues/9965
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
