### PR TITLE
Fix subquerload deprecation

### DIFF
--- a/doc/build/orm/queryguide/relationships.rst
+++ b/doc/build/orm/queryguide/relationships.rst
@@ -81,7 +81,8 @@ The primary forms of relationship loading are:
   option, this form of loading emits a second SELECT statement which re-states the
   original query embedded inside of a subquery, then JOINs that subquery to the
   related table to be loaded to load all members of related collections / scalar
-  references at once.  Subquery eager loading is detailed at :ref:`subquery_eager_loading`.
+  references at once.  Subquery eager loading is deprecated as of SQLAlchemy 2.1
+  and detailed at :ref:`subquery_eager_loading`.
 
 * **write only loading** - available via ``lazy='write_only'``, or by
   annotating the left side of the :class:`_orm.Relationship` object using the

--- a/lib/sqlalchemy/orm/strategy_options.py
+++ b/lib/sqlalchemy/orm/strategy_options.py
@@ -350,6 +350,8 @@ class _AbstractLoad(traversals.GenerativeOnTraversal, LoaderOption):
                 lazyload(Order.items).subqueryload(Item.keywords))
 
 
+        .. deprecated:: 2.1
+
         .. seealso::
 
             :ref:`loading_toplevel`
@@ -2405,6 +2407,13 @@ def joinedload(*keys: _AttrType, **kw: Any) -> _AbstractLoad:
 
 @loader_unbound_fn
 def subqueryload(*keys: _AttrType) -> _AbstractLoad:
+    """
+    .. deprecated:: 2.0
+
+    .. seealso::
+
+        :ref:`subquery_eager_loading`
+    """
     return _generate_from_keys(Load.subqueryload, keys, False, {})
 
 

--- a/lib/sqlalchemy/orm/strategy_options.py
+++ b/lib/sqlalchemy/orm/strategy_options.py
@@ -2408,7 +2408,7 @@ def joinedload(*keys: _AttrType, **kw: Any) -> _AbstractLoad:
 @loader_unbound_fn
 def subqueryload(*keys: _AttrType) -> _AbstractLoad:
     """
-    .. deprecated:: 2.0
+    .. deprecated:: 2.1
 
     .. seealso::
 


### PR DESCRIPTION
Change-Id: I3d1b844dee6dc29da4a6aaa0c2916e6a1178aaec

The deprecation info does not appear in 3 important sections:

* The initial overview
* API docstrings in 2 places.

This PR notes the deprecation in the overview, and adds links/deprecation docstrings to the functions so they should show up in the API docs.

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
