### PR TITLE
Allow reflecting UUID in MariaDB

### DIFF
--- a/doc/build/changelog/unreleased_20/10028.rst
+++ b/doc/build/changelog/unreleased_20/10028.rst
@@ -1,0 +1,7 @@
+.. change::
+	:tags: usecase, mariadb, reflection
+	:tickets: 10028
+
+	Allowed reflecting :class:`_types.UUID` columns from MariaDB. This allows
+	Alembic to properly detect the type of such columns in existing MariaDB
+	databases.

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1067,6 +1067,7 @@ from ...types import BINARY
 from ...types import BLOB
 from ...types import BOOLEAN
 from ...types import DATE
+from ...types import UUID
 from ...types import VARBINARY
 from ...util import topological
 
@@ -1155,6 +1156,7 @@ ischema_names = {
     "tinyblob": TINYBLOB,
     "tinyint": TINYINT,
     "tinytext": TINYTEXT,
+    "uuid": UUID,
     "varbinary": VARBINARY,
     "varchar": VARCHAR,
     "year": YEAR,

--- a/test/dialect/mysql/test_reflection.py
+++ b/test/dialect/mysql/test_reflection.py
@@ -242,6 +242,13 @@ class TypeReflectionTest(fixtures.TestBase):
 
         self._run_test(metadata, connection, specs, ["enums"])
 
+    @testing.only_on("mariadb>=10.7")
+    def test_uuid(self, metadata, connection):
+        specs = [
+            (mysql.UUID(), mysql.UUID()),
+        ]
+        self._run_test(metadata, connection, specs, [])
+
 
 class ReflectionTest(fixtures.TestBase, AssertsCompiledSQL):
     __only_on__ = "mysql", "mariadb"


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

Added the `"uuid"` key to `ischema_names` to enable lookup of `UUID` columns in reflection. There's also a new short test (MariaDB 10.7+ only) in the mysql reflection tests to verify if this feature works correctly.

Fixes #10028

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
