### PR TITLE
Import all legacy classes by sqlalchemy.orm.collections.*

### DIFF
--- a/doc/build/changelog/unreleased_20/11435.rst
+++ b/doc/build/changelog/unreleased_20/11435.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: bug
+    :tickets: 11435
+
+    Fixed some of the legacy class names not imported by
+    ``sqlalalchemy.orm.collections.*``.

--- a/lib/sqlalchemy/orm/collections.py
+++ b/lib/sqlalchemy/orm/collections.py
@@ -148,10 +148,12 @@ __all__ = [
     "keyfunc_mapping",
     "column_keyed_dict",
     "attribute_keyed_dict",
-    "column_keyed_dict",
-    "attribute_keyed_dict",
-    "MappedCollection",
     "KeyFuncDict",
+    # old names in < 2.0
+    "mapped_collection",
+    "column_mapped_collection",
+    "attribute_mapped_collection",
+    "MappedCollection",
 ]
 
 __instrumentation_mutex = threading.Lock()


### PR DESCRIPTION
### Description
Ensure all of the legacy class names like attribute_mapped_collection are imported by *, instead of only importing the old names partially.
    
Also remove repeated items from `__all__` because these are redundant.

Fixes: #11435

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.