### PR TITLE
Add overload for ColumnCollection.get(col, default)

### DIFF
--- a/lib/sqlalchemy/orm/properties.py
+++ b/lib/sqlalchemy/orm/properties.py
@@ -689,8 +689,10 @@ class MappedColumn(
             supercls_mapper = class_mapper(decl_scan.inherits, False)
 
             colname = column.name if column.name is not None else key
-            column = self.column = supercls_mapper.local_table.c.get(  # noqa: E501
-                colname, column
+            column = self.column = (
+                supercls_mapper.local_table.c.get(  # noqa: E501
+                    colname, column
+                )
             )
 
         if column.key is None:

--- a/lib/sqlalchemy/orm/properties.py
+++ b/lib/sqlalchemy/orm/properties.py
@@ -689,7 +689,7 @@ class MappedColumn(
             supercls_mapper = class_mapper(decl_scan.inherits, False)
 
             colname = column.name if column.name is not None else key
-            column = self.column = supercls_mapper.local_table.c.get(  # type: ignore # noqa: E501
+            column = self.column = supercls_mapper.local_table.c.get(  # noqa: E501
                 colname, column
             )
 

--- a/lib/sqlalchemy/sql/base.py
+++ b/lib/sqlalchemy/sql/base.py
@@ -1641,6 +1641,9 @@ class ColumnCollection(Generic[_COLKEY, _COL_co]):
     def __eq__(self, other: Any) -> bool:
         return self.compare(other)
 
+    @overload
+    def get(self, key: str, default: _COL_co) -> _COL_co: ...
+
     def get(
         self, key: str, default: Optional[_COL_co] = None
     ) -> Optional[_COL_co]:

--- a/lib/sqlalchemy/sql/base.py
+++ b/lib/sqlalchemy/sql/base.py
@@ -1353,6 +1353,7 @@ class _SentinelColumnCharacterization(NamedTuple):
 _COLKEY = TypeVar("_COLKEY", Union[None, str], str)
 
 _COL_co = TypeVar("_COL_co", bound="ColumnElement[Any]", covariant=True)
+_CE = TypeVar("_CE", bound="ColumnElement[Any]")
 _COL = TypeVar("_COL", bound="KeyedColumnElement[Any]")
 
 
@@ -1642,7 +1643,7 @@ class ColumnCollection(Generic[_COLKEY, _COL_co]):
         return self.compare(other)
 
     @overload
-    def get(self, key: str, default: _COL) -> _COL: ...
+    def get(self, key: str, default: _CE) -> _CE: ...
 
     @overload
     def get(

--- a/lib/sqlalchemy/sql/base.py
+++ b/lib/sqlalchemy/sql/base.py
@@ -1644,6 +1644,11 @@ class ColumnCollection(Generic[_COLKEY, _COL_co]):
     @overload
     def get(self, key: str, default: _COL_co) -> _COL_co: ...
 
+    @overload
+    def get(
+        self, key: str, default: Optional[_COL_co] = None
+    ) -> Optional[_COL_co]: ...
+
     def get(
         self, key: str, default: Optional[_COL_co] = None
     ) -> Optional[_COL_co]:

--- a/lib/sqlalchemy/sql/base.py
+++ b/lib/sqlalchemy/sql/base.py
@@ -1642,7 +1642,7 @@ class ColumnCollection(Generic[_COLKEY, _COL_co]):
         return self.compare(other)
 
     @overload
-    def get(self, key: str, default: _COL_co) -> _COL_co: ...
+    def get(self, key: str, default: _COL) -> _COL: ...
 
     @overload
     def get(

--- a/lib/sqlalchemy/sql/base.py
+++ b/lib/sqlalchemy/sql/base.py
@@ -1650,9 +1650,7 @@ class ColumnCollection(Generic[_COLKEY, _COL_co]):
         self, key: str, default: Optional[_COL_co] = None
     ) -> Optional[_COL_co]: ...
 
-    def get(
-        self, key: str, default: Optional[_COL_co] = None
-    ) -> Optional[_COL_co]:
+    def get(self, key, default=None):
         """Get a :class:`_sql.ColumnClause` or :class:`_schema.Column` object
         based on a string key name from this
         :class:`_expression.ColumnCollection`."""

--- a/test/sql/test_utils.py
+++ b/test/sql/test_utils.py
@@ -14,6 +14,7 @@ from sqlalchemy.sql import coercions
 from sqlalchemy.sql import column
 from sqlalchemy.sql import ColumnElement
 from sqlalchemy.sql import roles
+from sqlalchemy.sql import table
 from sqlalchemy.sql import util as sql_util
 from sqlalchemy.testing import assert_raises
 from sqlalchemy.testing import assert_raises_message
@@ -174,3 +175,15 @@ class MiscTest(fixtures.TestBase):
 
         for a, b in zip_longest(unwrapped, expected):
             assert a is not None and a.compare(b)
+
+    def test_column_collection_get(self):
+        col_id = column("id", Integer)
+        col_alt = column("alt", Integer)
+        table1 = table(
+            "mytable",
+            col_id,
+        )
+
+        assert table1.columns.get("id") == col_id
+        assert table1.columns.get("alt") is None
+        assert table1.columns.get("alt", col_alt) == col_alt


### PR DESCRIPTION
### Description
Fixes #11328 by adding an overload to ColumnCollection when a non-None default is provided.

### Checklist
This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

