### PR TITLE
Handle "SSL SYSCALL error: Success" in psycopg2

### DIFF
--- a/doc/build/changelog/unreleased_20/11522.rst
+++ b/doc/build/changelog/unreleased_20/11522.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: bug, postgresql
+    :tickets: 11522
+
+    It is now considered a pool-invalidating disconnect event when psycopg2
+    throws an "SSL SYSCALL error: Success" error message, which can occur when
+    the SSL connection to Postgres is terminated abnormally.

--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -866,6 +866,12 @@ class PGDialect_psycopg2(_PGDialect_common_psycopg):
                 "SSL SYSCALL error: EOF detected",
                 "SSL SYSCALL error: Operation timed out",
                 "SSL SYSCALL error: Bad address",
+                # This can occur in OpenSSL 1 when an unexpected EOF occurs.
+                # https://www.openssl.org/docs/man1.1.1/man3/SSL_get_error.html#BUGS
+                # It may also occur in newer OpenSSL for a non-recoverable I/O
+                # error as a result of a system call that does not set 'errno'
+                # in libc.
+                "SSL SYSCALL error: Success",
             ]:
                 idx = str_e.find(msg)
                 if idx >= 0 and '"' not in str_e[:idx]:

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -365,6 +365,7 @@ $$ LANGUAGE plpgsql;"""
             "SSL SYSCALL error: EOF detected",
             "SSL SYSCALL error: Operation timed out",
             "SSL SYSCALL error: Bad address",
+            "SSL SYSCALL error: Success",
         ]:
             eq_(dialect.is_disconnect(Error(error), None, None), True)
 


### PR DESCRIPTION
It is now considered a pool-invalidating disconnect event when psycopg2 throws an "SSL SYSCALL error: Success" error message, which can occur when the SSL connection to Postgres is terminated abnormally.

Fixes: #11522

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Added "SSL SYSCALL error: Success" to the list of exceptions that is considered a "disconnect" in psycopg2.  This addresses the issue in #11522.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
