### PR TITLE
Removed useless else branches in orm/collections.py.

### DIFF
--- a/lib/sqlalchemy/orm/collections.py
+++ b/lib/sqlalchemy/orm/collections.py
@@ -664,8 +664,7 @@ class CollectionAdapter:
             return self.attr.fire_append_wo_mutation_event(
                 self.owner_state, self.owner_state.dict, item, initiator, key
             )
-        else:
-            return item
+        return item
 
     def fire_append_event(self, item, initiator=None, key=NO_KEY):
         """Notify that a entity has entered the collection.
@@ -686,8 +685,7 @@ class CollectionAdapter:
             return self.attr.fire_append_event(
                 self.owner_state, self.owner_state.dict, item, initiator, key
             )
-        else:
-            return item
+        return item
 
     def _fire_remove_event_bulk(self, items, initiator=None, key=NO_KEY):
         if not items:


### PR DESCRIPTION
### Description
`else` branch in sqlalchemy/orm/collections.py fire_append_event and fire_append_wo_mutation_event CollectionAdapter methods are useless, because in first branch we **always** return from function.

### Checklist

This pull request is:

1. [x] A short code fix.

Should i open an issue for so small changes?
**Have a nice day!**
