### PR TITLE
Typing: url in create_mock_engine can be a string

### DIFF
--- a/lib/sqlalchemy/engine/mock.py
+++ b/lib/sqlalchemy/engine/mock.py
@@ -69,7 +69,9 @@ class MockConnection:
         return self._execute_impl(obj, parameters)
 
 
-def create_mock_engine(url: Union[str, URL], executor: Any, **kw: Any) -> MockConnection:
+def create_mock_engine(
+    url: Union[str, URL], executor: Any, **kw: Any
+) -> MockConnection:
     """Create a "mock" engine used for echoing DDL.
 
     This is a utility function used for debugging or storing the output of DDL

--- a/lib/sqlalchemy/engine/mock.py
+++ b/lib/sqlalchemy/engine/mock.py
@@ -69,7 +69,7 @@ class MockConnection:
         return self._execute_impl(obj, parameters)
 
 
-def create_mock_engine(url: URL, executor: Any, **kw: Any) -> MockConnection:
+def create_mock_engine(url: Union[str, URL], executor: Any, **kw: Any) -> MockConnection:
     """Create a "mock" engine used for echoing DDL.
 
     This is a utility function used for debugging or storing the output of DDL


### PR DESCRIPTION
### Description

`create_engine` can accept a `str` without any type issues, while passing `str` to `create_mock_engine` results in type mismatch with URL.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
