### PR TITLE
fix #10131: update type annotations for `load_only`, `defer` and `undefer`

### DIFF
--- a/lib/sqlalchemy/orm/strategy_options.py
+++ b/lib/sqlalchemy/orm/strategy_options.py
@@ -2319,7 +2319,9 @@ def contains_eager(*keys: _AttrType, **kw: Any) -> _AbstractLoad:
 
 
 @loader_unbound_fn
-def load_only(*attrs: _AttrType, raiseload: bool = False) -> _AbstractLoad:
+def load_only(
+    *attrs: QueryableAttribute[Any], raiseload: bool = False
+) -> _AbstractLoad:
     # TODO: attrs against different classes.  we likely have to
     # add some extra state to Load of some kind
     _, lead_element, _ = _parse_attr_argument(attrs[0])
@@ -2376,7 +2378,9 @@ def defaultload(*keys: _AttrType) -> _AbstractLoad:
 
 @loader_unbound_fn
 def defer(
-    key: _AttrType, *addl_attrs: _AttrType, raiseload: bool = False
+    key: Union[QueryableAttribute[Any], Literal["*"]],
+    *addl_attrs: Union[QueryableAttribute[Any], Literal["*"]],
+    raiseload: bool = False,
 ) -> _AbstractLoad:
     if addl_attrs:
         util.warn_deprecated(
@@ -2395,7 +2399,10 @@ def defer(
 
 
 @loader_unbound_fn
-def undefer(key: _AttrType, *addl_attrs: _AttrType) -> _AbstractLoad:
+def undefer(
+    key: Union[QueryableAttribute[Any], Literal["*"]],
+    *addl_attrs: Union[QueryableAttribute[Any], Literal["*"]],
+) -> _AbstractLoad:
     if addl_attrs:
         util.warn_deprecated(
             "The *addl_attrs on orm.undefer is deprecated.  Please use "


### PR DESCRIPTION
### Description

Change the annotations for the attribute(s) parameters to `QueryableAttribute` and `QueryableAttribute | Literal["*"]` for defer and undefer, to accurately reflect the types they accept.

Fixes #10131.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**