### PR TITLE
add postgres dialect alias

### DIFF
--- a/lib/sqlalchemy/dialects/__init__.py
+++ b/lib/sqlalchemy/dialects/__init__.py
@@ -33,6 +33,9 @@ def _auto_fn(name: str) -> Optional[Callable[[], Type[Dialect]]]:
         dialect = name
         driver = "base"
 
+    if dialect == "postgres":
+        dialect = "postgresql"
+
     try:
         if dialect == "mariadb":
             # it's "OK" for us to hardcode here since _auto_fn is already


### PR DESCRIPTION
Why
===
* Fixes #11705
* According to https://www.prisma.io/dataguide/postgresql/short-guides/connection-uris?query=&page=1 a postgres URL can have a schema of "postgres" or "postgresql".
* Users who have a URL starting with "postgres://" cannot use sqlalchemy without URL pre-processing, because they will see this error:

```
  File "/home/runner/UserAuth/.pythonlibs/lib/python3.12/site-packages/sqlalchemy/util/langhelpers.py", line 375, in load
    raise exc.NoSuchModuleError(
sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgres
```
* Since postgres unambiguously means we want to use postgresql, we can add a quick dialect alias to solve this UX problem

Description
===

* If the dialect is "postgres", rewrite it to "postgresql".

Test plan
===
* Using SQLALCHEMY_DATABASE_URI env var with a "postgres://" URL now works. I tested that that I can add a row to the database using sqlalchemy.

<!-- Provide a general summary of your proposed changes in the Title field above -->


<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
