### PR TITLE
Add row order after grouping for `ColExpressionsTest::test_group_by`

### DIFF
--- a/test/orm/inheritance/test_basic.py
+++ b/test/orm/inheritance/test_basic.py
@@ -177,6 +177,7 @@ class ColExpressionsTest(fixtures.DeclarativeMappedTest):
         rows = (
             s.query(B.id.expressions[0], B.id.expressions[1], func.sum(B.data))
             .group_by(*B.id.expressions)
+            .order_by(B.id.expressions[0])
             .all()
         )
         eq_(rows, [(1, 1, 5), (2, 2, 7)])


### PR DESCRIPTION
Fixes: https://github.com/sqlalchemy/sqlalchemy/issues/10332