### PR TITLE
handle builtins types in annotations with __allow_unmapped__

### DIFF
--- a/lib/sqlalchemy/util/typing.py
+++ b/lib/sqlalchemy/util/typing.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import builtins
 import re
 import sys
 import typing
@@ -234,6 +235,12 @@ def eval_name_only(
 ) -> Any:
     if "." in name:
         return eval_expression(name, module_name, locals_=locals_)
+
+    # Try builtins first, to handle `list`, `set` or `dict`, etc.
+    try:
+        return builtins.__dict__[name]
+    except KeyError:
+        pass
 
     try:
         base_globals: Dict[str, Any] = sys.modules[module_name].__dict__

--- a/test/orm/declarative/test_tm_future_annotations_sync.py
+++ b/test/orm/declarative/test_tm_future_annotations_sync.py
@@ -2167,8 +2167,15 @@ class RelationshipLHSTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
                 decl_base.registry.configure()
 
-    def test_14_style_anno_accepted_w_allow_unmapped(self):
-        """test for #8692"""
+    @testing.combinations(
+        ("list", testing.requires.python310),
+        ("List",),
+        ("set", testing.requires.python310),
+        ("Set",),
+        argnames="collection_type",
+    )
+    def test_14_style_anno_accepted_w_allow_unmapped(self, collection_type):
+        """test for #8692 and #10385"""
 
         class Base(DeclarativeBase):
             __allow_unmapped__ = True
@@ -2178,7 +2185,29 @@ class RelationshipLHSTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
             id: Mapped[int] = mapped_column(primary_key=True)
             data: str = Column(String)
-            bs: List["B"] = relationship("B", back_populates="a")  # noqa: F821
+
+            if collection_type == "list":
+                bs: list["B"] = relationship(  # noqa: F821
+                    "B",
+                    back_populates="a",
+                )
+            elif collection_type == "List":
+                bs: List["B"] = relationship(  # noqa: F821
+                    "B",
+                    back_populates="a",
+                )
+            elif collection_type == "set":
+                bs: set["B"] = relationship(  # noqa: F821
+                    "B",
+                    back_populates="a",
+                )
+            elif collection_type == "Set":
+                bs: Set["B"] = relationship(  # noqa: F821
+                    "B",
+                    back_populates="a",
+                )
+            else:
+                collection_type.fail()
 
         class B(Base):
             __tablename__ = "b"

--- a/test/orm/declarative/test_typed_mapping.py
+++ b/test/orm/declarative/test_typed_mapping.py
@@ -2158,8 +2158,15 @@ class RelationshipLHSTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
                 decl_base.registry.configure()
 
-    def test_14_style_anno_accepted_w_allow_unmapped(self):
-        """test for #8692"""
+    @testing.combinations(
+        ("list", testing.requires.python310),
+        ("List",),
+        ("set", testing.requires.python310),
+        ("Set",),
+        argnames="collection_type",
+    )
+    def test_14_style_anno_accepted_w_allow_unmapped(self, collection_type):
+        """test for #8692 and #10385"""
 
         class Base(DeclarativeBase):
             __allow_unmapped__ = True
@@ -2169,7 +2176,29 @@ class RelationshipLHSTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
             id: Mapped[int] = mapped_column(primary_key=True)
             data: str = Column(String)
-            bs: List["B"] = relationship("B", back_populates="a")  # noqa: F821
+
+            if collection_type == "list":
+                bs: list["B"] = relationship(  # noqa: F821
+                    "B",
+                    back_populates="a",
+                )
+            elif collection_type == "List":
+                bs: List["B"] = relationship(  # noqa: F821
+                    "B",
+                    back_populates="a",
+                )
+            elif collection_type == "set":
+                bs: set["B"] = relationship(  # noqa: F821
+                    "B",
+                    back_populates="a",
+                )
+            elif collection_type == "Set":
+                bs: Set["B"] = relationship(  # noqa: F821
+                    "B",
+                    back_populates="a",
+                )
+            else:
+                collection_type.fail()
 
         class B(Base):
             __tablename__ = "b"


### PR DESCRIPTION
Fixes #10385

### Description

When searching to resolve a type string from an annotation, first check if it exists in the Python's builtins before looking in the module's definitions.

### Checklist

This pull request is:

- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
