### PR TITLE
Fixed Improper Method Call: Removed `NotImplementedError`

### DIFF
--- a/lib/sqlalchemy/ext/associationproxy.py
+++ b/lib/sqlalchemy/ext/associationproxy.py
@@ -48,7 +48,6 @@ from .. import exc
 from .. import inspect
 from .. import orm
 from .. import util
-from ..orm import collections
 from ..orm import InspectionAttrExtensionType
 from ..orm import interfaces
 from ..orm import ORMDescriptor
@@ -1616,8 +1615,8 @@ class _AssociationList(_AssociationSingleItem[_T], MutableSequence[_T]):
         # is more plausibly useful than copying the backing objects.
         if n == 0:
             self.clear()
-        elif n > 1:
-            self.extend(list(self) * (n - 1))
+        elif int(n) > 1:
+            self.extend(list(self) * (int(n) - 1))
         return self
 
     if typing.TYPE_CHECKING:

--- a/lib/sqlalchemy/ext/associationproxy.py
+++ b/lib/sqlalchemy/ext/associationproxy.py
@@ -1614,8 +1614,6 @@ class _AssociationList(_AssociationSingleItem[_T], MutableSequence[_T]):
         # backing objects for each copy.  *= on proxied lists is a bit of
         # a stretch anyhow, and this interpretation of the __imul__ contract
         # is more plausibly useful than copying the backing objects.
-        if not isinstance(n, int):
-            raise NotImplementedError()
         if n == 0:
             self.clear()
         elif n > 1:
@@ -1895,8 +1893,6 @@ class _AssociationSet(_AssociationSingleItem[_T], MutableSet[_T]):
     def __ior__(  # type: ignore
         self, other: AbstractSet[_S]
     ) -> MutableSet[Union[_T, _S]]:
-        if not collections._set_binops_check_strict(self, other):
-            raise NotImplementedError()
         for value in other:
             self.add(value)
         return self
@@ -1922,8 +1918,6 @@ class _AssociationSet(_AssociationSingleItem[_T], MutableSet[_T]):
                 self.discard(value)
 
     def __isub__(self, s: AbstractSet[Any]) -> Self:
-        if not collections._set_binops_check_strict(self, s):
-            raise NotImplementedError()
         for value in s:
             self.discard(value)
         return self
@@ -1946,8 +1940,6 @@ class _AssociationSet(_AssociationSingleItem[_T], MutableSet[_T]):
                 self.add(value)
 
     def __iand__(self, s: AbstractSet[Any]) -> Self:
-        if not collections._set_binops_check_strict(self, s):
-            raise NotImplementedError()
         want = self.intersection(s)
         have: Set[_T] = set(self)
 
@@ -1976,9 +1968,6 @@ class _AssociationSet(_AssociationSingleItem[_T], MutableSet[_T]):
             self.add(value)
 
     def __ixor__(self, other: AbstractSet[_S]) -> MutableSet[Union[_T, _S]]:  # type: ignore  # noqa: E501
-        if not collections._set_binops_check_strict(self, other):
-            raise NotImplementedError()
-
         self.symmetric_difference_update(other)
         return self
 


### PR DESCRIPTION
## Discussion
[#10645](https://github.com/sqlalchemy/sqlalchemy/discussions/10645)


## Description
While triaging your project, our bug fixing tool generated the following message(s)-
> In file: [associationproxy.py](https://github.com/sqlalchemy/sqlalchemy/blob/main/lib/sqlalchemy/ext/associationproxy.py#L1980), class: _AssociationSet, there is a special method `__ixor__` that raises a NotImplementedError. If a special method supporting a binary operation is not implemented it should return [NotImplemented](https://docs.python.org/3/library/constants.html#NotImplemented). On the other hand, [NotImplementedError](https://docs.python.org/3/library/exceptions.html#NotImplementedError) should be raised from abstract methods inside user defined base classes to indicate that derived classes should override those methods. iCR suggested that the special method `__ixor__` should return NotImplemented instead of raising an exception. An example of how NotImplemented helps the interpreter support a binary operation is [here](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations).

The same message is generated for `__imul__`, `__iand__`, `__isub__`, `__ior__` methods too.


## Changes
- Removed `NotImplementedError` according to [discussion](https://github.com/sqlalchemy/sqlalchemy/discussions/10645)


## Previously Found & Fixed
- https://www.github.com/projecthamster/hamster/pull/737
- https://www.github.com/SciTools/iris/pull/5544
- https://www.github.com/cupy/cupy/pull/7900
- https://www.github.com/ethereum/web3.py/pull/3080

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**

## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
