### PR TITLE
Allow using Enum with length=None

### DIFF
--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -1451,7 +1451,11 @@ class Enum(String, SchemaType, Emulated, TypeEngine[Union[str, enum.Enum]]):
             self._default_length = length = 0
 
         if length_arg is not NO_ARG:
-            if not _disable_warnings and length_arg < length:
+            if (
+                not _disable_warnings
+                and length_arg is not None
+                and length_arg < length
+            ):
                 raise ValueError(
                     "When provided, length must be larger or equal"
                     " than the length of the longest enum value. %s < %s"
@@ -1658,14 +1662,14 @@ class Enum(String, SchemaType, Emulated, TypeEngine[Union[str, enum.Enum]]):
         )
 
     def as_generic(self, allow_nulltype=False):
-        if hasattr(self, "enums"):
+        try:
             args = self.enums
-        else:
+        except AttributeError:
             raise NotImplementedError(
                 "TypeEngine.as_generic() heuristic "
                 "is undefined for types that inherit Enum but do not have "
                 "an `enums` attribute."
-            )
+            ) from None
 
         return util.constructor_copy(
             self, self._generic_type_affinity, *args, _disable_warnings=True

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -2723,6 +2723,12 @@ class EnumTest(AssertsCompiledSQL, fixtures.TablesTest):
         e = Enum("x", "y", "long", native_enum=False, length=42)
         eq_(e.length, 42)
 
+    def test_none_length_non_native(self):
+        e = Enum("x", "y", native_enum=False, length=None)
+        eq_(e.length, None)
+        eq_(repr(e), "Enum('x', 'y', native_enum=False, length=None)")
+        self.assert_compile(e, "VARCHAR", dialect="default")
+
     def test_omit_aliases(self, connection):
         table0 = self.tables["stdlib_enum_table"]
         type0 = table0.c.someenum.type


### PR DESCRIPTION
Fixes: #10269

### Description
Allow passing `length=None` for string-based Enums, which turns them into `VARCHAR` without a length limit.

This pull request is:

- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
