### PR TITLE
Add missing overload to __add__

### DIFF
--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -1069,6 +1069,9 @@ class SQLCoreOperations(Generic[_T_co], ColumnOperators, TypingOnly):
             other: Any,
         ) -> ColumnElement[str]: ...
 
+        @overload
+        def __add__(self, other: Any) -> ColumnElement[Any]: ...
+            
         def __add__(self, other: Any) -> ColumnElement[Any]: ...
 
         @overload

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -1071,7 +1071,7 @@ class SQLCoreOperations(Generic[_T_co], ColumnOperators, TypingOnly):
 
         @overload
         def __add__(self, other: Any) -> ColumnElement[Any]: ...
-            
+
         def __add__(self, other: Any) -> ColumnElement[Any]: ...
 
         @overload

--- a/test/typing/plain_files/sql/operators.py
+++ b/test/typing/plain_files/sql/operators.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from decimal import Decimal
 from typing import Any
 from typing import List
@@ -6,6 +7,7 @@ from sqlalchemy import ARRAY
 from sqlalchemy import BigInteger
 from sqlalchemy import column
 from sqlalchemy import ColumnElement
+from sqlalchemy import func
 from sqlalchemy import Integer
 from sqlalchemy import select
 from sqlalchemy import String
@@ -100,6 +102,10 @@ adds: "ColumnElement[str]" = A.string + A.string
 add1: "ColumnElement[int]" = A.id + A.id
 add2: "ColumnElement[int]" = A.id + 1
 add3: "ColumnElement[int]" = 1 + A.id
+add_date: "ColumnElement[dt.date]" = func.current_date() + dt.timedelta(days=1)
+add_datetime: "ColumnElement[dt.datetime]" = (
+    func.current_timestamp() + dt.timedelta(seconds=1)
+)
 
 sub1: "ColumnElement[int]" = A.id - A.id
 sub2: "ColumnElement[int]" = A.id - 1


### PR DESCRIPTION
Add a missing `@overload` to the `__add__` operator.

### Description
The `__add__` function is missing an overload that handles the rest of the cases, similar to the one that `__sub__` has a few lines later in the same file.

This fix is taken from https://github.com/microsoft/pyright/issues/7743


### Checklist
This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
