### PR TITLE
Fix typo in Session.get_one() docs

### DIFF
--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -3671,7 +3671,7 @@ class Session(_SessionClassMethods, EventTarget):
         For a detailed documentation of the arguments see the
         method :meth:`.Session.get`.
 
-        ..versionadded: 2.0.22
+        .. versionadded:: 2.0.22
 
         :return: The object instance, or ``None``.
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

A typo in the docstrings [here](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.get_one) shows the incorrectly formatted text:

![Screenshot 2023-10-07 at 16 24 19](https://github.com/sqlalchemy/sqlalchemy/assets/12053937/95cbfbfa-dac3-465a-8e27-ec8e2a223117)

### Checklist

This pull request is:

- [X] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
