### PR TITLE
session.begin()'s contextmanager should return type Self

### DIFF
--- a/lib/sqlalchemy/engine/util.py
+++ b/lib/sqlalchemy/engine/util.py
@@ -17,6 +17,7 @@ from typing import TypeVar
 from .. import exc
 from .. import util
 from ..util._has_cy import HAS_CYEXTENSION
+from ..util.typing import Self
 
 if typing.TYPE_CHECKING or not HAS_CYEXTENSION:
     from ._py_util import _distill_params_20 as _distill_params_20
@@ -113,7 +114,7 @@ class TransactionalContext:
                     "before emitting further commands."
                 )
 
-    def __enter__(self) -> TransactionalContext:
+    def __enter__(self) -> Self:
         subject = self._get_subject()
 
         # none for outer transaction, may be non-None for nested

--- a/test/typing/plain_files/orm/session.py
+++ b/test/typing/plain_files/orm/session.py
@@ -97,6 +97,12 @@ with Session(e) as sess:
         User.id
     ).offset(User.id)
 
+    # test #11083
+
+    with sess.begin() as tx:
+        # EXPECTED_TYPE: SessionTransaction
+        reveal_type(tx)
+
 # more result tests in typed_results.py
 
 


### PR DESCRIPTION
### Description

Bugfix for https://github.com/sqlalchemy/sqlalchemy/issues/11083

Typing (mypy) fix while using a SessionTransaction within a context manager:

```python
with db_session.begin() as tx: # tx is SessionTransaction
  # tx is TransactionalContext
```

This PR modifies the return type of SessionTransaction's parent class (TransactionalContext)'s `__enter__` method to return type `Self` instead of `TransactionalContext`.

### Checklist

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
