### PR TITLE
Added YugabyteDB dialect to the documentation

### DIFF
--- a/doc/build/dialects/index.rst
+++ b/doc/build/dialects/index.rst
@@ -119,7 +119,7 @@ Currently maintained external dialect projects for SQLAlchemy include:
 +------------------------------------------------+---------------------------------------+
 | Teradata Vantage                               | teradatasqlalchemy_                   |
 +------------------------------------------------+---------------------------------------+
-| YugabyteDB                                     | sqlalchemy-yugabytedb_                 |
+| YugabyteDB                                     | sqlalchemy-yugabytedb_                |
 +------------------------------------------------+---------------------------------------+
 
 .. [1] Supports version 1.3.x only at the moment.

--- a/doc/build/dialects/index.rst
+++ b/doc/build/dialects/index.rst
@@ -119,6 +119,8 @@ Currently maintained external dialect projects for SQLAlchemy include:
 +------------------------------------------------+---------------------------------------+
 | Teradata Vantage                               | teradatasqlalchemy_                   |
 +------------------------------------------------+---------------------------------------+
+| YugabyteDB                                     | sqlalchemy-yugabytedb_                 |
++------------------------------------------------+---------------------------------------+
 
 .. [1] Supports version 1.3.x only at the moment.
 
@@ -150,3 +152,4 @@ Currently maintained external dialect projects for SQLAlchemy include:
 .. _sqlalchemy-sybase: https://pypi.org/project/sqlalchemy-sybase/
 .. _firebolt-sqlalchemy: https://pypi.org/project/firebolt-sqlalchemy/
 .. _pyathena: https://github.com/laughingman7743/PyAthena/
+.. _sqlalchemy-yugabytedb: https://pypi.org/project/sqlalchemy-yugabytedb/


### PR DESCRIPTION
### Describe the use case

YugabyteDB is a cloud native distributed database compatible with Postgresql. 
We have developed a YugabyteDB dialect for SQLAlchemy for adding enhancements specific to YugabyteDB. 
Adding the above dialect as suggested in [this ticket](https://github.com/sqlalchemy/sqlalchemy/issues/11026)


### Databases / Backends / Drivers targeted

Database: YugabyteDB (YSQL)
Drivers: `psycopg2` and `psycopg2-yugabytedb`