### PR TITLE
✏️ Fix syntax typo in `doc/build/tutorial/data_select.rst`

### DIFF
--- a/doc/build/tutorial/data_select.rst
+++ b/doc/build/tutorial/data_select.rst
@@ -130,7 +130,7 @@ for a :func:`_sql.select` by using a tuple of string names::
     FROM user_account
 
 .. versionadded:: 2.0 Added tuple-accessor capability to the
-   :attr`.FromClause.c` collection
+   :attr:`.FromClause.c` collection
 
 
 .. _tutorial_selecting_orm_entities:


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

✏️ Fix syntax typo in `doc/build/tutorial/data_select.rst`

In https://docs.sqlalchemy.org/en/20/tutorial/data_select.html, it renders as:

```
Added tuple-accessor capability to the :attr`.FromClause.c` collection
```

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
