### PR TITLE
Parse NOT NULL for MySQL generated columns

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2903,7 +2903,7 @@ class MySQLDialect(default.DefaultDialect):
             10,
             2,
         )
-    
+
     @property
     def _supports_notnull_generated_columns(self):
         return self._is_mysql and self.server_version_info >= (5, 7)

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2446,6 +2446,9 @@ class MySQLDialect(default.DefaultDialect):
     supports_for_update_of = False  # default for MySQL ...
     # ... may be updated to True for MySQL 8+ in initialize()
 
+    supports_notnull_generated_columns = False  # Only available ...
+    # ... in MySQL 5.7+
+
     _requires_alias_for_on_duplicate_key = False  # Only available ...
     # ... in MySQL 8+
 
@@ -2844,6 +2847,10 @@ class MySQLDialect(default.DefaultDialect):
 
         self.supports_for_update_of = (
             self._is_mysql and self.server_version_info >= (8,)
+        )
+
+        self.supports_notnull_generated_columns = (
+            self._is_mysql and self.server_version_info >= (5, 7)
         )
 
         self._needs_correct_for_88718_96365 = (

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2446,9 +2446,6 @@ class MySQLDialect(default.DefaultDialect):
     supports_for_update_of = False  # default for MySQL ...
     # ... may be updated to True for MySQL 8+ in initialize()
 
-    supports_notnull_generated_columns = False  # Only available ...
-    # ... in MySQL 5.7+
-
     _requires_alias_for_on_duplicate_key = False  # Only available ...
     # ... in MySQL 8+
 
@@ -2849,10 +2846,6 @@ class MySQLDialect(default.DefaultDialect):
             self._is_mysql and self.server_version_info >= (8,)
         )
 
-        self.supports_notnull_generated_columns = (
-            self._is_mysql and self.server_version_info >= (5, 7)
-        )
-
         self._needs_correct_for_88718_96365 = (
             not self.is_mariadb and self.server_version_info >= (8,)
         )
@@ -2910,6 +2903,10 @@ class MySQLDialect(default.DefaultDialect):
             10,
             2,
         )
+    
+    @property
+    def _supports_notnull_generated_columns(self):
+        return self._is_mysql and self.server_version_info >= (5, 7)
 
     @reflection.cache
     def get_schema_names(self, connection, **kw):

--- a/lib/sqlalchemy/dialects/mysql/reflection.py
+++ b/lib/sqlalchemy/dialects/mysql/reflection.py
@@ -290,6 +290,9 @@ class MySQLTableDefinitionParser:
         # this can be "NULL" in the case of TIMESTAMP
         if spec.get("notnull", False) == "NOT NULL":
             col_kw["nullable"] = False
+        # For generated columns, the nullability is marked in a different place
+        if spec.get("notnull_generated", False) == "NOT NULL":
+            col_kw["nullable"] = False
 
         # AUTO_INCREMENT
         if spec.get("autoincr", False):
@@ -452,7 +455,9 @@ class MySQLTableDefinitionParser:
             r"(?: +ON UPDATE [\-\w\.\(\)]+)?)"
             r"))?"
             r"(?: +(?:GENERATED ALWAYS)? ?AS +(?P<generated>\("
-            r".*\))? ?(?P<persistence>VIRTUAL|STORED)?)?"
+            r".*\))? ?(?P<persistence>VIRTUAL|STORED)?"
+            r"(?: +(?P<notnull_generated>(?:NOT )?NULL))?"
+            r")?"
             r"(?: +(?P<autoincr>AUTO_INCREMENT))?"
             r"(?: +COMMENT +'(?P<comment>(?:''|[^'])*)')?"
             r"(?: +COLUMN_FORMAT +(?P<colfmt>\w+))?"

--- a/test/dialect/mysql/test_reflection.py
+++ b/test/dialect/mysql/test_reflection.py
@@ -778,23 +778,26 @@ class ReflectionTest(fixtures.TestBase, AssertsCompiledSQL):
         ).first()
         explicit_defaults_for_timestamp = row[1].lower() in ("on", "1", "true")
 
-        reflected = []
-        for idx, cols in enumerate(
+        test_cases = [
             [
-                [
-                    "x INTEGER NULL",
-                    "y INTEGER NOT NULL",
-                    "z INTEGER",
-                    "q TIMESTAMP NULL",
-                ],
-                ["p TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP"],
-                ["r TIMESTAMP NOT NULL"],
-                ["s TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"],
-                ["t TIMESTAMP"],
-                ["u TIMESTAMP DEFAULT CURRENT_TIMESTAMP"],
-                ["v INTEGER GENERATED ALWAYS AS (4711) VIRTUAL NOT NULL"],
-            ]
-        ):
+                "x INTEGER NULL",
+                "y INTEGER NOT NULL",
+                "z INTEGER",
+                "q TIMESTAMP NULL",
+            ],
+            ["p TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP"],
+            ["r TIMESTAMP NOT NULL"],
+            ["s TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"],
+            ["t TIMESTAMP"],
+            ["u TIMESTAMP DEFAULT CURRENT_TIMESTAMP"],
+            ["v INTEGER GENERATED ALWAYS AS (4711) VIRTUAL NOT NULL"],
+        ]
+        if connection.dialect.supports_notnull_generated_columns:
+            test_cases.append(
+                ["v INTEGER GENERATED ALWAYS AS (4711) VIRTUAL NOT NULL"])
+
+        reflected = []
+        for idx, cols in enumerate(test_cases):
             Table("nn_t%d" % idx, meta)  # to allow DROP
 
             connection.exec_driver_sql(

--- a/test/dialect/mysql/test_reflection.py
+++ b/test/dialect/mysql/test_reflection.py
@@ -792,6 +792,7 @@ class ReflectionTest(fixtures.TestBase, AssertsCompiledSQL):
                 ["s TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"],
                 ["t TIMESTAMP"],
                 ["u TIMESTAMP DEFAULT CURRENT_TIMESTAMP"],
+                ["v INTEGER GENERATED ALWAYS AS (4711) VIRTUAL NOT NULL"],
             ]
         ):
             Table("nn_t%d" % idx, meta)  # to allow DROP
@@ -859,6 +860,7 @@ class ReflectionTest(fixtures.TestBase, AssertsCompiledSQL):
                     else False,
                     "default": current_timestamp,
                 },
+                {"name": "v", "nullable": False, "default": None},
             ],
         )
 

--- a/test/dialect/mysql/test_reflection.py
+++ b/test/dialect/mysql/test_reflection.py
@@ -792,7 +792,7 @@ class ReflectionTest(fixtures.TestBase, AssertsCompiledSQL):
             ["u TIMESTAMP DEFAULT CURRENT_TIMESTAMP"],
             ["v INTEGER GENERATED ALWAYS AS (4711) VIRTUAL NOT NULL"],
         ]
-        if connection.dialect.supports_notnull_generated_columns:
+        if connection.dialect._supports_notnull_generated_columns:
             test_cases.append(
                 ["v INTEGER GENERATED ALWAYS AS (4711) VIRTUAL NOT NULL"])
 


### PR DESCRIPTION
### Description

As per the MySQL CREATE TABLE specification (see https://dev.mysql.com/doc/refman/8.0/en/create-table.html), the location of the NULL/NOT NULL syntax is slightly different for generated vs. regular columns: in generated columns, the NULL/NOT NULL goes after the VIRTUAL/STORED instead of directly after the data type.

Fixes #10850

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
