### PR TITLE
Fix typing issue in `MetaData.reflect()` in AsyncIO context

### DIFF
--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -5687,6 +5687,36 @@ class MetaData(HasSchemaAttr):
             sorted(self.tables.values(), key=lambda t: t.key)  # type: ignore
         )
 
+    @overload
+    def reflect(
+        self,
+        bind: Engine,
+        schema: Optional[str] = ...,
+        views: bool = ...,
+        only: Union[
+            _typing_Sequence[str], Callable[[str, MetaData], bool], None
+        ] = ...,
+        extend_existing: bool = ...,
+        autoload_replace: bool = ...,
+        resolve_fks: bool = ...,
+        **dialect_kwargs: Any,
+    ) -> None: ...
+
+    @overload
+    def reflect(
+        self,
+        bind: Connection,
+        schema: Optional[str] = ...,
+        views: bool = ...,
+        only: Union[
+            _typing_Sequence[str], Callable[[str, MetaData], bool], None
+        ] = ...,
+        extend_existing: bool = ...,
+        autoload_replace: bool = ...,
+        resolve_fks: bool = ...,
+        **dialect_kwargs: Any,
+    ) -> None: ...
+
     @util.preload_module("sqlalchemy.engine.reflection")
     def reflect(
         self,

--- a/test/typing/plain_files/ext/asyncio/engines.py
+++ b/test/typing/plain_files/ext/asyncio/engines.py
@@ -76,4 +76,6 @@ async def asyncio() -> None:
     async with e.connect() as conn:
         metadata = MetaData()
 
+        await conn.run_sync(metadata.create_all)
         await conn.run_sync(metadata.reflect)
+        await conn.run_sync(metadata.drop_all)

--- a/test/typing/plain_files/ext/asyncio/engines.py
+++ b/test/typing/plain_files/ext/asyncio/engines.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from sqlalchemy import Connection
+from sqlalchemy import Enum
 from sqlalchemy import MetaData
 from sqlalchemy import select
 from sqlalchemy import text
@@ -79,3 +80,18 @@ async def asyncio() -> None:
         await conn.run_sync(metadata.create_all)
         await conn.run_sync(metadata.reflect)
         await conn.run_sync(metadata.drop_all)
+
+        # Just to avoid creating new constructs manually:
+        for _, table in metadata.tables.items():
+            await conn.run_sync(table.create)
+            await conn.run_sync(table.drop)
+
+            # Indexes:
+            for index in table.indexes:
+                await conn.run_sync(index.create)
+                await conn.run_sync(index.drop)
+
+        # Test for enum types:
+        enum = Enum("a", "b")
+        await conn.run_sync(enum.create)
+        await conn.run_sync(enum.drop)

--- a/test/typing/plain_files/ext/asyncio/engines.py
+++ b/test/typing/plain_files/ext/asyncio/engines.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from sqlalchemy import Connection
+from sqlalchemy import MetaData
 from sqlalchemy import select
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -71,3 +72,8 @@ async def asyncio() -> None:
     ce.statement
     cc = select(1).compile(conn)
     cc.statement
+
+    async with e.connect() as conn:
+        metadata = MetaData()
+
+        await conn.run_sync(metadata.reflect)


### PR DESCRIPTION
I've added some overloads to the method.

### Description
Mypy threats unions and overloads different. To fix the issue, I've added two overloads to the method.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
