### PR TITLE
Optionally include rollback exception in closed transaction invalid request error message when possible

### DIFF
--- a/lib/sqlalchemy/engine/util.py
+++ b/lib/sqlalchemy/engine/util.py
@@ -97,6 +97,15 @@ class TransactionalContext:
         trans_context = subject._trans_context_manager
         if trans_context:
             if not trans_context._transaction_is_active():
+                transaction = getattr(subject, "transaction", None)
+                if transaction is not None:
+                    if transaction.rollback_exception is not None:
+                        raise exc.InvalidRequestError(
+                            "Can't operate on closed transaction inside context manager. "
+                            f"The transaction was rolled back due to an exception, {transaction.rollback_exception}. "
+                            "Please complete the context manager before emitting further commands."
+                        )
+
                 raise exc.InvalidRequestError(
                     "Can't operate on closed transaction inside context "
                     "manager.  Please complete the context manager "

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -1031,6 +1031,10 @@ class SessionTransaction(_StateChange, TransactionalContext):
     def _is_transaction_boundary(self) -> bool:
         return self.nested or not self._parent
 
+    @property
+    def rollback_exception(self):
+        return self._rollback_exception
+
     @_StateChange.declare_states(
         (SessionTransactionState.ACTIVE,), _StateChangeStates.NO_CHANGE
     )


### PR DESCRIPTION
Following discussion https://github.com/sqlalchemy/sqlalchemy/discussions/11243 

### Description
1. Exposing private attribute `SessionTransaction._rollback_exception` using public property `rollback_exception` 
2. In `TransactionalContext._trans_ctx_check()` when a closed transaction is detected. first checking a transaction's `rollback_exception` is accessible and if it is, raising an InvalidRequestError which includes it in the error message

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
