### PR TITLE
Improved typehints in ext/compiler module

### DIFF
--- a/lib/sqlalchemy/ext/compiler.py
+++ b/lib/sqlalchemy/ext/compiler.py
@@ -453,6 +453,7 @@ Example usage::
 
 """
 from __future__ import annotations
+
 from typing import Callable
 from typing import Type
 from typing import TypeVar

--- a/lib/sqlalchemy/ext/compiler.py
+++ b/lib/sqlalchemy/ext/compiler.py
@@ -489,7 +489,8 @@ def compiles(class_: Type[ClauseElement], *specs: str) -> Callable[[_C], _C]:
 
                 def _wrap_existing_dispatch(
                         element: ClauseElement,
-                        compiler: Union[Compiled, TypeCompiler], **kw: Any) -> Any:
+                        compiler: Union[Compiled, TypeCompiler],
+                        **kw: Any) -> Any:
                     try:
                         return existing_dispatch(element, compiler, **kw)
                     except exc.UnsupportedCompilationError as uce:


### PR DESCRIPTION
### Description
Improved typehints for `compiles` `and` deregister functions from ext/compiler module.
`compiles` function `class_` parameter type was taken from its doc string and `*specs` is `str tuple` in all call places.
`decorate` closure in `compiles` takes `fn` and return it. `fn` is `Callable` because `decorate` is decorator.
`_wrap_existing_dispatch` closure typehints were taken from `exc.UnsupportedCompilationError`.
`deregister` arg type was taken from its doc string.
`_dispatcher.__call__()` typehints were taken from `exc.UnsupportedCompilationError`/

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
