### PR TITLE
Reflect broader range of check constraints for SQLite.

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2626,12 +2626,12 @@ class SQLiteDialect(default.DefaultDialect):
 
         # Notes:
         # * The pattern currently matches any character for the name of the constraint
-        #   except tab and newline characters.
+        #   non greedily.
         # * Because check constraints in the table data can contain space, newline and tab characters,
         #   the pattern matches any character untill either the beginning of the next CONSTRAINT
         #   statement using a non-capturing non-consuming group (allowing the next one to match),
         #   or the end of the table definition e.g. newline and closing ')'.
-        CHECK_PATTERN = r"(?:CONSTRAINT ([^\t\n]+) )?CHECK \((.+?)\)(?:, *\n\t?(?=CONSTRAINT|CHECK)|\n\))"
+        CHECK_PATTERN = r"(?:CONSTRAINT (.+?) )?CHECK \((.+?)\)(?:, *\n\t?(?=CONSTRAINT|CHECK)|\n\))"
         cks = []
         for match in re.finditer(CHECK_PATTERN, table_data or "", re.I|re.S):
             name = match.group(1)

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2624,7 +2624,7 @@ class SQLiteDialect(default.DefaultDialect):
             connection, table_name, schema=schema, **kw
         )
 
-        CHECK_PATTERN = r"(?:CONSTRAINT (.+) +)?CHECK *\( *((.|\n)+?) *\)(?:, ?\n|\n) *"
+        CHECK_PATTERN = r"(?:CONSTRAINT ([^\s]+) +)?CHECK *\( *(.+?) *\)(?:, ?\n|\n) *"
         cks = []
         # NOTE: we aren't using re.S here because we actually are
         # taking advantage of each CHECK constraint being all on one

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2625,17 +2625,24 @@ class SQLiteDialect(default.DefaultDialect):
         )
 
         # Notes:
-        # * The pattern currently matches any character for the name of the constraint,
-        #   including newline and tab characters, as long as none of the SQLite's table constraints
-        #   keywords are encountered seperated by spaces.
-        #   This prevents the pattern from matching subsequent constraints as part of the name.
-        # * Because check constraints can contain special characters and newline and tab characters,
-        #   the pattern matches any character untill either the beginning of the next constraint
-        #   statement using a non-capturing non-consuming group (allowing the next one to match),
-        #   or the end of the table definition e.g. newline and closing ')'.
+        # * The pattern currently matches any character for the name of the
+        #   constraint, including newline characters (re.S flag) as long as
+        #   none of the SQLite's table constraints keywords are encountered
+        #   by a negative lookahead.
+        #   This prevents the pattern from matching subsequent constraints
+        #   as part of the name.
+        #   This is only done for those keywords if seperated by spaces, to
+        #   support constraint names that contains them e.g. "check_value".
+        #
+        # * Because check constraint definitions can also contain newline
+        #   or tab characters, the pattern matches any character untill either
+        #   the beginning of the next constraint statement using a
+        #   non-capturing and non-consuming group, allowing the next one
+        #   to match, or the end of the table definition
+        #   e.g. newline and closing ')'.
         CHECK_PATTERN = r"(?:CONSTRAINT ((?:(?! PRIMARY | FOREIGN KEY| UNIQUE | CHECK ).)+) )?CHECK \((.+?)\)(?:, *\n\t?(?=CONSTRAINT|CHECK)|\n\))"
         cks = []
-        for match in re.finditer(CHECK_PATTERN, table_data or "", re.I|re.S):
+        for match in re.finditer(CHECK_PATTERN, table_data or "", re.I | re.S):
             name = match.group(1)
 
             if name:

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2631,9 +2631,9 @@ class SQLiteDialect(default.DefaultDialect):
         #   the pattern matches any character untill either the beginning of the next CONSTRAINT
         #   statement using a non-capturing non-consuming group (allowing the next one to match),
         #   or the end of the table definition e.g. newline and closing ')'.
-        CHECK_PATTERN = r"(?:CONSTRAINT ([^\t\n]+) )?CHECK \((.+?)\)(?:, *\n\t?(?=CONSTRAINT)|\n\))"
+        CHECK_PATTERN = r"(?:CONSTRAINT ([^\t\n]+) )?CHECK \((.+?)\)(?:, *\n\t?(?=CONSTRAINT|CHECK)|\n\))"
         cks = []
-
+        print(table_data)
         for match in re.finditer(CHECK_PATTERN, table_data or "", re.I|re.S):
             name = match.group(1)
 

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2684,8 +2684,9 @@ class SQLiteDialect(default.DefaultDialect):
         )
         """
         cks = []
-        for match in re.finditer(CHECK_PATTERN, table_data or "",
-                                 re.I | re.S | re.VERBOSE):
+        for match in re.finditer(
+            CHECK_PATTERN, table_data or "", re.I | re.S | re.VERBOSE
+        ):
             name = match.group(1)
 
             if name:

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2626,11 +2626,6 @@ class SQLiteDialect(default.DefaultDialect):
 
         CHECK_PATTERN = r"(?:CONSTRAINT ([^\n^\t]+) +)?CHECK *\( *(.+?) *\)(?:, ?\n|\n) *"
         cks = []
-        # NOTE: we aren't using re.S here because we actually are
-        # taking advantage of each CHECK constraint being all on one
-        # line in the table definition in order to delineate.  This
-        # necessarily makes assumptions as to how the CREATE TABLE
-        # was emitted.
 
         for match in re.finditer(CHECK_PATTERN, table_data or "", re.I|re.S):
             name = match.group(1)

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2624,7 +2624,14 @@ class SQLiteDialect(default.DefaultDialect):
             connection, table_name, schema=schema, **kw
         )
 
-        CHECK_PATTERN = r"(?:CONSTRAINT ([^\n^\t]+) +)?CHECK *\( *(.+?) *\)(?:, ?\n|\n) *"
+        # Notes:
+        # * The pattern currently matches any character for the name of the constraint
+        #   except tab and newline characters.
+        # * Because check constraints in the table data can contain space, newline and tab characters,
+        #   the pattern matches any character untill either the beginning of the next CONSTRAINT
+        #   statement using a non-capturing non-consuming group (allowing the next one to match),
+        #   or the end of the table definition e.g. newline and closing ')'.
+        CHECK_PATTERN = r"(?:CONSTRAINT ([^\t\n]+) )?CHECK \((.+?)\)(?:, *\n\t?(?=CONSTRAINT)|\n\))"
         cks = []
 
         for match in re.finditer(CHECK_PATTERN, table_data or "", re.I|re.S):

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2624,7 +2624,7 @@ class SQLiteDialect(default.DefaultDialect):
             connection, table_name, schema=schema, **kw
         )
 
-        CHECK_PATTERN = r"(?:CONSTRAINT (.+) +)?" r"CHECK *\( *(.+) *\),? *"
+        CHECK_PATTERN = r"(?:CONSTRAINT (.+) +)?CHECK *\( *((.|\n)+?) *\)(?:, ?\n|\n) *"
         cks = []
         # NOTE: we aren't using re.S here because we actually are
         # taking advantage of each CHECK constraint being all on one
@@ -2632,7 +2632,7 @@ class SQLiteDialect(default.DefaultDialect):
         # necessarily makes assumptions as to how the CREATE TABLE
         # was emitted.
 
-        for match in re.finditer(CHECK_PATTERN, table_data or "", re.I):
+        for match in re.finditer(CHECK_PATTERN, table_data or "", re.I|re.S):
             name = match.group(1)
 
             if name:

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2625,13 +2625,15 @@ class SQLiteDialect(default.DefaultDialect):
         )
 
         # Notes:
-        # * The pattern currently matches any character for the name of the constraint
-        #   non greedily.
-        # * Because check constraints in the table data can contain space, newline and tab characters,
-        #   the pattern matches any character untill either the beginning of the next CONSTRAINT
+        # * The pattern currently matches any character for the name of the constraint,
+        #   including newline and tab characters, as long as none of the SQLite's table constraints
+        #   keywords are encountered seperated by spaces.
+        #   This prevents the pattern from matching subsequent constraints as part of the name.
+        # * Because check constraints can contain special characters and newline and tab characters,
+        #   the pattern matches any character untill either the beginning of the next constraint
         #   statement using a non-capturing non-consuming group (allowing the next one to match),
         #   or the end of the table definition e.g. newline and closing ')'.
-        CHECK_PATTERN = r"(?:CONSTRAINT (.+?) )?CHECK \((.+?)\)(?:, *\n\t?(?=CONSTRAINT|CHECK)|\n\))"
+        CHECK_PATTERN = r"(?:CONSTRAINT ((?:(?! PRIMARY | FOREIGN KEY| UNIQUE | CHECK ).)+) )?CHECK \((.+?)\)(?:, *\n\t?(?=CONSTRAINT|CHECK)|\n\))"
         cks = []
         for match in re.finditer(CHECK_PATTERN, table_data or "", re.I|re.S):
             name = match.group(1)

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2633,7 +2633,6 @@ class SQLiteDialect(default.DefaultDialect):
         #   or the end of the table definition e.g. newline and closing ')'.
         CHECK_PATTERN = r"(?:CONSTRAINT ([^\t\n]+) )?CHECK \((.+?)\)(?:, *\n\t?(?=CONSTRAINT|CHECK)|\n\))"
         cks = []
-        print(table_data)
         for match in re.finditer(CHECK_PATTERN, table_data or "", re.I|re.S):
             name = match.group(1)
 

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2624,7 +2624,7 @@ class SQLiteDialect(default.DefaultDialect):
             connection, table_name, schema=schema, **kw
         )
 
-        CHECK_PATTERN = r"(?:CONSTRAINT ([^\s]+) +)?CHECK *\( *(.+?) *\)(?:, ?\n|\n) *"
+        CHECK_PATTERN = r"(?:CONSTRAINT ([^\n^\t]+) +)?CHECK *\( *(.+?) *\)(?:, ?\n|\n) *"
         cks = []
         # NOTE: we aren't using re.S here because we actually are
         # taking advantage of each CHECK constraint being all on one

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -1816,6 +1816,10 @@ class ConstraintReflectionTest(fixtures.TestBase):
 
             Table("q", meta, Column("id", Integer), PrimaryKeyConstraint("id"))
 
+            # intentional new line
+            Table("r", meta, Column("id", Integer), Column("value", Integer), PrimaryKeyConstraint("id"),
+                  CheckConstraint("((value > 0) AND \n(value < 100))"), CheckConstraint("id > 0"))
+
             meta.create_all(conn)
 
             # will contain an "autoindex"
@@ -1911,6 +1915,7 @@ class ConstraintReflectionTest(fixtures.TestBase):
                 "b",
                 "a1",
                 "a2",
+                "r",
             ]:
                 conn.exec_driver_sql("drop table %s" % name)
 
@@ -2506,6 +2511,11 @@ class ConstraintReflectionTest(fixtures.TestBase):
         else:
             assert False
 
+    def test_multiline_check_constraints(self):
+        inspector = inspect(testing.db)
+        constraints = inspector.get_check_constraints('r')
+        eq_(constraints[0]['sqltext'], "((value > 0) AND \n(value < 100))")
+        eq_(constraints[1]['sqltext'], "id > 0")
 
 class SavepointTest(fixtures.TablesTest):
     """test that savepoints work when we use the correct event setup"""

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -1821,8 +1821,8 @@ class ConstraintReflectionTest(fixtures.TestBase):
                   CheckConstraint("id > 0"),
                   # Constraint definition with newline and tab characters
                   CheckConstraint("((value > 0) AND \n\t(value < 100) AND \n\t(value != 50))", name='ck_r_value_multiline'),
-                  # Constraint name with special characters.
-                  CheckConstraint("value IS NOT NULL", name="^ck-r* #\n\t"),
+                  # Constraint name with special characters and 'check' in the name
+                  CheckConstraint("value IS NOT NULL", name="^check-r* #\n\t"),
                   # Constraint definition with special characters.
                   CheckConstraint("prefix NOT GLOB '*[^-. /#,]*'")
             )
@@ -2471,7 +2471,7 @@ class ConstraintReflectionTest(fixtures.TestBase):
         eq_(
             inspector.get_check_constraints("r"),
             [
-                {"sqltext": "value IS NOT NULL", "name": "^ck-r* #\n\t"},
+                {"sqltext": "value IS NOT NULL", "name": "^check-r* #\n\t"},
                 {"sqltext": "((value > 0) AND \n\t(value < 100) AND \n\t(value != 50))", "name": "ck_r_value_multiline"},
                 {"sqltext": "id > 0", "name": None},
                 {"sqltext": "prefix NOT GLOB '*[^-. /#,]*'", "name": None},

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -1818,7 +1818,9 @@ class ConstraintReflectionTest(fixtures.TestBase):
 
             # intentional new line
             Table("r", meta, Column("id", Integer), Column("value", Integer), PrimaryKeyConstraint("id"),
-                  CheckConstraint("((value > 0) AND \n(value < 100))"), CheckConstraint("id > 0"))
+                  CheckConstraint("id > 0"),
+                  CheckConstraint("((value > 0) AND \n\t(value < 100))", name='ck_r_value'),
+            )
 
             meta.create_all(conn)
 
@@ -2514,8 +2516,10 @@ class ConstraintReflectionTest(fixtures.TestBase):
     def test_multiline_check_constraints(self):
         inspector = inspect(testing.db)
         constraints = inspector.get_check_constraints('r')
-        eq_(constraints[0]['sqltext'], "((value > 0) AND \n(value < 100))")
+        eq_(constraints[1]['name'], None)
         eq_(constraints[1]['sqltext'], "id > 0")
+        eq_(constraints[0]['name'], "ck_r_value")
+        eq_(constraints[0]['sqltext'], "((value > 0) AND \n\t(value < 100))")
 
 class SavepointTest(fixtures.TablesTest):
     """test that savepoints work when we use the correct event setup"""

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -1817,15 +1817,22 @@ class ConstraintReflectionTest(fixtures.TestBase):
             Table("q", meta, Column("id", Integer), PrimaryKeyConstraint("id"))
 
             # intentional new line
-            Table("r", meta, Column("id", Integer), Column("value", Integer), Column("prefix", String), PrimaryKeyConstraint("id"),
+            Table("r", meta,
+                  Column("id", Integer),
+                  Column("value", Integer),
+                  Column("prefix", String),
+                  PrimaryKeyConstraint("id"),
                   CheckConstraint("id > 0"),
                   # Constraint definition with newline and tab characters
-                  CheckConstraint("((value > 0) AND \n\t(value < 100) AND \n\t(value != 50))", name='ck_r_value_multiline'),
-                  # Constraint name with special characters and 'check' in the name
+                  CheckConstraint(
+                      """((value > 0) AND \n\t(value < 100) AND \n\t
+                      (value != 50))""",
+                      name='ck_r_value_multiline'),
+                  # Constraint name with special chars and 'check' in the name
                   CheckConstraint("value IS NOT NULL", name="^check-r* #\n\t"),
                   # Constraint definition with special characters.
                   CheckConstraint("prefix NOT GLOB '*[^-. /#,]*'")
-            )
+                  )
 
             meta.create_all(conn)
 
@@ -2468,11 +2475,16 @@ class ConstraintReflectionTest(fixtures.TestBase):
                 {"sqltext": "q > 1 AND q < 6", "name": None},
             ],
         )
+        print(inspector.get_check_constraints("r"))
         eq_(
             inspector.get_check_constraints("r"),
             [
                 {"sqltext": "value IS NOT NULL", "name": "^check-r* #\n\t"},
-                {"sqltext": "((value > 0) AND \n\t(value < 100) AND \n\t(value != 50))", "name": "ck_r_value_multiline"},
+                # Triple-quote multi-line definition should have added a
+                # newline and whitespace:
+                {"sqltext": "((value > 0) AND \n\t(value < 100) AND \n\t\n"
+                            "                      (value != 50))",
+                 "name": "ck_r_value_multiline"},
                 {"sqltext": "id > 0", "name": None},
                 {"sqltext": "prefix NOT GLOB '*[^-. /#,]*'", "name": None},
             ],
@@ -2526,6 +2538,7 @@ class ConstraintReflectionTest(fixtures.TestBase):
             eq_(const["column_names"], [expected])
         else:
             assert False
+
 
 class SavepointTest(fixtures.TablesTest):
     """test that savepoints work when we use the correct event setup"""

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -1817,22 +1817,25 @@ class ConstraintReflectionTest(fixtures.TestBase):
             Table("q", meta, Column("id", Integer), PrimaryKeyConstraint("id"))
 
             # intentional new line
-            Table("r", meta,
-                  Column("id", Integer),
-                  Column("value", Integer),
-                  Column("prefix", String),
-                  PrimaryKeyConstraint("id"),
-                  CheckConstraint("id > 0"),
-                  # Constraint definition with newline and tab characters
-                  CheckConstraint(
-                      """((value > 0) AND \n\t(value < 100) AND \n\t
+            Table(
+                "r",
+                meta,
+                Column("id", Integer),
+                Column("value", Integer),
+                Column("prefix", String),
+                PrimaryKeyConstraint("id"),
+                CheckConstraint("id > 0"),
+                # Constraint definition with newline and tab characters
+                CheckConstraint(
+                    """((value > 0) AND \n\t(value < 100) AND \n\t
                       (value != 50))""",
-                      name='ck_r_value_multiline'),
-                  # Constraint name with special chars and 'check' in the name
-                  CheckConstraint("value IS NOT NULL", name="^check-r* #\n\t"),
-                  # Constraint definition with special characters.
-                  CheckConstraint("prefix NOT GLOB '*[^-. /#,]*'")
-                  )
+                    name="ck_r_value_multiline",
+                ),
+                # Constraint name with special chars and 'check' in the name
+                CheckConstraint("value IS NOT NULL", name="^check-r* #\n\t"),
+                # Constraint definition with special characters.
+                CheckConstraint("prefix NOT GLOB '*[^-. /#,]*'"),
+            )
 
             meta.create_all(conn)
 
@@ -2482,9 +2485,11 @@ class ConstraintReflectionTest(fixtures.TestBase):
                 {"sqltext": "value IS NOT NULL", "name": "^check-r* #\n\t"},
                 # Triple-quote multi-line definition should have added a
                 # newline and whitespace:
-                {"sqltext": "((value > 0) AND \n\t(value < 100) AND \n\t\n"
-                            "                      (value != 50))",
-                 "name": "ck_r_value_multiline"},
+                {
+                    "sqltext": "((value > 0) AND \n\t(value < 100) AND \n\t\n"
+                    "                      (value != 50))",
+                    "name": "ck_r_value_multiline",
+                },
                 {"sqltext": "id > 0", "name": None},
                 {"sqltext": "prefix NOT GLOB '*[^-. /#,]*'", "name": None},
             ],

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -2464,7 +2464,6 @@ class ConstraintReflectionTest(fixtures.TestBase):
                 {"sqltext": "q > 1 AND q < 6", "name": None},
             ],
         )
-        print(inspector.get_check_constraints("r"))
         eq_(
             inspector.get_check_constraints("r"),
             [

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -1821,8 +1821,8 @@ class ConstraintReflectionTest(fixtures.TestBase):
                   CheckConstraint("id > 0"),
                   # Constraint definition with newline and tab characters
                   CheckConstraint("((value > 0) AND \n\t(value < 100) AND \n\t(value != 50))", name='ck_r_value_multiline'),
-                  # Constraint name with special characters and spaces.
-                  CheckConstraint("value IS NOT NULL", name='^ck-r* # Value'),
+                  # Constraint name with special characters.
+                  CheckConstraint("value IS NOT NULL", name="^ck-r* #\n\t"),
                   # Constraint definition with special characters.
                   CheckConstraint("prefix NOT GLOB '*[^-. /#,]*'")
             )
@@ -2471,7 +2471,7 @@ class ConstraintReflectionTest(fixtures.TestBase):
         eq_(
             inspector.get_check_constraints("r"),
             [
-                {"sqltext": "value IS NOT NULL", "name": "^ck-r* # Value"},
+                {"sqltext": "value IS NOT NULL", "name": "^ck-r* #\n\t"},
                 {"sqltext": "((value > 0) AND \n\t(value < 100) AND \n\t(value != 50))", "name": "ck_r_value_multiline"},
                 {"sqltext": "id > 0", "name": None},
                 {"sqltext": "prefix NOT GLOB '*[^-. /#,]*'", "name": None},


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

These changes are an extended and corrected version of PR https://github.com/sqlalchemy/sqlalchemy/pull/11678, which was made by one of our job students and may be closed.
This fixes issue https://github.com/sqlalchemy/sqlalchemy/issues/11677.

We've adjusted the check constraint pattern to match a broader range of check constraints that can be encountered.
This includes:
* allowing spaces and special characters in the name of the check constraints.
   This is done as long as none of the SQLite's table constraints keywords are encountered seperated by spaces.
   This prevents the pattern from matching subsequent constraints as part of the name.
* allowing newline, tab or space characters in the constraint definition.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
