### PR TITLE
Update index.rst to include MariaDB

### DIFF
--- a/doc/build/index.rst
+++ b/doc/build/index.rst
@@ -158,7 +158,7 @@ SQLAlchemy Documentation
       This section describes notes, options, and usage patterns regarding individual dialects.
 
       :doc:`PostgreSQL <dialects/postgresql>` |
-      :doc:`MySQL <dialects/mysql>` |
+      :doc:`MySQL and MariaDB <dialects/mysql>` |
       :doc:`SQLite <dialects/sqlite>` |
       :doc:`Oracle <dialects/oracle>` |
       :doc:`Microsoft SQL Server <dialects/mssql>`


### PR DESCRIPTION
Change title of link to "dialects/mysql" to read "MySQL and MariaDB" to match the actual title of the target page. (now only states MySQL). Corresponding published pages are [index](https://docs.sqlalchemy.org/en/20/) and [MySQL and MariaDB](https://docs.sqlalchemy.org/en/20/dialects/mysql.html).

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
