### PR TITLE
Eta reduced useless lambda

### DIFF
--- a/lib/sqlalchemy/ext/compiler.py
+++ b/lib/sqlalchemy/ext/compiler.py
@@ -486,11 +486,10 @@ def compiles(class_, *specs):
 
                 existing.specs["default"] = _wrap_existing_dispatch
 
-            # TODO: why is the lambda needed ?
             setattr(
                 class_,
                 "_compiler_dispatch",
-                lambda *arg, **kw: existing(*arg, **kw),
+                existing,
             )
             setattr(class_, "_compiler_dispatcher", existing)
 


### PR DESCRIPTION
### Description
I found comment
> TODO: why is the lambda needed ?

in sources of ext/compiler module.
```python
lambda *arg, **kw: existing(*arg, **kw)
```
and
`existing`
are semantically equivalent(except case where existing isn't declared but it isn't this case). So we can eta reduce it. 

### Checklist

This pull request is:

- [x] A short code fix

**Have a nice day!**
