### PR TITLE
Type annotate postgresql dml

### DIFF
--- a/lib/sqlalchemy/dialects/_typing.py
+++ b/lib/sqlalchemy/dialects/_typing.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Any
+from typing import Iterable
+from typing import Mapping
+from typing import Optional
+from typing import Union
+
+from ..sql._typing import _DDLColumnArgument
+from ..sql.elements import DQLDMLClauseElement
+from ..sql.schema import ColumnCollectionConstraint
+
+
+_OnConflictConstraintT = Union[str, ColumnCollectionConstraint, None]
+_OnConflictIndexElementsT = Optional[Iterable[_DDLColumnArgument]]
+_OnConflictIndexWhereT = Optional[DQLDMLClauseElement]
+_OnConflictSetT = Optional[Mapping[Any, Any]]
+_OnConflictWhereT = Union[DQLDMLClauseElement, str, None]

--- a/lib/sqlalchemy/dialects/postgresql/dml.py
+++ b/lib/sqlalchemy/dialects/postgresql/dml.py
@@ -24,11 +24,11 @@ from ...sql._typing import _DMLTableArgument
 from ...sql.base import _exclusive_against
 from ...sql.base import _generative
 from ...sql.base import ColumnCollection
-from ...sql.base import KeyedColumnElement
 from ...sql.base import ReadOnlyColumnCollection
 from ...sql.dml import Insert as StandardInsert
 from ...sql.elements import ClauseElement
 from ...sql.elements import DQLDMLClauseElement
+from ...sql.elements import KeyedColumnElement
 from ...sql.expression import alias
 from ...sql.schema import ColumnCollectionConstraint
 from ...util.typing import Self

--- a/lib/sqlalchemy/dialects/postgresql/dml.py
+++ b/lib/sqlalchemy/dialects/postgresql/dml.py
@@ -6,26 +6,32 @@
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
 # mypy: ignore-errors
 
-from typing import Iterable, Mapping, Optional, Union, Any
+from __future__ import annotations
+
+from typing import Any
+from typing import Iterable
+from typing import Mapping
+from typing import Optional
+from typing import Union
 
 from . import ext
 from ... import util
 from ...sql import coercions
 from ...sql import roles
 from ...sql import schema
+from ...sql._typing import _DDLColumnArgument
+from ...sql._typing import _DMLTableArgument
 from ...sql.base import _exclusive_against
-from ...sql.base import (
-    _generative,
-    ReadOnlyColumnCollection,
-    KeyedColumnElement,
-)
+from ...sql.base import _generative
 from ...sql.base import ColumnCollection
+from ...sql.base import KeyedColumnElement
+from ...sql.base import ReadOnlyColumnCollection
 from ...sql.dml import Insert as StandardInsert
-from ...sql.elements import ClauseElement, DQLDMLClauseElement
+from ...sql.elements import ClauseElement
+from ...sql.elements import DQLDMLClauseElement
 from ...sql.expression import alias
 from ...sql.schema import ColumnCollectionConstraint
 from ...util.typing import Self
-from ...sql._typing import _DMLTableArgument, _DDLColumnArgument
 
 
 __all__ = ("Insert", "insert")

--- a/lib/sqlalchemy/dialects/postgresql/dml.py
+++ b/lib/sqlalchemy/dialects/postgresql/dml.py
@@ -9,17 +9,17 @@
 from __future__ import annotations
 
 from typing import Any
-from typing import Iterable
-from typing import Mapping
-from typing import Optional
-from typing import Union
 
 from . import ext
+from .._typing import _OnConflictConstraintT
+from .._typing import _OnConflictIndexElementsT
+from .._typing import _OnConflictIndexWhereT
+from .._typing import _OnConflictSetT
+from .._typing import _OnConflictWhereT
 from ... import util
 from ...sql import coercions
 from ...sql import roles
 from ...sql import schema
-from ...sql._typing import _DDLColumnArgument
 from ...sql._typing import _DMLTableArgument
 from ...sql.base import _exclusive_against
 from ...sql.base import _generative
@@ -27,23 +27,15 @@ from ...sql.base import ColumnCollection
 from ...sql.base import ReadOnlyColumnCollection
 from ...sql.dml import Insert as StandardInsert
 from ...sql.elements import ClauseElement
-from ...sql.elements import DQLDMLClauseElement
 from ...sql.elements import KeyedColumnElement
 from ...sql.expression import alias
-from ...sql.schema import ColumnCollectionConstraint
 from ...util.typing import Self
 
 
 __all__ = ("Insert", "insert")
 
-_ConstraintT = Union[str, ColumnCollectionConstraint, None]
-_IndexElementsT = Optional[Iterable[_DDLColumnArgument]]
-_IndexWhereT = Optional[DQLDMLClauseElement]
-_SetT = Optional[Mapping[Any, Any]]
-_WhereT = Union[DQLDMLClauseElement, str, None]
 
-
-def insert(table: _DMLTableArgument) -> "Insert":
+def insert(table: _DMLTableArgument) -> Insert:
     """Construct a PostgreSQL-specific variant :class:`_postgresql.Insert`
     construct.
 
@@ -117,11 +109,11 @@ class Insert(StandardInsert):
     @_on_conflict_exclusive
     def on_conflict_do_update(
         self,
-        constraint: _ConstraintT = None,
-        index_elements: _IndexElementsT = None,
-        index_where: _IndexWhereT = None,
-        set_: _SetT = None,
-        where: _WhereT = None,
+        constraint: _OnConflictConstraintT = None,
+        index_elements: _OnConflictIndexElementsT = None,
+        index_where: _OnConflictIndexWhereT = None,
+        set_: _OnConflictSetT = None,
+        where: _OnConflictWhereT = None,
     ) -> Self:
         r"""
         Specifies a DO UPDATE SET action for ON CONFLICT clause.
@@ -183,9 +175,9 @@ class Insert(StandardInsert):
     @_on_conflict_exclusive
     def on_conflict_do_nothing(
         self,
-        constraint: _ConstraintT = None,
-        index_elements: _IndexElementsT = None,
-        index_where: _IndexWhereT = None,
+        constraint: _OnConflictConstraintT = None,
+        index_elements: _OnConflictIndexElementsT = None,
+        index_where: _OnConflictIndexWhereT = None,
     ) -> Self:
         """
         Specifies a DO NOTHING action for ON CONFLICT clause.
@@ -222,9 +214,9 @@ class OnConflictClause(ClauseElement):
 
     def __init__(
         self,
-        constraint: _ConstraintT = None,
-        index_elements: _IndexElementsT = None,
-        index_where: _IndexWhereT = None,
+        constraint: _OnConflictConstraintT = None,
+        index_elements: _OnConflictIndexElementsT = None,
+        index_where: _OnConflictIndexWhereT = None,
     ):
         if constraint is not None:
             if not isinstance(constraint, str) and isinstance(
@@ -276,11 +268,11 @@ class OnConflictDoUpdate(OnConflictClause):
 
     def __init__(
         self,
-        constraint: _ConstraintT = None,
-        index_elements: _IndexElementsT = None,
-        index_where: _IndexWhereT = None,
-        set_: _SetT = None,
-        where: _WhereT = None,
+        constraint: _OnConflictConstraintT = None,
+        index_elements: _OnConflictIndexElementsT = None,
+        index_where: _OnConflictIndexWhereT = None,
+        set_: _OnConflictSetT = None,
+        where: _OnConflictWhereT = None,
     ):
         super().__init__(
             constraint=constraint,

--- a/lib/sqlalchemy/dialects/sqlite/dml.py
+++ b/lib/sqlalchemy/dialects/sqlite/dml.py
@@ -5,23 +5,32 @@
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
 # mypy: ignore-errors
 
+from __future__ import annotations
 
+from typing import Any
+
+from .._typing import _OnConflictIndexElementsT
+from .._typing import _OnConflictIndexWhereT
+from .._typing import _OnConflictSetT
+from .._typing import _OnConflictWhereT
 from ... import util
 from ...sql import coercions
 from ...sql import roles
+from ...sql._typing import _DMLTableArgument
 from ...sql.base import _exclusive_against
 from ...sql.base import _generative
 from ...sql.base import ColumnCollection
+from ...sql.base import ReadOnlyColumnCollection
 from ...sql.dml import Insert as StandardInsert
 from ...sql.elements import ClauseElement
+from ...sql.elements import KeyedColumnElement
 from ...sql.expression import alias
 from ...util.typing import Self
-
 
 __all__ = ("Insert", "insert")
 
 
-def insert(table):
+def insert(table: _DMLTableArgument) -> Insert:
     """Construct a sqlite-specific variant :class:`_sqlite.Insert`
     construct.
 
@@ -61,7 +70,9 @@ class Insert(StandardInsert):
     inherit_cache = False
 
     @util.memoized_property
-    def excluded(self):
+    def excluded(
+        self,
+    ) -> ReadOnlyColumnCollection[str, KeyedColumnElement[Any]]:
         """Provide the ``excluded`` namespace for an ON CONFLICT statement
 
         SQLite's ON CONFLICT clause allows reference to the row that would
@@ -94,10 +105,10 @@ class Insert(StandardInsert):
     @_on_conflict_exclusive
     def on_conflict_do_update(
         self,
-        index_elements=None,
-        index_where=None,
-        set_=None,
-        where=None,
+        index_elements: _OnConflictIndexElementsT = None,
+        index_where: _OnConflictIndexWhereT = None,
+        set_: _OnConflictSetT = None,
+        where: _OnConflictWhereT = None,
     ) -> Self:
         r"""
         Specifies a DO UPDATE SET action for ON CONFLICT clause.
@@ -147,7 +158,9 @@ class Insert(StandardInsert):
     @_generative
     @_on_conflict_exclusive
     def on_conflict_do_nothing(
-        self, index_elements=None, index_where=None
+        self,
+        index_elements: _OnConflictIndexElementsT = None,
+        index_where: _OnConflictIndexWhereT = None,
     ) -> Self:
         """
         Specifies a DO NOTHING action for ON CONFLICT clause.
@@ -172,7 +185,11 @@ class Insert(StandardInsert):
 class OnConflictClause(ClauseElement):
     stringify_dialect = "sqlite"
 
-    def __init__(self, index_elements=None, index_where=None):
+    def __init__(
+        self,
+        index_elements: _OnConflictIndexElementsT = None,
+        index_where: _OnConflictIndexWhereT = None,
+    ):
         if index_elements is not None:
             self.constraint_target = None
             self.inferred_target_elements = index_elements
@@ -192,10 +209,10 @@ class OnConflictDoUpdate(OnConflictClause):
 
     def __init__(
         self,
-        index_elements=None,
-        index_where=None,
-        set_=None,
-        where=None,
+        index_elements: _OnConflictIndexElementsT = None,
+        index_where: _OnConflictIndexWhereT = None,
+        set_: _OnConflictSetT = None,
+        where: _OnConflictWhereT = None,
     ):
         super().__init__(
             index_elements=index_elements,


### PR DESCRIPTION
### Description
The goal is to annotate postgresql specific apis that are under postgresql/dml.py file.
I've looked around to see what types are used for similar apis, hope I got it right :)

### Checklist

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
