### PR TITLE
fix a docs typo

### DIFF
--- a/doc/build/orm/inheritance.rst
+++ b/doc/build/orm/inheritance.rst
@@ -638,7 +638,7 @@ using :paramref:`_orm.Mapper.polymorphic_abstract` as follows::
     class SysAdmin(Technologist):
         """a systems administrator"""
 
-        __mapper_args__ = {"polymorphic_identity": "engineer"}
+        __mapper_args__ = {"polymorphic_identity": "sysadmin"}
 
 In the above example, the new classes ``Technologist`` and ``Executive``
 are ordinary mapped classes, and also indicate new columns to be added to the


### PR DESCRIPTION



<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

The [code on line 662](https://github.com/sqlalchemy/sqlalchemy/blob/9fe5f4fcf2f36e35c7a6865bbaa29dc05617d01e/doc/build/orm/inheritance.rst?plain=1#L662) following this declaration suggests the employee.type should be `sysadmin`.

<img width="902" alt="image" src="https://github.com/sqlalchemy/sqlalchemy/assets/57258/75feb450-17dd-453f-943f-d5193d9b4735">

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
