### PR TITLE
Fix parse failures for constraints marked NO INHERIT

### DIFF
--- a/doc/build/changelog/unreleased_21/10777.rst
+++ b/doc/build/changelog/unreleased_21/10777.rst
@@ -1,0 +1,5 @@
+.. change:
+    :tags: bug, postrgesql, reflection
+    :tickets: 10777
+
+    Fixed issue in parsing of PostgreSQL CHECK constraints marked "NO INHERIT".

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -4696,9 +4696,10 @@ class PGDialect(default.DefaultDialect):
             # "CHECK (((a > 1) AND (a < 5))) NOT VALID"
             # "CHECK (some_boolean_function(a))"
             # "CHECK (((a\n < 1)\n OR\n (a\n >= 5))\n)"
+            # "CHECK (a NOT NULL) NO INHERIT"
 
             m = re.match(
-                r"^CHECK *\((.+)\)( NOT VALID)?$", src, flags=re.DOTALL
+                r"^CHECK *\((.+)\)( NOT VALID)?( NO INHERIT)?$", src, flags=re.DOTALL
             )
             if not m:
                 util.warn("Could not parse CHECK constraint text: %r" % src)

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -4697,9 +4697,10 @@ class PGDialect(default.DefaultDialect):
             # "CHECK (some_boolean_function(a))"
             # "CHECK (((a\n < 1)\n OR\n (a\n >= 5))\n)"
             # "CHECK (a NOT NULL) NO INHERIT"
+            # "CHECK (a NOT NULL) NO INHERIT NOT VALID"
 
             m = re.match(
-                r"^CHECK *\((.+)\)( NOT VALID)?( NO INHERIT)?$", src, flags=re.DOTALL
+                r"^CHECK *\((.+)\)( NO INHERIT)?( NOT VALID)?$", src, flags=re.DOTALL
             )
             if not m:
                 util.warn("Could not parse CHECK constraint text: %r" % src)
@@ -4713,7 +4714,7 @@ class PGDialect(default.DefaultDialect):
                 "sqltext": sqltext,
                 "comment": comment,
             }
-            if m and m.group(2):
+            if m and " NOT VALID" in m.groups():
                 entry["dialect_options"] = {"not_valid": True}
 
             check_constraints[(schema, table_name)].append(entry)

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -2199,7 +2199,8 @@ class ReflectionTest(
 
     def test_reflect_with_no_inherit_check_constraint(self):
         rows = [
-            ("foo", "some name", "CHECK ((a IS NOT NULL)) NO INHERIT", None)
+            ("foo", "some name", "CHECK ((a IS NOT NULL)) NO INHERIT", None),
+            ("foo", "some name", "CHECK ((a IS NOT NULL)) NO INHERIT NOT VALID", None),
         ]
         conn = mock.Mock(
             execute=lambda *arg, **kw: mock.MagicMock(
@@ -2215,9 +2216,14 @@ class ReflectionTest(
                 {
                     "name": "some name",
                     "sqltext": "a IS NOT NULL",
-                    "dialect_options": {"no_inherit": True},
                     "comment": None,
-                }
+                },
+                {
+                    "name": "some name",
+                    "sqltext": "a IS NOT NULL",
+                    "dialect_options": {"not_valid": True},
+                    "comment": None,
+                },
             ],
         )
 

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -2197,6 +2197,30 @@ class ReflectionTest(
             ],
         )
 
+    def test_reflect_with_no_inherit_check_constraint(self):
+        rows = [
+            ("foo", "some name", "CHECK ((a IS NOT NULL)) NO INHERIT", None)
+        ]
+        conn = mock.Mock(
+            execute=lambda *arg, **kw: mock.MagicMock(
+                fetchall=lambda: rows, __iter__=lambda self: iter(rows)
+            )
+        )
+        check_constraints = testing.db.dialect.get_check_constraints(
+            conn, "foo"
+        )
+        eq_(
+            check_constraints,
+            [
+                {
+                    "name": "some name",
+                    "sqltext": "a IS NOT NULL",
+                    "dialect_options": {"no_inherit": True},
+                    "comment": None,
+                }
+            ],
+        )
+
     def _apply_stm(self, connection, use_map):
         if use_map:
             return connection.execution_options(


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
* Extend the existing `get_check_constraints()` regex pattern to parse check constraints marked `NO INHERIT`.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
