### PR TITLE
add type annotations for Unicode and UnicodeText classes

### DIFF
--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -307,14 +307,14 @@ class Unicode(String):
 
     __visit_name__ = "unicode"
 
-    def __init__(self, length=None, **kwargs):
+    def __init__(self, length: Optional[int] = None, collation: Optional[str] = None):
         """
         Create a :class:`.Unicode` object.
 
         Parameters are the same as that of :class:`.String`.
 
         """
-        super().__init__(length=length, **kwargs)
+        super().__init__(length=length, collation=collation)
 
 
 class UnicodeText(Text):
@@ -331,14 +331,14 @@ class UnicodeText(Text):
 
     __visit_name__ = "unicode_text"
 
-    def __init__(self, length=None, **kwargs):
+    def __init__(self, length: Optional[int] = None, collation: Optional[str] = None):
         """
         Create a Unicode-converting Text type.
 
-        Parameters are the same as that of :class:`_expression.TextClause`.
+        Parameters are the same as that of :class:`.Text`.
 
         """
-        super().__init__(length=length, **kwargs)
+        super().__init__(length=length, collation=collation)
 
 
 class Integer(HasExpressionLookup, TypeEngine[int]):


### PR DESCRIPTION
Fixes #10969

Duplicates #9267


### Description

Based on discussion https://github.com/sqlalchemy/sqlalchemy/discussions/10950#discussioncomment-8368380 here are the type annotations for the `Unicode` class; while at it, I noticed them missing from the `UnicodeText` class as well and added them.

No functional changes, simply duplicate the initializer signature and type annotation from the `String` base class to the `Unicode` and `UnicodeText` sub-classes.

I’ll add tests next, hence the Draft PR for now.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
