### PR TITLE
fix(#10056): keep nullable as true for mariadb generated columns

### DIFF
--- a/doc/build/changelog/unreleased_20/10056.rst
+++ b/doc/build/changelog/unreleased_20/10056.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: bug, sql
+    :tickets: 10056
+
+    mariaDB does not support setting NOT NULL for generated column
+    ref: https://mariadb.com/kb/en/generated-columns/#statement-support
+    added a check in `get_column_specification` for mariadb, checking
+    if user has not specified nullable set it as True for computed column.

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1063,6 +1063,7 @@ from ...sql import roles
 from ...sql import sqltypes
 from ...sql import util as sql_util
 from ...sql.compiler import InsertmanyvaluesSentinelOpts
+from ...sql.schema import SchemaConst
 from ...types import BINARY
 from ...types import BLOB
 from ...types import BOOLEAN
@@ -1070,6 +1071,7 @@ from ...types import DATE
 from ...types import UUID
 from ...types import VARBINARY
 from ...util import topological
+
 
 SET_RE = re.compile(
     r"\s*SET\s+(?:(?:GLOBAL|SESSION)\s+)?\w", re.I | re.UNICODE
@@ -1766,7 +1768,12 @@ class MySQLCompiler(compiler.SQLCompiler):
 class MySQLDDLCompiler(compiler.DDLCompiler):
     def get_column_specification(self, column, **kw):
         """Builds column DDL."""
-
+        if (
+            self.dialect.is_mariadb is True
+            and column.computed is not None
+            and column._user_defined_nullable is SchemaConst.NULL_UNSPECIFIED
+        ):
+            column.nullable = True
         colspec = [
             self.preparer.format_column(column),
             self.dialect.type_compiler_instance.process(


### PR DESCRIPTION
mariaDB does not support setting NOT NULL for generated column
ref: https://mariadb.com/kb/en/generated-columns/#statement-support

added a check in `get_column_specification` for mariadb, checking
if user has not specified nullable set it as True for computed column,
but if user has explicitly set as False raise a compile error.

added testcase for same

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.

**Have a nice day!**
