### PR TITLE
Changed some `declared_attr` code examples in the docs to return `mapped_column` to indicate that it's possible.

### DIFF
--- a/doc/build/orm/dataclasses.rst
+++ b/doc/build/orm/dataclasses.rst
@@ -787,8 +787,8 @@ example at :ref:`orm_declarative_mixins_relationships`::
 
     class RefTargetMixin:
         @declared_attr
-        def target_id(cls):
-            return Column("target_id", ForeignKey("target.id"))
+        def target_id(cls) -> Mapped[int]:
+            return mapped_column("target_id", ForeignKey("target.id"))
 
         @declared_attr
         def target(cls):

--- a/doc/build/orm/extensions/mypy.rst
+++ b/doc/build/orm/extensions/mypy.rst
@@ -497,7 +497,7 @@ plugin that a particular class intends to serve as a declarative mixin::
     class HasCompany:
         @declared_attr
         def company_id(cls) -> Mapped[int]:  # uses Mapped
-            return Column(ForeignKey("company.id"))
+            return mapped_column(ForeignKey("company.id"))
 
         @declared_attr
         def company(cls) -> Mapped["Company"]:

--- a/doc/build/orm/mapping_api.rst
+++ b/doc/build/orm/mapping_api.rst
@@ -53,11 +53,11 @@ Class Mapping API
 
             class HasIdMixin:
                 @declared_attr.cascading
-                def id(cls):
+                def id(cls) -> Mapped[int]:
                     if has_inherited_table(cls):
-                        return Column(ForeignKey("myclass.id"), primary_key=True)
+                        return mapped_column(ForeignKey("myclass.id"), primary_key=True)
                     else:
-                        return Column(Integer, primary_key=True)
+                        return mapped_column(Integer, primary_key=True)
 
 
             class MyClass(HasIdMixin, Base):


### PR DESCRIPTION
Good day to you!

### Description
As per [this discussion](https://github.com/sqlalchemy/sqlalchemy/discussions/11249), I've changed some code examples for `declared_attr` to return `mapped_column` instead of column to illustrate that this is possible.

Turned out pretty minimal, but I think, this would have helped me a lot when I was looking into this possibility.

### Checklist
This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
