### PR TITLE
docs: fix type annotation in Self-Referential Many-to-Many Relationsh…

### DIFF
--- a/doc/build/orm/join_conditions.rst
+++ b/doc/build/orm/join_conditions.rst
@@ -564,14 +564,14 @@ is when establishing a many-to-many relationship from a class to itself, as show
         __tablename__ = "node"
         id: Mapped[int] = mapped_column(primary_key=True)
         label: Mapped[str]
-        right_nodes: Mapped[List["None"]] = relationship(
+        right_nodes: Mapped[List["Node"]] = relationship(
             "Node",
             secondary=node_to_node,
             primaryjoin=id == node_to_node.c.left_node_id,
             secondaryjoin=id == node_to_node.c.right_node_id,
             back_populates="left_nodes",
         )
-        left_nodes: Mapped[List["None"]] = relationship(
+        left_nodes: Mapped[List["Node"]] = relationship(
             "Node",
             secondary=node_to_node,
             primaryjoin=id == node_to_node.c.right_node_id,


### PR DESCRIPTION
A type annotation was wrong in the [Self-Referential Many-to-Many Relationship](https://docs.sqlalchemy.org/en/20/orm/join_conditions.html#self-referential-many-to-many-relationship) code example.

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

The type annotation was `right_nodes: Mapped[List["None"]]`. I changed it to `Node` since we refer to the ORM class we're looking at.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
