### PR TITLE
Update `TZDateTime` type decorator example to align with python docs

### DIFF
--- a/doc/build/core/custom_types.rst
+++ b/doc/build/core/custom_types.rst
@@ -156,7 +156,7 @@ denormalize::
 
         def process_bind_param(self, value, dialect):
             if value is not None:
-                if not value.tzinfo:
+                if not value.tzinfo and not value.tzinfo.utcoffset(value):
                     raise TypeError("tzinfo is required")
                 value = value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
             return value


### PR DESCRIPTION
### Description
This change updates the `TZDateTime` type decorator to use the timezone awareness checks described in the Python documentation located here:

https://docs.python.org/3/library/datetime.html#determining-if-an-object-is-aware-or-naive

The specific lines state:

> A [`datetime`](https://docs.python.org/3/library/datetime.html#datetime.datetime) object `d` is aware if both of the following hold:
>
> `d.tzinfo is not None`
>
> `d.tzinfo.utcoffset(d)` does not return `None`
>
> Otherwise, `d` is naive.

### Checklist

This pull request is:

- [X] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.
