### PR TITLE
modified test_reflect_oltp_compression

### DIFF
--- a/test/dialect/oracle/test_reflection.py
+++ b/test/dialect/oracle/test_reflection.py
@@ -672,7 +672,7 @@ class TableReflectionTest(fixtures.TestBase):
         m2 = MetaData()
 
         tbl = Table("test_compress", m2, autoload_with=connection)
-        assert tbl.dialect_options["oracle"]["compress"] == "OLTP"
+        assert tbl.dialect_options["oracle"]["compress"] in ("OLTP","ADVANCED")
 
     def test_reflect_hidden_column(self):
         with testing.db.begin() as conn:

--- a/test/dialect/oracle/test_reflection.py
+++ b/test/dialect/oracle/test_reflection.py
@@ -630,13 +630,7 @@ def all_tables_compression_missing():
 
 
 def all_tables_compress_for_missing():
-    with testing.db.connect() as conn:
-        if (
-            "Enterprise Edition"
-            not in conn.exec_driver_sql("select * from v$version").scalar()
-        ):
-            return True
-        return False
+    return False
 
 
 class TableReflectionTest(fixtures.TestBase):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
Fixes #10271

### Description
<!-- Describe your changes in detail -->
In older releases the "compress for oltp" clause stored that fact in the data dictionary but newer releases the value "ADVANCED" is stored. This causes this test to fail. 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
