### PR TITLE
typing: annotate Exists.select() to return Select[bool]

### DIFF
--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -6674,7 +6674,7 @@ class Exists(UnaryExpression[bool]):
         assert isinstance(return_value, SelectStatementGrouping)
         return return_value
 
-    def select(self) -> Select[Unpack[TupleAny]]:
+    def select(self) -> Select[bool]:
         r"""Return a SELECT of this :class:`_expression.Exists`.
 
         e.g.::

--- a/test/typing/plain_files/sql/common_sql_element.py
+++ b/test/typing/plain_files/sql/common_sql_element.py
@@ -98,6 +98,11 @@ stmt2 = (
 # EXPECTED_TYPE: Select[int]
 reveal_type(stmt2)
 
+stmt3 = select(User.id).exists().select()
+
+# EXPECTED_TYPE: Select[bool]
+reveal_type(stmt3)
+
 
 receives_str_col_expr(User.email)
 receives_str_col_expr(User.email + "some expr")


### PR DESCRIPTION
Fixes: #11231

A query of the form:

``` sql
SELECT EXISTS (
    SELECT 1
    FROM ...
    WHERE ...
)
```

… returns a boolean.