### PR TITLE
Fix indentation in reST directive title

### DIFF
--- a/doc/build/orm/dataclasses.rst
+++ b/doc/build/orm/dataclasses.rst
@@ -529,9 +529,9 @@ Integrating with Alternate Dataclass Providers such as Pydantic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. warning::  The dataclass layer of Pydantic version 1.x is **not fully
-    compatible with SQLAlchemy's class instrumentation without additional
-    internal changes, and many features such as related collections may
-    not work correctly.**.
+   compatible with SQLAlchemy's class instrumentation without additional
+   internal changes, and many features such as related collections may
+   not work correctly.**.
 
    For Pydantic compatibility, please consider the
    `SQLModel <https://sqlmodel.tiangolo.com/>` ORM which is built with


### PR DESCRIPTION
### Description
This fixes a markup glitch in the [dataclasses](https://docs.sqlalchemy.org/en/20/orm/dataclasses.html#integrating-with-alternate-dataclass-providers-such-as-pydantic) documentation, where the title of the `.. warning::` directive is wrongly indented.

### Checklist
This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
