### PR TITLE
fixes: #10509, use oracle.INTERVAL for generic interval

### DIFF
--- a/lib/sqlalchemy/dialects/oracle/types.py
+++ b/lib/sqlalchemy/dialects/oracle/types.py
@@ -203,6 +203,15 @@ class INTERVAL(sqltypes.NativeForEmulated, sqltypes._AbstractInterval):
             second_precision=interval.second_precision,
         )
 
+    @classmethod
+    def adapt_emulated_to_native(
+        cls, interval: sqltypes.Interval, **kw  # type: ignore[override]
+    ):
+        return INTERVAL(
+            day_precision=interval.day_precision,
+            second_precision=interval.second_precision,
+        )
+
     @property
     def _type_affinity(self):
         return sqltypes.Interval

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -2052,8 +2052,8 @@ class Interval(Emulated, _AbstractInterval, TypeDecorator[dt.timedelta]):
     """A type for ``datetime.timedelta()`` objects.
 
     The Interval type deals with ``datetime.timedelta`` objects.  In
-    PostgreSQL, the native ``INTERVAL`` type is used; for others, the
-    value is stored as a date which is relative to the "epoch"
+    PostgreSQL and Oracle, the native ``INTERVAL`` type is used; for others,
+    the value is stored as a date which is relative to the "epoch"
     (Jan. 1, 1970).
 
     Note that the ``Interval`` type does not currently provide date arithmetic

--- a/test/dialect/oracle/test_types.py
+++ b/test/dialect/oracle/test_types.py
@@ -183,6 +183,10 @@ class DialectTypesTest(fixtures.TestBase, AssertsCompiledSQL):
             oracle.INTERVAL(day_precision=2, second_precision=5),
             "INTERVAL DAY(2) TO SECOND(5)",
         ),
+        (
+            sqltypes.Interval(day_precision=9, second_precision=3),
+            "INTERVAL DAY(9) TO SECOND(3)",
+        ),
     )
     def test_interval(self, type_, expected):
         self.assert_compile(type_, expected)


### PR DESCRIPTION
sqltypes.Interval was not using Oracle.INTERVAL to genrate DDL query due to which precisions for DB was not being set. added `adapt_emulated_to_native` method to oracle.INTERVAL to adapt Interval to native INTERVAL class.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [X] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.

**Have a nice day!**
