### PR TITLE
Correct type hint for FunctionElement.table_valued()

### DIFF
--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
     from ._typing import _ByArgument
     from ._typing import _ColumnExpressionArgument
     from ._typing import _ColumnExpressionOrLiteralArgument
+    from ._typing import _ColumnExpressionOrStrLabelArgument
     from ._typing import _TypeEngineArgument
     from .base import _EntityNamespace
     from .elements import ClauseElement
@@ -235,7 +236,7 @@ class FunctionElement(Executable, ColumnElement[_T], FromClause, Generative):
         return ScalarFunctionColumn(self, name, type_)
 
     def table_valued(
-        self, *expr: _ColumnExpressionArgument[Any], **kw: Any
+        self, *expr: _ColumnExpressionOrStrLabelArgument[Any], **kw: Any
     ) -> TableValuedAlias:
         r"""Return a :class:`_sql.TableValuedAlias` representation of this
         :class:`_functions.FunctionElement` with table-valued expressions added.

--- a/test/typing/plain_files/sql/functions_again.py
+++ b/test/typing/plain_files/sql/functions_again.py
@@ -54,3 +54,9 @@ stmt2 = select(
 ).group_by(Foo.a)
 # EXPECTED_TYPE: Select[Tuple[int, str]]
 reveal_type(stmt2)
+
+
+# EXPECTED_TYPE: TableValuedAlias
+reveal_type(func.json_each().table_valued("key", "value"))
+# EXPECTED_TYPE: TableValuedAlias
+reveal_type(func.json_each().table_valued(Foo.a, Foo.b))


### PR DESCRIPTION
### Description

The documentation and the type annotations for `TableValueType()` clearly
state that both strings and column expression arguments are accepted
but the annotation omits `str`, which is the most common use case.

### Checklist
This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

