### PR TITLE
fixes: #9737, add literal_processors for interval

### DIFF
--- a/doc/build/changelog/unreleased_20/9737.rst
+++ b/doc/build/changelog/unreleased_20/9737.rst
@@ -1,0 +1,9 @@
+.. change::
+    :tags: usecase, sql
+    :tickets: 9737
+
+    Added literal_processor methods to Interval Module 
+    for Oracle and PostgreSQL :meth:`_oracle.Interval.literal_processor` and
+    :meth:`_postgresql.Interval.literal_processor`.
+    Allowing use of timedelta based literal queries for these Databases.
+    Pull request courtesy Indivar Mishra.

--- a/lib/sqlalchemy/dialects/postgresql/types.py
+++ b/lib/sqlalchemy/dialects/postgresql/types.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import datetime as dt
 from typing import Any
+from typing import Callable
+from typing import no_type_check
 from typing import Optional
 from typing import overload
 from typing import Type
@@ -20,6 +22,7 @@ from ...util.typing import Literal
 if TYPE_CHECKING:
     from ...sql.operators import OperatorType
     from ...sql.type_api import TypeEngine
+    from ...engine.interfaces import Dialect
 
 _DECIMAL_TYPES = (1231, 1700)
 _FLOAT_TYPES = (700, 701, 1021, 1022)
@@ -246,6 +249,17 @@ class INTERVAL(type_api.NativeForEmulated, sqltypes._AbstractInterval):
     @property
     def python_type(self) -> Type[dt.timedelta]:
         return dt.timedelta
+
+    @no_type_check
+    def literal_processor(
+        self, dialect: Optional[Dialect]
+    ) -> Callable[[Optional[dt.timedelta]], Optional[str]]:
+        def process(value: Optional[dt.timedelta]) -> Optional[str]:
+            if value is not None:
+                return f"make_interval(secs=>{value.total_seconds()})"
+            return None
+
+        return process
 
 
 PGInterval = INTERVAL

--- a/lib/sqlalchemy/testing/requirements.py
+++ b/lib/sqlalchemy/testing/requirements.py
@@ -846,6 +846,14 @@ class SuiteRequirements(Requirements):
         return exclusions.open()
 
     @property
+    def datetime_interval(self):
+        """target dialect supports rendering of a datetime.timedelta as a
+        literal string, e.g. via the TypeEngine.literal_processor() method.
+
+        """
+        return exclusions.closed()
+
+    @property
     def datetime_literals(self):
         """target dialect supports rendering of a date, time, or datetime as a
         literal string, e.g. via the TypeEngine.literal_processor() method.

--- a/test/dialect/oracle/test_types.py
+++ b/test/dialect/oracle/test_types.py
@@ -208,6 +208,33 @@ class DialectTypesTest(fixtures.TestBase, AssertsCompiledSQL):
     def test_float_type_compile(self, type_, sql_text):
         self.assert_compile(type_, sql_text)
 
+    @testing.combinations(
+        (
+            text("select :parameter from dual").bindparams(
+                parameter=datetime.timedelta(days=2)
+            ),
+            "select NUMTODSINTERVAL(172800.0, 'SECOND') from dual",
+        ),
+        (
+            text("SELECT :parameter from dual").bindparams(
+                parameter=datetime.timedelta(days=1, minutes=3, seconds=4)
+            ),
+            "SELECT NUMTODSINTERVAL(86584.0, 'SECOND') from dual",
+        ),
+        (
+            text("select :parameter - :parameter2 from dual").bindparams(
+                parameter=datetime.timedelta(days=1, minutes=3, seconds=4),
+                parameter2=datetime.timedelta(days=0, minutes=1, seconds=4),
+            ),
+            (
+                "select NUMTODSINTERVAL(86584.0, 'SECOND') - "
+                "NUMTODSINTERVAL(64.0, 'SECOND') from dual"
+            ),
+        ),
+    )
+    def test_interval_literal_processor(self, type_, expected):
+        self.assert_compile(type_, expected, literal_binds=True)
+
 
 class TypesTest(fixtures.TestBase):
     __only_on__ = "oracle"
@@ -322,6 +349,31 @@ class TypesTest(fixtures.TestBase):
             row._mapping["day_interval"],
             datetime.timedelta(days=35, seconds=5743),
         )
+
+    def test_interval_literal_processor(self, connection):
+        result = connection.execute(
+            select(
+                literal(
+                    datetime.timedelta(days=1, minutes=3, seconds=4),
+                    literal_execute=True,
+                )
+                - literal(
+                    datetime.timedelta(days=0, minutes=1, seconds=4),
+                    literal_execute=True,
+                )
+            )
+        ).one()
+        eq_(result[0], datetime.timedelta(days=1, seconds=120))
+
+    def test_interval_value(self, connection):
+        """#9737"""
+        stmt = text("select :parameter from dual")
+        result = connection.execute(
+            stmt.bindparams(
+                parameter=datetime.timedelta(days=1, minutes=3, seconds=4),
+            )
+        ).one()
+        eq_(result[0], datetime.timedelta(days=1, minutes=3, seconds=4))
 
     def test_no_decimal_float_precision(self):
         with expect_raises_message(

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -1203,6 +1203,14 @@ class DefaultRequirements(SuiteRequirements):
         return self.json_type
 
     @property
+    def datetime_interval(self):
+        """target dialect supports rendering of a datetime.timedelta as a
+        literal string, e.g. via the TypeEngine.literal_processor() method.
+        Added for Oracle and Postgresql as of now.
+        """
+        return only_on(["oracle", "postgresql"])
+
+    @property
     def datetime_literals(self):
         """target dialect supports rendering of a date, time, or datetime as a
         literal string, e.g. via the TypeEngine.literal_processor() method.


### PR DESCRIPTION
added literal processor for intervals for postgres and oracle db in their respective types module.
added tests for same in the dialects directory within test_types.py docs refered
postgres: https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-INTERVAL-INPUT oracle: https://docs.oracle.com/cd/B19306_01/server.102/b14200/sql_elements003.htm#i38598

- Didn't add YEARS to MONTH for oracle as it was not already supported 
- not sure on how to support precision for postgres interval seconds so added a fixme note there for now.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.

**Have a nice day!**
