### PR TITLE
Include `content_type` to RESERVED_WORDS_MYSQL

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/reserved_words.py
+++ b/lib/sqlalchemy/dialects/mysql/reserved_words.py
@@ -291,6 +291,7 @@ RESERVED_WORDS_MARIADB = {
 #       MySQL x.0 Removed Keywords and Reserved Words
 RESERVED_WORDS_MYSQL = {
     "accessible",
+    "accept",
     "add",
     "admin",
     "all",
@@ -301,6 +302,8 @@ RESERVED_WORDS_MYSQL = {
     "as",
     "asc",
     "asensitive",
+    "aws_bedrock_invoke_model",
+    "aws_sagemaker_invoke_endpoint",
     "before",
     "between",
     "bigint",
@@ -535,6 +538,7 @@ RESERVED_WORDS_MYSQL = {
     "table",
     "terminated",
     "then",
+    "timeout_ms",
     "tinyblob",
     "tinyint",
     "tinytext",

--- a/lib/sqlalchemy/dialects/mysql/reserved_words.py
+++ b/lib/sqlalchemy/dialects/mysql/reserved_words.py
@@ -319,6 +319,7 @@ RESERVED_WORDS_MYSQL = {
     "column",
     "condition",
     "constraint",
+    "content_type",
     "continue",
     "convert",
     "create",


### PR DESCRIPTION
Addition of extra reserved keywords to RESERVED_WORDS_MYSQL

### Description
With the latest changes to Aurora MySQL database in 2024-03-07, there are additional reserved keywords that must be encased in ` (backticks). See doc below

https://docs.aws.amazon.com/AmazonRDS/latest/AuroraMySQLReleaseNotes/AuroraMySQL.Updates.3060.html

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
