### PR TITLE
set type of type_of to be same as input argument

### DIFF
--- a/lib/sqlalchemy/orm/attributes.py
+++ b/lib/sqlalchemy/orm/attributes.py
@@ -401,7 +401,7 @@ class QueryableAttribute(
             parententity=adapt_to_entity,
         )
 
-    def of_type(self, entity: _EntityType[Any]) -> QueryableAttribute[_T]:
+    def of_type(self, entity: _EntityType[_T]) -> QueryableAttribute[_T]:
         return QueryableAttribute(
             self.class_,
             self.key,

--- a/test/typing/plain_files/orm/relationship.py
+++ b/test/typing/plain_files/orm/relationship.py
@@ -127,7 +127,7 @@ class Team(Base):
 class Engineer(Employee):
     engineer_info: Mapped[str]
 
-    __mapper_args__ = {"polymorphic_identity": "engineer",}
+    __mapper_args__ = {"polymorphic_identity": "engineer"}
 
 
 if typing.TYPE_CHECKING:
@@ -226,5 +226,3 @@ with Session(e) as s:
     s.execute(select(B).options(joinedload(B.a7)))
     s.execute(select(B).options(joinedload(B.a8)))
     s.execute(select(B).options(joinedload(B.a9)))
-
-


### PR DESCRIPTION
Closes: #11371

Fixes the of_type method so that it does not return a class with unset generic. 
See the original issue for a more detailed explanation. 