### PR TITLE
FIX #11285 CONSTRAINT FOREIGN KEY ON DELETE was missing SET DEFAULT from mysql reflection

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/reflection.py
+++ b/lib/sqlalchemy/dialects/mysql/reflection.py
@@ -505,7 +505,7 @@ class MySQLTableDefinitionParser:
         #
         # unique constraints come back as KEYs
         kw = quotes.copy()
-        kw["on"] = "RESTRICT|CASCADE|SET NULL|NO ACTION"
+        kw["on"] = "RESTRICT|CASCADE|SET NULL|NO ACTION|SET DEFAULT"
         self._re_fk_constraint = _re_compile(
             r"  "
             r"CONSTRAINT +"

--- a/test/dialect/mysql/test_reflection.py
+++ b/test/dialect/mysql/test_reflection.py
@@ -1557,7 +1557,7 @@ class RawReflectionTest(fixtures.TestBase):
             "  CONSTRAINT `addresses_user_id_fkey` "
             "FOREIGN KEY (`user_id`) "
             "REFERENCES `users` (`id`) "
-            "ON DELETE CASCADE ON UPDATE SET NULL"
+            "ON DELETE SET DEFAULT ON UPDATE SET NULL"
         )
         eq_(
             m.groups(),
@@ -1567,7 +1567,7 @@ class RawReflectionTest(fixtures.TestBase):
                 "`users`",
                 "`id`",
                 None,
-                "CASCADE",
+                "SET DEFAULT",
                 "SET NULL",
             ),
         )


### PR DESCRIPTION
CONSTRAINT FOREIGN KEY ON DELETE SET DEFAULT is missing from mysql reflection.

### Description

This was discussed in [issue 11285](https://github.com/sqlalchemy/sqlalchemy/issues/11285).

MySQL [documentation](https://dev.mysql.com/doc/refman/8.3/en/create-table-foreign-keys.html) for FOREIGN KEY Constraints.

I added the `SET DEFAULT` in the reflexion regex and modified one of the test case since both were testing for `ON DELETE CASCADE`.

Fixes: #11285

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
