### PR TITLE
Upgrade to Oracle Database 23c Free

### DIFF
--- a/README.unittests.rst
+++ b/README.unittests.rst
@@ -97,8 +97,8 @@ a pre-set URL.  These can be seen using --dbs::
                    mssql    mssql+pyodbc://scott:tiger^5HHH@mssql2017:1433/test?driver=ODBC+Driver+13+for+SQL+Server
            mssql_pymssql    mssql+pymssql://scott:tiger@ms_2008
                    mysql    mysql+mysqldb://scott:tiger@127.0.0.1:3306/test?charset=utf8mb4
-                  oracle    oracle+cx_oracle://scott:tiger@oracle23c
-         oracle_oracledb    oracle+oracledb://scott:tiger@oracle23c
+                  oracle    oracle+cx_oracle://scott:tiger@oracle18c
+         oracle_oracledb    oracle+oracledb://scott:tiger@oracle18c
                   pg8000    postgresql+pg8000://scott:tiger@127.0.0.1:5432/test
               postgresql    postgresql+psycopg2://scott:tiger@127.0.0.1:5432/test
     postgresql_psycopg2cffi postgresql+psycopg2cffi://scott:tiger@127.0.0.1:5432/test

--- a/README.unittests.rst
+++ b/README.unittests.rst
@@ -97,8 +97,8 @@ a pre-set URL.  These can be seen using --dbs::
                    mssql    mssql+pyodbc://scott:tiger^5HHH@mssql2017:1433/test?driver=ODBC+Driver+13+for+SQL+Server
            mssql_pymssql    mssql+pymssql://scott:tiger@ms_2008
                    mysql    mysql+mysqldb://scott:tiger@127.0.0.1:3306/test?charset=utf8mb4
-                  oracle    oracle+cx_oracle://scott:tiger@oracle18c
-         oracle_oracledb    oracle+oracledb://scott:tiger@oracle18c
+                  oracle    oracle+cx_oracle://scott:tiger@oracle23c
+         oracle_oracledb    oracle+oracledb://scott:tiger@oracle23c
                   pg8000    postgresql+pg8000://scott:tiger@127.0.0.1:5432/test
               postgresql    postgresql+psycopg2://scott:tiger@127.0.0.1:5432/test
     postgresql_psycopg2cffi postgresql+psycopg2cffi://scott:tiger@127.0.0.1:5432/test
@@ -307,11 +307,11 @@ be used with pytest by using ``--db docker_mssql``.
 **Oracle configuration**::
 
     # create the container with the proper configuration for sqlalchemy
-    docker run --rm --name oracle -p 127.0.0.1:1521:1521 -d -e ORACLE_PASSWORD=tiger -e ORACLE_DATABASE=test -e APP_USER=scott -e APP_USER_PASSWORD=tiger gvenzl/oracle-xe:21-slim
+    docker run --rm --name oracle -p 127.0.0.1:1521:1521 -d -e ORACLE_PASSWORD=tiger -e ORACLE_DATABASE=test -e APP_USER=scott -e APP_USER_PASSWORD=tiger gvenzl/oracle-free:23-slim
 
     # enter the database container and run the command
     docker exec -ti oracle bash
-    >> sqlplus system/tiger@//localhost/XEPDB1 <<EOF
+    >> sqlplus system/tiger@//localhost/FREEPDB1 <<EOF
     CREATE USER test_schema IDENTIFIED BY tiger;
     GRANT DBA TO SCOTT;
     GRANT CREATE TABLE TO scott;
@@ -319,16 +319,16 @@ be used with pytest by using ``--db docker_mssql``.
     GRANT UNLIMITED TABLESPACE TO scott;
     GRANT UNLIMITED TABLESPACE TO test_schema;
     GRANT CREATE SESSION TO test_schema;
-    CREATE PUBLIC DATABASE LINK test_link CONNECT TO scott IDENTIFIED BY tiger USING 'XEPDB1';
-    CREATE PUBLIC DATABASE LINK test_link2 CONNECT TO test_schema IDENTIFIED BY tiger USING 'XEPDB1';
+    CREATE PUBLIC DATABASE LINK test_link CONNECT TO scott IDENTIFIED BY tiger USING 'FREEPDB1';
+    CREATE PUBLIC DATABASE LINK test_link2 CONNECT TO test_schema IDENTIFIED BY tiger USING 'FREEPDB1';
     EOF
 
     # To stop the container. It will also remove it.
     docker stop oracle
 
 NOTE: with this configuration the url to use is
-``oracle+cx_oracle://scott:tiger@127.0.0.1:1521/?service_name=XEPDB1``.  It can
-be used with pytest by using ``--dburi oracle+cx_oracle://scott:tiger@127.0.0.1:1521/?service_name=XEPDB1``.
+``oracle+cx_oracle://scott:tiger@127.0.0.1:1521/?service_name=FREEPDB1``.  It can
+be used with pytest by using ``--dburi oracle+cx_oracle://scott:tiger@127.0.0.1:1521/?service_name=FREEPDB1``.
 
 CONFIGURING LOGGING
 -------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -133,13 +133,13 @@ requirement_cls = test.requirements:DefaultRequirements
 profile_file = test/profiles.txt
 
 # name of a "loopback" link set up on the oracle database.
-# to create this, suppose your DB is scott/tiger@xe.  You'd create it
+# to create this, suppose your DB is scott/tiger@free.  You'd create it
 # like:
 # create public database link test_link connect to scott identified by tiger
-# using 'xe';
+# using 'free';
 oracle_db_link = test_link
 # create public database link test_link2 connect to test_schema identified by tiger
-# using 'xe';
+# using 'free';
 oracle_db_link2 = test_link2
 
 # host name of a postgres database that has the postgres_fdw extension.
@@ -179,7 +179,7 @@ mssql = mssql+pyodbc://scott:tiger^5HHH@mssql2017:1433/test?driver=ODBC+Driver+1
 mssql_async = mssql+aioodbc://scott:tiger^5HHH@mssql2017:1433/test?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes
 pymssql = mssql+pymssql://scott:tiger^5HHH@mssql2017:1433/test
 docker_mssql = mssql+pyodbc://scott:tiger^5HHH@127.0.0.1:1433/test?driver=ODBC+Driver+18+for+SQL+Server
-oracle = oracle+cx_oracle://scott:tiger@oracle18c/xe
-cxoracle = oracle+cx_oracle://scott:tiger@oracle18c/xe
-oracledb = oracle+oracledb://scott:tiger@oracle18c/xe
-docker_oracle = oracle+cx_oracle://scott:tiger@127.0.0.1:1521/?service_name=XEPDB1
+oracle = oracle+cx_oracle://scott:tiger@oracle23c/free
+cxoracle = oracle+cx_oracle://scott:tiger@oracle23c/free
+oracledb = oracle+oracledb://scott:tiger@oracle23c/free
+docker_oracle = oracle+cx_oracle://scott:tiger@127.0.0.1:1521/?service_name=FREEPDB1

--- a/setup.cfg
+++ b/setup.cfg
@@ -179,7 +179,7 @@ mssql = mssql+pyodbc://scott:tiger^5HHH@mssql2017:1433/test?driver=ODBC+Driver+1
 mssql_async = mssql+aioodbc://scott:tiger^5HHH@mssql2017:1433/test?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes
 pymssql = mssql+pymssql://scott:tiger^5HHH@mssql2017:1433/test
 docker_mssql = mssql+pyodbc://scott:tiger^5HHH@127.0.0.1:1433/test?driver=ODBC+Driver+18+for+SQL+Server
-oracle = oracle+cx_oracle://scott:tiger@oracle23c/free
-cxoracle = oracle+cx_oracle://scott:tiger@oracle23c/free
-oracledb = oracle+oracledb://scott:tiger@oracle23c/free
+oracle = oracle+cx_oracle://scott:tiger@oracle18c/xe
+cxoracle = oracle+cx_oracle://scott:tiger@oracle18c/xe
+oracledb = oracle+oracledb://scott:tiger@oracle18c/xe
 docker_oracle = oracle+cx_oracle://scott:tiger@127.0.0.1:1521/?service_name=FREEPDB1


### PR DESCRIPTION
### Description
This PR updates the unittest ReadMe and `setup.cfg` to use Oracle Database Free, the successor to Oracle Database XE.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
