### PR TITLE
Fixed typing issues with sync code runners

### DIFF
--- a/lib/sqlalchemy/ext/asyncio/engine.py
+++ b/lib/sqlalchemy/ext/asyncio/engine.py
@@ -21,9 +21,6 @@ from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 
-from typing_extensions import Concatenate
-from typing_extensions import ParamSpec
-
 from . import exc as async_exc
 from .base import asyncstartablecontext
 from .base import GeneratorStartableContext
@@ -43,6 +40,8 @@ from ...engine.base import NestedTransaction
 from ...engine.base import Transaction
 from ...exc import ArgumentError
 from ...util.concurrency import greenlet_spawn
+from ...util.typing import Concatenate
+from ...util.typing import ParamSpec
 from ...util.typing import TupleAny
 from ...util.typing import TypeVarTuple
 from ...util.typing import Unpack

--- a/lib/sqlalchemy/ext/asyncio/session.py
+++ b/lib/sqlalchemy/ext/asyncio/session.py
@@ -25,9 +25,6 @@ from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 
-from typing_extensions import Concatenate
-from typing_extensions import ParamSpec
-
 from . import engine
 from .base import ReversibleProxy
 from .base import StartableContext
@@ -41,6 +38,8 @@ from ...orm import Session
 from ...orm import SessionTransaction
 from ...orm import state as _instance_state
 from ...util.concurrency import greenlet_spawn
+from ...util.typing import Concatenate
+from ...util.typing import ParamSpec
 from ...util.typing import TupleAny
 from ...util.typing import TypeVarTuple
 from ...util.typing import Unpack

--- a/test/typing/plain_files/ext/asyncio/async_sessionmaker.py
+++ b/test/typing/plain_files/ext/asyncio/async_sessionmaker.py
@@ -52,6 +52,10 @@ def work_with_a_session_two(sess: Session, param: Optional[str] = None) -> Any:
     pass
 
 
+def work_with_wrong_parameter(session: Session, foo: int) -> Any:
+    pass
+
+
 async def async_main() -> None:
     """Main program function."""
 
@@ -70,6 +74,9 @@ async def async_main() -> None:
     async with async_session.begin() as session:
         await session.run_sync(work_with_a_session_one)
         await session.run_sync(work_with_a_session_two, param="foo")
+
+        # EXPECTED_MYPY: Missing positional argument "foo" in call to "run_sync" of "AsyncSession"
+        await session.run_sync(work_with_wrong_parameter)
 
         session.add_all(
             [

--- a/test/typing/plain_files/ext/asyncio/engines.py
+++ b/test/typing/plain_files/ext/asyncio/engines.py
@@ -1,5 +1,12 @@
+from typing import Any
+
+from sqlalchemy import Connection
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
+
+
+def work_sync(conn: Connection, foo: int) -> Any:
+    pass
 
 
 async def asyncio() -> None:
@@ -53,3 +60,8 @@ async def asyncio() -> None:
 
         # EXPECTED_TYPE: CursorResult[Unpack[.*tuple[Any, ...]]]
         reveal_type(result)
+
+        await conn.run_sync(work_sync, 1)
+
+        # EXPECTED_MYPY: Missing positional argument "foo" in call to "run_sync" of "AsyncConnection"
+        await conn.run_sync(work_sync)


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

This PR makes use of typing extension constructs available some versions ago to avoid typing issues when running sync code in async session and connection objects.

### Description
<!-- Describe your changes in detail -->

I just added `ParamSpec` usage to the `run_sync` methods.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
