### PR TITLE
Update type annotation for DBAPI Cursor's executemany()

### DIFF
--- a/lib/sqlalchemy/engine/interfaces.py
+++ b/lib/sqlalchemy/engine/interfaces.py
@@ -194,7 +194,7 @@ class DBAPICursor(Protocol):
     def executemany(
         self,
         operation: Any,
-        parameters: Sequence[_DBAPIMultiExecuteParams],
+        parameters: _DBAPIMultiExecuteParams,
     ) -> Any:
         ...
 


### PR DESCRIPTION
### Description
As per https://groups.google.com/g/sqlalchemy/c/DkyffAgDmwM, fixes an issue with the DBAPI cursor's executemany() type signature.

### Checklist

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
