### PR TITLE
prevent pysqlcipher connect error with create_function params cnt

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/pysqlite.py
+++ b/lib/sqlalchemy/dialects/sqlite/pysqlite.py
@@ -544,7 +544,7 @@ class SQLiteDialect_pysqlite(SQLiteDialect):
                 return None
             return re.search(a, b) is not None
 
-        if util.py38 and self._get_server_version_info(None) >= (3, 9):
+        if util.py38 and self._get_server_version_info(None) >= (3, 9) and self.driver != 'pysqlcipher':
             # sqlite must be greater than 3.8.3 for deterministic=True
             # https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.create_function
             # the check is more conservative since there were still issues


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
to fix the pysqlcipher  broken usage in 2.0.22 with pysqlcipher3 new master

### Description
issue fix : https://github.com/sqlalchemy/sqlalchemy/issues/10544

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
