### PR TITLE
fixes issue #11677 SQLITE: SQLiteDialect.get_check_constraints incorrectly reflects multiline check constraints

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2617,7 +2617,7 @@ class SQLiteDialect(default.DefaultDialect):
             connection, table_name, schema=schema, **kw
         )
 
-        CHECK_PATTERN = r"(?:CONSTRAINT (\w+) +)?" r"CHECK *\( *((.|\n)+?) *\)(, ?\n|\n) *"
+        CHECK_PATTERN = r"(?:CONSTRAINT (.+) +)?CHECK *\( *((.|\n)+?) *\)(?:, ?\n|\n) *"
         cks = []
 
         for match in re.finditer(CHECK_PATTERN, table_data or "", re.I|re.S):

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2617,15 +2617,10 @@ class SQLiteDialect(default.DefaultDialect):
             connection, table_name, schema=schema, **kw
         )
 
-        CHECK_PATTERN = r"(?:CONSTRAINT (.+) +)?" r"CHECK *\( *(.+) *\),? *"
+        CHECK_PATTERN = r"(?:CONSTRAINT (\w+) +)?" r"CHECK *\( *((.|\n)+?) *\)(, ?\n|\n) *"
         cks = []
-        # NOTE: we aren't using re.S here because we actually are
-        # taking advantage of each CHECK constraint being all on one
-        # line in the table definition in order to delineate.  This
-        # necessarily makes assumptions as to how the CREATE TABLE
-        # was emitted.
 
-        for match in re.finditer(CHECK_PATTERN, table_data or "", re.I):
+        for match in re.finditer(CHECK_PATTERN, table_data or "", re.I|re.S):
             name = match.group(1)
 
             if name:

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -1816,6 +1816,10 @@ class ConstraintReflectionTest(fixtures.TestBase):
 
             Table("q", meta, Column("id", Integer), PrimaryKeyConstraint("id"))
 
+            # intentional new line
+            Table("r", meta, Column("id", Integer), Column("value", Integer), PrimaryKeyConstraint("id"),
+                  CheckConstraint("((value > 0) AND \n(value < 100))"), CheckConstraint("id > 0"))
+
             meta.create_all(conn)
 
             # will contain an "autoindex"
@@ -1911,6 +1915,7 @@ class ConstraintReflectionTest(fixtures.TestBase):
                 "b",
                 "a1",
                 "a2",
+                "r",
             ]:
                 conn.exec_driver_sql("drop table %s" % name)
 
@@ -2505,6 +2510,12 @@ class ConstraintReflectionTest(fixtures.TestBase):
             eq_(const["column_names"], [expected])
         else:
             assert False
+
+    def test_multiline_check_constraint(self):
+        inspector = inspect(testing.db)
+        constraints = inspector.get_check_constraints('r')
+        eq_(constraints[0]['sqltext'], "((value > 0) AND \n(value < 100))")
+        eq_(constraints[1]['sqltext'], "id > 0")
 
 
 class SavepointTest(fixtures.TablesTest):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Fixes #11677
Changed Constraint matching regex to lazily match any character including newlines, and adding a stricter ending to the regex to ensure the whole constraint is matched

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
