### PR TITLE
Check if oracle compression-related features are supported before using them

### DIFF
--- a/doc/build/changelog/unreleased_20/11557.txt
+++ b/doc/build/changelog/unreleased_20/11557.txt
@@ -1,0 +1,5 @@
+.. change::
+    :tags: bug, sql, oracle
+    :tickets: 11557
+
+    On 10.2 and older Oracle databases, Table reflection does not assume compression is supported

--- a/lib/sqlalchemy/dialects/oracle/base.py
+++ b/lib/sqlalchemy/dialects/oracle/base.py
@@ -2054,12 +2054,12 @@ class OracleDialect(default.DefaultDialect):
             (
                 dictionary.all_tables.c.compression
                 if self._supports_table_compression
-                else sql.literal_column("NULL").label("compression")
+                else sql.null().label("compression")
             ),
             (
                 dictionary.all_tables.c.compress_for
                 if self._supports_table_compress_for
-                else sql.literal_column("NULL").label("compress_for")
+                else sql.null().label("compress_for")
             ),
         ).where(dictionary.all_tables.c.owner == owner)
         if has_filter_names:

--- a/lib/sqlalchemy/dialects/oracle/base.py
+++ b/lib/sqlalchemy/dialects/oracle/base.py
@@ -2051,8 +2051,16 @@ class OracleDialect(default.DefaultDialect):
     ):
         query = select(
             dictionary.all_tables.c.table_name,
-            dictionary.all_tables.c.compression,
-            dictionary.all_tables.c.compress_for,
+            (
+                dictionary.all_tables.c.compression
+                if self._supports_table_compression
+                else sql.literal_column("NULL").label("compression")
+            ),
+            (
+                dictionary.all_tables.c.compress_for
+                if self._supports_table_compress_for
+                else sql.literal_column("NULL").label("compress_for")
+            ),
         ).where(dictionary.all_tables.c.owner == owner)
         if has_filter_names:
             query = query.where(


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Check if oracle `compression` and `compress_for` features are supported before using them.

This is required for table reflection to work on older oracle versions (with "best effort" support).

Fixes: #11557 

### Checklist

This pull request is:

- [x] A short code fix
	- #11557 
	- [x] `Fixes: #<issue number>` in the commit message
	- Since it's a "best effort" support and it requires an old oracle instance to reproduce I can't provide a test case. I hope it's enough as a best effort though.

**Have a nice day!** (you too!, and thank you for your time!)
