### PR TITLE
Fix typo in 'Mapping Table Columns' documentation

### DIFF
--- a/doc/build/orm/mapping_columns.rst
+++ b/doc/build/orm/mapping_columns.rst
@@ -4,6 +4,6 @@ Mapping Table Columns
 =====================
 
 This section has been integrated into the
-:ref:`orm_declarative_table_config_toplevel` Declarative section.
+:ref:`orm_declarative_table_config_toplevel` section.
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Fix a typo - the word `Declarative` is duplicated in the docs

Before:

![image](https://github.com/sqlalchemy/sqlalchemy/assets/19196352/751fd153-eb43-410c-88ef-89f8ac6aad9b)

After:

![image](https://github.com/sqlalchemy/sqlalchemy/assets/19196352/0d815688-fde9-4710-8431-409dd6e2d291)



<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
