### PR TITLE
Added test cases to check precedence of regexp and concat operators.

### DIFF
--- a/lib/sqlalchemy/sql/operators.py
+++ b/lib/sqlalchemy/sql/operators.py
@@ -2537,7 +2537,7 @@ _PRECEDENCE: Dict[OperatorType, int] = {
     filter_op: 6,
     match_op: 5,
     not_match_op: 5,
-    regexp_match_op: 5,
+    regexp_match_op: 6,
     not_regexp_match_op: 5,
     regexp_replace_op: 5,
     ilike_op: 5,

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -1249,7 +1249,7 @@ class RegexpCommon(testing.AssertsCompiledSQL):
     def test_regexp_match_column_concat(self):
         self.assert_compile(
             self.table.c.myid.regexp_match(self.table.c.name + '$'),
-            "mytable.myid REGEXP concat(mytable.name, %s)",
+            "mytable.myid REGEXP (concat(mytable.name, %s))",
             checkpositional=("$",),
         )
 

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -1246,6 +1246,13 @@ class RegexpCommon(testing.AssertsCompiledSQL):
             checkpositional=(),
         )
 
+    def test_regexp_match_column_concat(self):
+        self.assert_compile(
+            self.table.c.myid.regexp_match(self.table.c.name + '$'),
+            "mytable.myid REGEXP concat(mytable.name, %s)",
+            checkpositional=("$",),
+        )
+
     def test_regexp_match_str(self):
         self.assert_compile(
             literal("string").regexp_match(self.table.c.name),

--- a/test/dialect/oracle/test_compiler.py
+++ b/test/dialect/oracle/test_compiler.py
@@ -1679,6 +1679,13 @@ class RegexpTest(fixtures.TestBase, testing.AssertsCompiledSQL):
             checkparams={},
         )
 
+    def test_regexp_match_column_concat(self):
+        self.assert_compile(
+            self.table.c.myid.regexp_match(self.table.c.name + '$'),
+            "REGEXP_LIKE(mytable.myid, mytable.name || :name_1)",
+            checkparams={"name_1": "$"},
+        )
+
     def test_regexp_match_str(self):
         self.assert_compile(
             literal("string").regexp_match(self.table.c.name),

--- a/test/dialect/oracle/test_compiler.py
+++ b/test/dialect/oracle/test_compiler.py
@@ -1682,7 +1682,7 @@ class RegexpTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_regexp_match_column_concat(self):
         self.assert_compile(
             self.table.c.myid.regexp_match(self.table.c.name + '$'),
-            "REGEXP_LIKE(mytable.myid, mytable.name || :name_1)",
+            "REGEXP_LIKE(mytable.myid, (mytable.name || :name_1))",
             checkparams={"name_1": "$"},
         )
 

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -3669,6 +3669,13 @@ class RegexpTest(fixtures.TestBase, testing.AssertsCompiledSQL):
             checkparams={},
         )
 
+    def test_regexp_match_column_concat(self):
+        self.assert_compile(
+            self.table.c.myid.regexp_match(self.table.c.name + '$'),
+            "mytable.myid ~ (mytable.name || %(name_1)s)",
+            checkparams={"name_1": "$"},
+        )
+
     def test_regexp_match_str(self):
         self.assert_compile(
             literal("string").regexp_match(self.table.c.name),


### PR DESCRIPTION
Fixes: #9610 

### Description
Added test cases to check precedence of regexp and concat operators.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
