### PR TITLE
Add array type to SuiteRequirements

### DIFF
--- a/lib/sqlalchemy/testing/requirements.py
+++ b/lib/sqlalchemy/testing/requirements.py
@@ -33,7 +33,7 @@ class Requirements:
     pass
 
 
-class SuiteRequirements(Requirements):
+class SuiteRequirements(Requirements): 
     @property
     def create_table(self):
         """target platform can emit basic CreateTable DDL."""
@@ -1092,7 +1092,12 @@ class SuiteRequirements(Requirements):
                 )
 
         return exclusions.only_if(go)
-
+    
+    @property
+    def array_type(self):
+    """Target platform implements a native ARRAY type"""
+    return exclusions.closed()
+        
     @property
     def json_type(self):
         """target platform implements a native JSON type."""

--- a/lib/sqlalchemy/testing/requirements.py
+++ b/lib/sqlalchemy/testing/requirements.py
@@ -1095,8 +1095,8 @@ class SuiteRequirements(Requirements):
     
     @property
     def array_type(self):
-    """Target platform implements a native ARRAY type"""
-    return exclusions.closed()
+        """Target platform implements a native ARRAY type"""
+        return exclusions.closed()
         
     @property
     def json_type(self):

--- a/lib/sqlalchemy/testing/requirements.py
+++ b/lib/sqlalchemy/testing/requirements.py
@@ -33,7 +33,7 @@ class Requirements:
     pass
 
 
-class SuiteRequirements(Requirements): 
+class SuiteRequirements(Requirements):
     @property
     def create_table(self):
         """target platform can emit basic CreateTable DDL."""


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
When a dialect implements the SQLAlchemy test, it is expected to create a `Requirements` class which subclasses `SuiteRequirements` from `sqlalchemy.testing.requirements`. As is, that `SuiteRequirements` fails, as it does not have an `array_type` property defined. When checking SQLAlchemy's own test suite, the `Requirements` class does implement `array_type`

This PR adds the `array_type` property to `SuiteRequirements`, allowing dialects to properly subclass.


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
