### PR TITLE
Fix mysql dialect text docstring, length is interpreted as byte size

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/types.py
+++ b/lib/sqlalchemy/dialects/mysql/types.py
@@ -499,7 +499,7 @@ class YEAR(sqltypes.TypeEngine):
 
 
 class TEXT(_StringType, sqltypes.TEXT):
-    """MySQL TEXT type, for text up to 2^16 characters."""
+    """MySQL TEXT type, for character storage encoded up to 2^16 bytes."""
 
     __visit_name__ = "TEXT"
 
@@ -508,7 +508,7 @@ class TEXT(_StringType, sqltypes.TEXT):
 
         :param length: Optional, if provided the server may optimize storage
           by substituting the smallest TEXT type sufficient to store
-          ``length`` characters.
+          ``length`` bytes of characters.
 
         :param charset: Optional, a column-level character set for this string
           value.  Takes precedence to 'ascii' or 'unicode' short-hand.
@@ -535,7 +535,7 @@ class TEXT(_StringType, sqltypes.TEXT):
 
 
 class TINYTEXT(_StringType):
-    """MySQL TINYTEXT type, for text up to 2^8 characters."""
+    """MySQL TINYTEXT type, for character storage encoded up to 2^8 bytes."""
 
     __visit_name__ = "TINYTEXT"
 
@@ -567,7 +567,7 @@ class TINYTEXT(_StringType):
 
 
 class MEDIUMTEXT(_StringType):
-    """MySQL MEDIUMTEXT type, for text up to 2^24 characters."""
+    """MySQL MEDIUMTEXT type, for character storage encoded up to 2^24 bytes."""
 
     __visit_name__ = "MEDIUMTEXT"
 
@@ -599,7 +599,7 @@ class MEDIUMTEXT(_StringType):
 
 
 class LONGTEXT(_StringType):
-    """MySQL LONGTEXT type, for text up to 2^32 characters."""
+    """MySQL LONGTEXT type, for character storage encoded up to 2^32 bytes."""
 
     __visit_name__ = "LONGTEXT"
 


### PR DESCRIPTION


<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
The `Text` and its variant types in MySQL are bytes size limited, not character length, so fixing the doctoring where the upper limit uses the `characters` as the unit instead of `bytes`

https://dev.mysql.com/doc/refman/5.7/en/storage-requirements.html 
https://dev.mysql.com/doc/refman/8.0/en/storage-requirements.html

<img width="878" alt="Screenshot 2024-02-15 at 17 27 59" src="https://github.com/sqlalchemy/sqlalchemy/assets/5219229/29731769-f57e-46f9-858b-46feda0ae83c">


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
