### PR TITLE
Use `sqlite://` over `sqlite:///:memory:`

### DIFF
--- a/README.dialects.rst
+++ b/README.dialects.rst
@@ -75,7 +75,7 @@ Key aspects of this file layout include:
 
     [db]
     default=access+pyodbc://admin@access_test
-    sqlite=sqlite:///:memory:
+    sqlite=sqlite://
 
   Above, the ``[sqla_testing]`` section contains configuration used by
   SQLAlchemy's test plugin.  The ``[tool:pytest]`` section

--- a/README.unittests.rst
+++ b/README.unittests.rst
@@ -87,7 +87,7 @@ a pre-set URL.  These can be seen using --dbs::
           aiosqlite_file    sqlite+aiosqlite:///async_querytest.db
                  asyncmy    mysql+asyncmy://scott:tiger@127.0.0.1:3306/test?charset=utf8mb4
                  asyncpg    postgresql+asyncpg://scott:tiger@127.0.0.1:5432/test
-                 default    sqlite:///:memory:
+                 default    sqlite://
             docker_mssql    mssql+pymssql://scott:tiger^5HHH@127.0.0.1:1433/test
                  mariadb    mariadb+mysqldb://scott:tiger@127.0.0.1:3306/test
        mariadb_connector    mariadb+mariadbconnector://scott:tiger@127.0.0.1:3306/test
@@ -104,7 +104,7 @@ a pre-set URL.  These can be seen using --dbs::
            psycopg_async    postgresql+psycopg_async://scott:tiger@127.0.0.1:5432/test
                  pymysql    mysql+pymysql://scott:tiger@127.0.0.1:3306/test?charset=utf8mb4
         pysqlcipher_file    sqlite+pysqlcipher://:test@/querytest.db.enc
-                  sqlite    sqlite:///:memory:
+                  sqlite    sqlite://
              sqlite_file    sqlite:///querytest.db
 
 Note that a pyodbc URL **must be against a hostname / database name

--- a/doc/build/core/metadata.rst
+++ b/doc/build/core/metadata.rst
@@ -174,7 +174,7 @@ will issue the CREATE statements:
 
 .. sourcecode:: python+sql
 
-    engine = create_engine("sqlite:///:memory:")
+    engine = create_engine("sqlite://")
 
     metadata_obj = MetaData()
 
@@ -229,7 +229,7 @@ default issue the CREATE or DROP regardless of the table being present:
 
 .. sourcecode:: python+sql
 
-    engine = create_engine("sqlite:///:memory:")
+    engine = create_engine("sqlite://")
 
     metadata_obj = MetaData()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,8 +52,8 @@ oracle_db_link2 = test_link2
 # postgres_test_db_link = localhost
 
 [db]
-default = sqlite:///:memory:
-sqlite = sqlite:///:memory:
+default = sqlite://
+sqlite = sqlite://
 sqlite_numeric = sqlite+pysqlite_numeric:///:memory:
 sqlite_dollar = sqlite+pysqlite_dollar:///:memory:
 aiosqlite = sqlite+aiosqlite:///:memory:

--- a/test/ext/asyncio/test_engine_py3k.py
+++ b/test/ext/asyncio/test_engine_py3k.py
@@ -1277,11 +1277,11 @@ class TextSyncDBAPI(fixtures.TestBase):
             exc.InvalidRequestError,
             "The asyncio extension requires an async driver to be used.",
         ):
-            create_async_engine("sqlite:///:memory:")
+            create_async_engine("sqlite://")
 
     @testing.fixture
     def async_engine(self):
-        engine = create_engine("sqlite:///:memory:", future=True)
+        engine = create_engine("sqlite://", future=True)
         engine.dialect.is_async = True
         engine.dialect.supports_server_side_cursors = True
         with mock.patch.object(


### PR DESCRIPTION
### Description
Your guide suggests using the empty string - https://docs.sqlalchemy.org/en/20/core/engines.html#sqlite - but that syntax is inconsistent throughout your codebase. This resolves said inconsistency.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
