### PR TITLE
[Issue 10662] Replace custom URL-encoding method with quote_plus

### DIFF
--- a/doc/build/changelog/unreleased_21/10662.rst
+++ b/doc/build/changelog/unreleased_21/10662.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: bug, engine
+    :tickets: 10662
+
+    Fixed URL-encoding of the username and password components of
+    `sqalchemy.engine.url.URL` objects when converting them to string
+    using the `render_as_string` method.

--- a/lib/sqlalchemy/engine/url.py
+++ b/lib/sqlalchemy/engine/url.py
@@ -631,7 +631,7 @@ class URL(NamedTuple):
             s += "@"
         if self.host is not None:
             if ":" in self.host:
-                s += "[%s]" % self.host
+                s += f"[{self.host}]"
             else:
                 s += self.host
         if self.port is not None:
@@ -642,7 +642,7 @@ class URL(NamedTuple):
             keys = list(self.query)
             keys.sort()
             s += "?" + "&".join(
-                "%s=%s" % (_sqla_url_quote(k), _sqla_url_quote(element))
+                f"{_sqla_url_quote(k)}={_sqla_url_quote(element)}"
                 for k in keys
                 for element in util.to_list(self.query[k])
             )

--- a/lib/sqlalchemy/engine/url.py
+++ b/lib/sqlalchemy/engine/url.py
@@ -642,7 +642,7 @@ class URL(NamedTuple):
             keys = list(self.query)
             keys.sort()
             s += "?" + "&".join(
-                "%s=%s" % (quote_plus(k), quote_plus(element))
+                "%s=%s" % (_sqla_url_quote(k), _sqla_url_quote(element))
                 for k in keys
                 for element in util.to_list(self.query[k])
             )
@@ -906,8 +906,7 @@ def _parse_url(name: str) -> URL:
         )
 
 
-def _sqla_url_quote(text: str) -> str:
-    return re.sub(r"[:@/]", lambda m: "%%%X" % ord(m.group(0)), text)
+_sqla_url_quote = quote_plus
 
 
 _sqla_url_unquote = unquote

--- a/test/engine/test_parseconnect.py
+++ b/test/engine/test_parseconnect.py
@@ -95,7 +95,7 @@ class URLTest(fixtures.TestBase):
         eq_(str(u), "dbtype://user:***@host/dbname")
         eq_(
             u.render_as_string(hide_password=False),
-            "dbtype://user:pass word + other%3Awords@host/dbname",
+            "dbtype://user:pass+word+%2B+other%3Awords@host/dbname",
         )
 
         u = url.make_url(
@@ -491,6 +491,41 @@ class URLTest(fixtures.TestBase):
             res = u.translate_connect_args(["foo"])
             is_true("foo" in res)
             eq_(res["foo"], u.host)
+
+    @testing.combinations(
+        "dbtype://username:password@hostspec:110//usr/db_file.db",
+        "dbtype://username:password@hostspec/database",
+        "dbtype+apitype://username:password@hostspec/database",
+        "dbtype://username:password@hostspec",
+        "dbtype://username:password@/database",
+        "dbtype://username@hostspec",
+        "dbtype://username:password@127.0.0.1:1521",
+        "dbtype://hostspec/database",
+        "dbtype://hostspec",
+        "dbtype://hostspec/?arg1=val1&arg2=val2",
+        "dbtype+apitype:///database",
+        "dbtype:///:memory:",
+        "dbtype:///foo/bar/im/a/file",
+        "dbtype:///E:/work/src/LEM/db/hello.db",
+        "dbtype:///E:/work/src/LEM/db/hello.db?foo=bar&hoho=lala",
+        "dbtype:///E:/work/src/LEM/db/hello.db?foo=bar&hoho=lala&hoho=bat",
+        "dbtype://",
+        "dbtype://username:password@/database",
+        "dbtype:////usr/local/_xtest@example.com/members.db",
+        "dbtype://username:apples%2Foranges@hostspec/database",
+        "dbtype://username:password@[2001:da8:2004:1000:202:116:160:90]"
+        "/database?foo=bar",
+        "dbtype://username:password@[2001:da8:2004:1000:202:116:160:90]:80"
+        "/database?foo=bar",
+        "dbtype://username:password@hostspec/test database with@atsign",
+        "dbtype://username:password@hostspec?query=but_no_db",
+        "dbtype://username:password@hostspec:450?query=but_no_db",
+        "dbtype://user%25%26%7Cname:pass%25%26%7Cword@hostspec:499?query=but_no_db",
+    )
+    def test_render_as_string(self, text):
+        u = url.make_url(text)
+
+        eq_(text, u.render_as_string(hide_password=False))
 
 
 class DialectImportTest(fixtures.TestBase):

--- a/test/engine/test_parseconnect.py
+++ b/test/engine/test_parseconnect.py
@@ -62,13 +62,19 @@ class URLTest(fixtures.TestBase):
         "dbtype://username:password@hostspec/test database with@atsign",
         "dbtype://username:password@hostspec?query=but_no_db",
         "dbtype://username:password@hostspec:450?query=but_no_db",
+        "dbtype://user%25%26%7Cname:pass%25%26%7Cword@hostspec:499?query=but_no_db",
     )
     def test_rfc1738(self, text):
         u = url.make_url(text)
 
         assert u.drivername in ("dbtype", "dbtype+apitype")
-        assert u.username in ("username", None)
-        assert u.password in ("password", "apples/oranges", None)
+        assert u.username in ("username", "user%&|name", None)
+        assert u.password in (
+            "password",
+            "apples/oranges",
+            "pass%&|word",
+            None,
+        )
         assert u.host in (
             "hostspec",
             "127.0.0.1",
@@ -491,41 +497,6 @@ class URLTest(fixtures.TestBase):
             res = u.translate_connect_args(["foo"])
             is_true("foo" in res)
             eq_(res["foo"], u.host)
-
-    @testing.combinations(
-        "dbtype://username:password@hostspec:110//usr/db_file.db",
-        "dbtype://username:password@hostspec/database",
-        "dbtype+apitype://username:password@hostspec/database",
-        "dbtype://username:password@hostspec",
-        "dbtype://username:password@/database",
-        "dbtype://username@hostspec",
-        "dbtype://username:password@127.0.0.1:1521",
-        "dbtype://hostspec/database",
-        "dbtype://hostspec",
-        "dbtype://hostspec/?arg1=val1&arg2=val2",
-        "dbtype+apitype:///database",
-        "dbtype:///:memory:",
-        "dbtype:///foo/bar/im/a/file",
-        "dbtype:///E:/work/src/LEM/db/hello.db",
-        "dbtype:///E:/work/src/LEM/db/hello.db?foo=bar&hoho=lala",
-        "dbtype:///E:/work/src/LEM/db/hello.db?foo=bar&hoho=lala&hoho=bat",
-        "dbtype://",
-        "dbtype://username:password@/database",
-        "dbtype:////usr/local/_xtest@example.com/members.db",
-        "dbtype://username:apples%2Foranges@hostspec/database",
-        "dbtype://username:password@[2001:da8:2004:1000:202:116:160:90]"
-        "/database?foo=bar",
-        "dbtype://username:password@[2001:da8:2004:1000:202:116:160:90]:80"
-        "/database?foo=bar",
-        "dbtype://username:password@hostspec/test database with@atsign",
-        "dbtype://username:password@hostspec?query=but_no_db",
-        "dbtype://username:password@hostspec:450?query=but_no_db",
-        "dbtype://user%25%26%7Cname:pass%25%26%7Cword@hostspec:499?query=but_no_db",
-    )
-    def test_render_as_string(self, text):
-        u = url.make_url(text)
-
-        eq_(text, u.render_as_string(hide_password=False))
 
 
 class DialectImportTest(fixtures.TestBase):

--- a/test/engine/test_parseconnect.py
+++ b/test/engine/test_parseconnect.py
@@ -62,17 +62,17 @@ class URLTest(fixtures.TestBase):
         "dbtype://username:password@hostspec/test database with@atsign",
         "dbtype://username:password@hostspec?query=but_no_db",
         "dbtype://username:password@hostspec:450?query=but_no_db",
-        "dbtype://user%25%26%7Cname:pass%25%26%7Cword@hostspec:499?query=but_no_db",
+        "dbtype://user%25%26%7C:pass%25%26%7C@hostspec:499?query=but_no_db",
     )
     def test_rfc1738(self, text):
         u = url.make_url(text)
 
         assert u.drivername in ("dbtype", "dbtype+apitype")
-        assert u.username in ("username", "user%&|name", None)
+        assert u.username in ("username", "user%&|", None)
         assert u.password in (
             "password",
             "apples/oranges",
-            "pass%&|word",
+            "pass%&|",
             None,
         )
         assert u.host in (


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

The `render_as_string` method of the `URL` class was using a custom method to quote the password and username of URLs. However, this custom method was not compliant with RFC 1738 URL encoding. This PR replaces the custom method with `quote_plus` from the `urllib` library.

The code is tested to ensure that `render_as_string` is stable for URLs that are compliant with RFC 1738.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- [x] please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- [x] Please include: `Fixes: #<issue number>` in the commit message
	- [x] please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.


