### PR TITLE
Fix `get_one` return value description

### DIFF
--- a/lib/sqlalchemy/orm/scoping.py
+++ b/lib/sqlalchemy/orm/scoping.py
@@ -1099,7 +1099,7 @@ class scoped_session(Generic[_S]):
 
         .. versionadded:: 2.0.22
 
-        :return: The object instance, or ``None``.
+        :return: The object instance.
 
         .. seealso::
 

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -3683,7 +3683,7 @@ class Session(_SessionClassMethods, EventTarget):
 
         .. versionadded:: 2.0.22
 
-        :return: The object instance, or ``None``.
+        :return: The object instance.
 
         .. seealso::
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

The `get_one()` method is described as raising an error if no row is found instead of returning `None` (as `get()` does). Also, the return type hint prohibits `None`.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
