### PR TITLE
Ability to specify `WITH` when creating a table + fixes `WITH` when creating an index

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2453,6 +2453,18 @@ class PGDDLCompiler(compiler.DDLCompiler):
         if pg_opts["using"]:
             table_opts.append("\n USING %s" % pg_opts["using"])
 
+        if pg_opts["with"]:
+            with_opts = []
+            for param, value in pg_opts["with"].items():
+                if value is not None:
+                    processed_value = self.sql_compiler.process(
+                        sql.literal(value), literal_binds=True
+                    )
+                    with_opts.append("%s = %s" % (param, processed_value))
+                else:
+                    with_opts.append("%s" % param)
+            table_opts.append("\n WITH (%s)" % (", ".join(with_opts)))
+
         if pg_opts["with_oids"] is True:
             table_opts.append("\n WITH OIDS")
         elif pg_opts["with_oids"] is False:
@@ -3067,6 +3079,7 @@ class PGDialect(default.DefaultDialect):
                 "ignore_search_path": False,
                 "tablespace": None,
                 "partition_by": None,
+                "with": {},
                 "with_oids": None,
                 "on_commit": None,
                 "inherits": None,

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -950,6 +950,26 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             postgresql_with={"buffering": "off"},
         )
 
+        idx4 = Index(
+            "test_idx4",
+            tbl.c.data,
+            postgresql_using="gin",
+            postgresql_with={
+                "fastupdate": False,
+                "gin_pending_list_limit": 4096,
+            },
+        )
+
+        idx5 = Index(
+            "test_idx5",
+            tbl.c.data,
+            postgresql_using="brin",
+            postgresql_with={
+                "pages_per_range": 1,
+                "autosummarize": None,
+            },
+        )
+
         self.assert_compile(
             schema.CreateIndex(idx1),
             "CREATE INDEX test_idx1 ON testtbl (data)",
@@ -964,7 +984,19 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             schema.CreateIndex(idx3),
             "CREATE INDEX test_idx3 ON testtbl "
             "USING gist (data) "
-            "WITH (buffering = off)",
+            "WITH (buffering = 'off')",
+        )
+        self.assert_compile(
+            schema.CreateIndex(idx4),
+            "CREATE INDEX test_idx4 ON testtbl "
+            "USING gin (data) "
+            "WITH (fastupdate = false, gin_pending_list_limit = 4096)",
+        )
+        self.assert_compile(
+            schema.CreateIndex(idx5),
+            "CREATE INDEX test_idx5 ON testtbl "
+            "USING brin (data) "
+            "WITH (pages_per_range = 1, autosummarize)",
         )
 
     def test_create_index_with_using_unusual_conditions(self):

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -552,6 +552,34 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             "PARTITION BY RANGE (part_column)",
         )
 
+    def test_create_table_with(self):
+        m = MetaData()
+
+        tbl = Table(
+            "atable",
+            m,
+            Column("id", Integer),
+            postgresql_with={
+                "fillfactor": 30,
+                "autovacuum_enabled": False,
+                "autovacuum_analyze_scale_factor": 0.2,
+                "vacuum_index_cleanup": "auto",
+                "vacuum_truncate": None,  # default true
+            },
+        )
+
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE atable (id INTEGER) "
+            "WITH ("
+            "fillfactor = 30, "
+            "autovacuum_enabled = false, "
+            "autovacuum_analyze_scale_factor = 0.2, "
+            "vacuum_index_cleanup = 'auto', "
+            "vacuum_truncate"
+            ")",
+        )
+
     def test_create_table_with_oids(self):
         m = MetaData()
         tbl = Table(


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Adding the ability to specify storage parameters via with + fix for specifying index storage parameters (should it be split into two different PRs?).

Fixes: #11122

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
