### PR TITLE
Fix a misreference in inheritance.rst

### DIFF
--- a/doc/build/orm/queryguide/inheritance.rst
+++ b/doc/build/orm/queryguide/inheritance.rst
@@ -128,7 +128,7 @@ objects at once.  This loader option works in a similar fashion as the
 SELECT statement against each sub-table for objects loaded in the hierarchy,
 using ``IN`` to query for additional rows based on primary key.
 
-:func:`_orm.selectinload` accepts as its arguments the base entity that is
+:func:`_orm.selectin_polymorphic` accepts as its arguments the base entity that is
 being queried, followed by a sequence of subclasses of that entity for which
 their specific attributes should be loaded for incoming rows::
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Based on the context (the code segment following the paragraph), we can find that the function whose signature (arguments) is described here is `selectin_polymorphic` instead of `selectinload`:

> ~~selectinload()~~ selectin_polymorphic() accepts as its arguments the base entity that is being queried, followed by a sequence of subclasses of that entity for which their specific attributes should be loaded for incoming rows:
> ```
> from sqlalchemy.orm import selectin_polymorphic
> loader_opt = selectin_polymorphic(Employee, [Manager, Engineer])
>              ^^^^^^^^^^^^^^^^^^^^
> ```
> 


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
