### PR TITLE
Inline _get_bind_args method.

### DIFF
--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -2871,7 +2871,7 @@ class Query(
 
         try:
             bind = (
-                self._get_bind_args(statement, self.session.get_bind)
+                self.session.get_bind(clause=statement)
                 if self.session
                 else None
             )
@@ -2879,9 +2879,6 @@ class Query(
             bind = None
 
         return str(statement.compile(bind))
-
-    def _get_bind_args(self, statement: Any, fn: Any, **kw: Any) -> Any:
-        return fn(clause=statement, **kw)
 
     @property
     def column_descriptions(self) -> List[ORMColumnDescription]:


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
_get_bind_args is strange method in query module. It is called only in one place. It takes self(but don't use it) and two args with Any type. I think it must be static method with typehints if it will has more use cases in the future. But now removing is more simple solution.

### Checklist

This pull request is:

- [x] A short code fix

**Have a nice day!**
