### PR TITLE
patch for servers not supporting certain assumed postgresql capabilities

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3049,15 +3049,18 @@ class PGDialect(default.DefaultDialect):
         super().initialize(connection)
 
         # https://www.postgresql.org/docs/9.3/static/release-9-2.html#AEN116689
-        self.supports_smallserial = self.server_version_info >= (9, 2)
+        self.supports_smallserial = self.server_version_info and self.server_version_info >= (9, 2)
 
-        self._set_backslash_escapes(connection)
+        try: 
+            self._set_backslash_escapes(connection)
+        except:
+            pass
 
-        self._supports_drop_index_concurrently = self.server_version_info >= (
+        self._supports_drop_index_concurrently = self.server_version_info and self.server_version_info >= (
             9,
             2,
         )
-        self.supports_identity_columns = self.server_version_info >= (10,)
+        self.supports_identity_columns = self.server_version_info and self.server_version_info >= (10,)
 
     def get_isolation_level_values(self, dbapi_conn):
         # note the generic dialect doesn't have AUTOCOMMIT, however

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -514,20 +514,20 @@ class DefaultDialect(Dialect):
             self.server_version_info = self._get_server_version_info(
                 connection
             )
-        except NotImplementedError:
+        except :
             self.server_version_info = None
         try:
             self.default_schema_name = self._get_default_schema_name(
                 connection
             )
-        except NotImplementedError:
+        except :
             self.default_schema_name = None
 
         try:
             self.default_isolation_level = self.get_default_isolation_level(
                 connection.connection.dbapi_connection
             )
-        except NotImplementedError:
+        except :
             self.default_isolation_level = None
 
         if not self._user_defined_max_identifier_length:


### PR DESCRIPTION
This issue is described in [#10656](https://github.com/sqlalchemy/sqlalchemy/issues/10656) with test code there. It is a minimal functionality fix. A caveat is that this fix doesn't deal with ramifications of handling failure of _set_backslash_escapes() which was not in the original sqlalchemy code base either.

Due to otherwise needs to setup an external database, unit tests were not added besideds the test code in the issue.  It is not expected to break any current test cases. It is recommended that sqlacademy to add mocks for all assumptions and handle them as gracefully as possible.

sqlalchemy is widely used and we hope that it is even more widely used. :-)

### Checklist


This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [X ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
