### PR TITLE
add a docs cross-reference between adding columns & relationships to existing table mappings

### DIFF
--- a/doc/build/orm/basic_relationships.rst
+++ b/doc/build/orm/basic_relationships.rst
@@ -1102,8 +1102,10 @@ that will be passed to ``eval()`` are:
     are **evaluated as Python code expressions using eval().  DO NOT PASS
     UNTRUSTED INPUT TO THESE ARGUMENTS.**
 
+.. _orm_declarative_table_adding_relationship:
+
 Adding Relationships to Mapped Classes After Declaration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 It should also be noted that in a similar way as described at
 :ref:`orm_declarative_table_adding_columns`, any :class:`_orm.MapperProperty`

--- a/doc/build/orm/declarative_tables.rst
+++ b/doc/build/orm/declarative_tables.rst
@@ -1158,6 +1158,10 @@ additional columns are present on mapped subclasses that have
 no :class:`.Table` of their own.  This is illustrated in the section
 :ref:`single_inheritance`.
 
+Note that in a similar fashion a :func:`_orm.relationship` can be added
+to an existing declarative table mapping as described in
+:ref:`orm_declarative_table_adding_relationship`.
+
 .. note:: Assignment of mapped
     properties to an already mapped class will only
     function correctly if the "declarative base" class is used, meaning


### PR DESCRIPTION
For context see discussion https://github.com/sqlalchemy/sqlalchemy/discussions/11124. This change adds the requested cross-reference to the documentation.

This pull request is:

- [X] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
