### PR TITLE
fix code typo in doc:faq:sqlexpressions on `in_()`

### DIFF
--- a/doc/build/faq/sqlexpressions.rst
+++ b/doc/build/faq/sqlexpressions.rst
@@ -319,7 +319,7 @@ known values are passed.   "Expanding" parameters are used for
 string can be safely cached independently of the actual lists of values
 being passed to a particular invocation of :meth:`_sql.ColumnOperators.in_`::
 
-  >>> stmt = select(A).where(A.id.in_[1, 2, 3])
+  >>> stmt = select(A).where(A.id.in_([1, 2, 3]))
 
 To render the IN clause with real bound parameter symbols, use the
 ``render_postcompile=True`` flag with :meth:`_sql.ClauseElement.compile`:


### PR DESCRIPTION
When learning SQLAlchemy, I find one line of the code example executes with an error, so I just fixed it.

### Description
The first code snippet in [the section](https://docs.sqlalchemy.org/en/20/faq/sqlexpressions.html#rendering-postcompile-parameters-as-bound-parameters) of sqlexpression gives an error when running:
```
  File "sqlalchemy/a.py", line 29, in <module>
    stmt = select(A).where(A.id.in_[1, 2, 3])
                           ~~~~~~~~^^^^^^^^^
TypeError: 'method' object is not subscriptable
```

### Checklist

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
