### PR TITLE
Documentation: Update package name for CrateDB dialect

### DIFF
--- a/doc/build/dialects/index.rst
+++ b/doc/build/dialects/index.rst
@@ -79,7 +79,7 @@ Currently maintained external dialect projects for SQLAlchemy include:
 +------------------------------------------------+---------------------------------------+
 | CockroachDB                                    | sqlalchemy-cockroachdb_               |
 +------------------------------------------------+---------------------------------------+
-| CrateDB                                        | crate-python_                         |
+| CrateDB                                        | sqlalchemy-cratedb_                   |
 +------------------------------------------------+---------------------------------------+
 | Databend                                       | databend-sqlalchemy_                  |
 +------------------------------------------------+---------------------------------------+
@@ -150,7 +150,7 @@ Currently maintained external dialect projects for SQLAlchemy include:
 .. _sqlalchemy-monetdb: https://github.com/gijzelaerr/sqlalchemy-monetdb
 .. _snowflake-sqlalchemy: https://github.com/snowflakedb/snowflake-sqlalchemy
 .. _sqlalchemy-tds: https://github.com/m32/sqlalchemy-tds
-.. _crate-python: https://github.com/crate/crate-python
+.. _sqlalchemy-cratedb: https://github.com/crate/sqlalchemy-cratedb
 .. _sqlalchemy-access: https://pypi.org/project/sqlalchemy-access/
 .. _elasticsearch-dbapi: https://github.com/preset-io/elasticsearch-dbapi/
 .. _pydruid: https://github.com/druid-io/pydruid


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
The CrateDB SQLAlchemy dialect needs more love, so it was separated from the DB API HTTP driver.
The new canonical spots for the _SQLAlchemy dialect for CrateDB_ are:

- PyPI: https://pypi.org/project/sqlalchemy-cratedb/
- Docs: https://cratedb.com/docs/sqlalchemy-cratedb/

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed

**Have a nice day!**
