### PR TITLE
Ignore all dunders when checking attributes in `sqlalchemy.util.langhelpers.TypingOnly`

### DIFF
--- a/lib/sqlalchemy/util/langhelpers.py
+++ b/lib/sqlalchemy/util/langhelpers.py
@@ -1973,6 +1973,7 @@ class TypingOnly:
                     "__slots__",
                     "__orig_bases__",
                     "__annotations__",
+                    "__static_attributes__",
                 }
             )
             if remaining:

--- a/lib/sqlalchemy/util/langhelpers.py
+++ b/lib/sqlalchemy/util/langhelpers.py
@@ -1967,14 +1967,7 @@ class TypingOnly:
     def __init_subclass__(cls) -> None:
         if TypingOnly in cls.__bases__:
             remaining = set(cls.__dict__).difference(
-                {
-                    "__module__",
-                    "__doc__",
-                    "__slots__",
-                    "__orig_bases__",
-                    "__annotations__",
-                    "__static_attributes__",
-                }
+                {name for name in cls.__dict__ if re.match("^__.+__$", name)}
             )
             if remaining:
                 raise AssertionError(


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

Add missing Python 3.13 built-in attribute `__static_attributes__` in `sqlalchemy.utils.langhelpers.TypingOnly`.

### Description
<!-- Describe your changes in detail -->

An exception is raised on Python 3.13:

```
AssertionError: Class <class 'sqlalchemy.sql.elements.SQLCoreOperations'> directly inherits TypingOnly but has additional attributes {'__static_attributes__'}.
```

This PR addresses it by adding the missing attribute to the check within `TypingOnly`.

Fixes #11334


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

Not sure where to add tests for this since `TypingOnly` is not tested AFAICT.

**Have a nice day!**
