### PR TITLE
use callable for relationship.back_populates and ForeignKey.column

### DIFF
--- a/lib/sqlalchemy/orm/_orm_constructors.py
+++ b/lib/sqlalchemy/orm/_orm_constructors.py
@@ -28,6 +28,7 @@ from .properties import MappedColumn
 from .properties import MappedSQLExpression
 from .query import AliasOption
 from .relationships import _RelationshipArgumentType
+from .relationships import _RelationshipBackPopulatesArgument
 from .relationships import _RelationshipSecondaryArgument
 from .relationships import Relationship
 from .relationships import RelationshipProperty
@@ -917,7 +918,7 @@ def relationship(
     ] = None,
     primaryjoin: Optional[_RelationshipJoinConditionArgument] = None,
     secondaryjoin: Optional[_RelationshipJoinConditionArgument] = None,
-    back_populates: Optional[str] = None,
+    back_populates: Optional[_RelationshipBackPopulatesArgument] = None,
     order_by: _ORMOrderByArgument = False,
     backref: Optional[ORMBackrefArgument] = None,
     overlaps: Optional[str] = None,

--- a/test/sql/test_metadata.py
+++ b/test/sql/test_metadata.py
@@ -469,6 +469,24 @@ class MetaDataTest(fixtures.TestBase, ComparesTables):
             ["b.a", "b.b"],
         )
 
+    def test_fk_callable(self):
+        meta = MetaData()
+
+        a = Table(
+            "a",
+            meta,
+            Column("id", Integer, primary_key=True),
+        )
+
+        b = Table(
+            "b",
+            meta,
+            Column("id", Integer, primary_key=True),
+            Column("a_id", ForeignKey(lambda: a.c.id), nullable=False),
+        )
+
+        assert b.c.a_id.references(a.c.id)
+
     def test_pickle_metadata_sequence_restated(self):
         m1 = MetaData()
         Table(


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

Fixes: https://github.com/sqlalchemy/sqlalchemy/issues/10050

### Description
<!-- Describe your changes in detail -->
We will be able to use of callable for relationship.back_populates and ForeignKey.column. The goal is to make this code more robust by enabling refactoring support for attribute renaming. 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
