### PR TITLE
Raise exception for execute() when parameter is an empty list

### DIFF
--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -1403,6 +1403,10 @@ class Connection(ConnectionEventsTarget, inspection.Inspectable["Inspector"]):
         :return: a :class:`_engine.Result` object.
 
         """
+        if isinstance(parameters, list) and not parameters:
+            raise exc.ArgumentError(
+                "Empty list of parameters passed; no statement to execute"
+            )
         distilled_parameters = _distill_params_20(parameters)
         try:
             meth = statement._execute_on_connection

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -2151,7 +2151,7 @@ class Session(_SessionClassMethods, EventTarget):
             )
         else:
             result = conn.execute(
-                statement, params or {}, execution_options=execution_options
+                statement, params, execution_options=execution_options
             )
 
         if _scalar_result:

--- a/test/orm/test_session.py
+++ b/test/orm/test_session.py
@@ -128,6 +128,24 @@ class ExecutionTest(_fixtures.FixtureTest):
             ):
                 sess.scalar("select id from users where id=:id", {"id": 7})
 
+    def test_empty_list_execute(self, connection):
+        users = self.tables.users
+        sess = Session(bind=testing.db)
+        sess.execute(users.insert(), {"id": 10, "name": "u10"})
+
+        with expect_raises_message(
+            sa.exc.ArgumentError,
+            "Empty list of parameters passed; no statement to execute",
+        ):
+            sess.execute(users.insert(), [])
+
+        eq_(
+            sess.execute(
+                sa.select(users.c.id).order_by(users.c.id)
+            ).fetchall(),
+            [(10,)],
+        )
+
 
 class TransScopingTest(_fixtures.FixtureTest):
     run_inserts = None


### PR DESCRIPTION
Fixes: #9647 
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Raise ArgumentError exception when execute() is called with an empty list

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
