### PR TITLE
MAINT: cleanup the lasts of datetime.utcnow()

### DIFF
--- a/examples/extending_query/temporal_range.py
+++ b/examples/extending_query/temporal_range.py
@@ -5,6 +5,7 @@ to selected entities.
 """
 
 import datetime
+from functools import partial
 
 from sqlalchemy import Column
 from sqlalchemy import create_engine
@@ -22,9 +23,8 @@ from sqlalchemy.orm import sessionmaker
 class HasTemporal:
     """Mixin that identifies a class as having a timestamp column"""
 
-    timestamp = Column(
-        DateTime, default=datetime.datetime.now(datetime.UTC), nullable=False
-    )
+    utc = partial(datetime.datetime.now, datetime.UTC)
+    timestamp = Column(DateTime, default=utc, nullable=False)
 
 
 def temporal_range(range_lower, range_upper):

--- a/examples/extending_query/temporal_range.py
+++ b/examples/extending_query/temporal_range.py
@@ -23,7 +23,7 @@ class HasTemporal:
     """Mixin that identifies a class as having a timestamp column"""
 
     timestamp = Column(
-        DateTime, default=datetime.datetime.utcnow, nullable=False
+        DateTime, default=datetime.datetime.now(datetime.UTC), nullable=False
     )
 
 

--- a/examples/extending_query/temporal_range.py
+++ b/examples/extending_query/temporal_range.py
@@ -23,8 +23,11 @@ from sqlalchemy.orm import sessionmaker
 class HasTemporal:
     """Mixin that identifies a class as having a timestamp column"""
 
-    utc = partial(datetime.datetime.now, datetime.timezone.utc)
-    timestamp = Column(DateTime, default=utc, nullable=False)
+    timestamp = Column(
+        DateTime,
+        default=partial(datetime.datetime.now, datetime.timezone.utc),
+        nullable=False,
+    )
 
 
 def temporal_range(range_lower, range_upper):

--- a/examples/extending_query/temporal_range.py
+++ b/examples/extending_query/temporal_range.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import sessionmaker
 class HasTemporal:
     """Mixin that identifies a class as having a timestamp column"""
 
-    utc = partial(datetime.datetime.now, datetime.UTC)
+    utc = partial(datetime.datetime.now, datetime.timezone.utc)
     timestamp = Column(DateTime, default=utc, nullable=False)
 
 

--- a/lib/sqlalchemy/orm/events.py
+++ b/lib/sqlalchemy/orm/events.py
@@ -3135,7 +3135,7 @@ class QueryEvents(event.Events[Query[Any]]):
                         entity = desc['entity']
                         query = query.filter(entity.deleted == False)
 
-                        update_context.values['timestamp'] = datetime.datetime.now(datetime.UTC)
+                        update_context.values['timestamp'] = datetime.datetime.now(datetime.timezone.utc)
                 return query
 
         The ``.values`` dictionary of the "update context" object can also

--- a/lib/sqlalchemy/orm/events.py
+++ b/lib/sqlalchemy/orm/events.py
@@ -3135,7 +3135,7 @@ class QueryEvents(event.Events[Query[Any]]):
                         entity = desc['entity']
                         query = query.filter(entity.deleted == False)
 
-                        update_context.values['timestamp'] = datetime.utcnow()
+                        update_context.values['timestamp'] = datetime.datetime.now(datetime.UTC)
                 return query
 
         The ``.values`` dictionary of the "update context" object can also

--- a/lib/sqlalchemy/orm/events.py
+++ b/lib/sqlalchemy/orm/events.py
@@ -3135,7 +3135,9 @@ class QueryEvents(event.Events[Query[Any]]):
                         entity = desc['entity']
                         query = query.filter(entity.deleted == False)
 
-                        update_context.values['timestamp'] = datetime.datetime.now(datetime.timezone.utc)
+                        update_context.values['timestamp'] = (
+                            datetime.datetime.now(datetime.UTC)
+                        )
                 return query
 
         The ``.values`` dictionary of the "update context" object can also

--- a/test/orm/test_relationship_criteria.py
+++ b/test/orm/test_relationship_criteria.py
@@ -1661,8 +1661,11 @@ class TemporalFixtureTest(testing.fixtures.DeclarativeMappedTest):
         class HasTemporal:
             """Mixin that identifies a class as having a timestamp column"""
 
-            utc = partial(datetime.datetime.now, datetime.timezone.utc)
-            timestamp = Column(DateTime, default=utc, nullable=False)
+            timestamp = Column(
+                DateTime,
+                default=partial(datetime.datetime.now, datetime.timezone.utc),
+                nullable=False,
+            )
 
         cls.HasTemporal = HasTemporal
 

--- a/test/orm/test_relationship_criteria.py
+++ b/test/orm/test_relationship_criteria.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+from functools import partial
 import random
 from typing import List
 
@@ -1660,9 +1661,8 @@ class TemporalFixtureTest(testing.fixtures.DeclarativeMappedTest):
         class HasTemporal:
             """Mixin that identifies a class as having a timestamp column"""
 
-            timestamp = Column(
-                DateTime, default=datetime.datetime.now(datetime.UTC), nullable=False
-            )
+            utc = partial(datetime.datetime.now, datetime.UTC)
+            timestamp = Column(DateTime, default=utc, nullable=False)
 
         cls.HasTemporal = HasTemporal
 

--- a/test/orm/test_relationship_criteria.py
+++ b/test/orm/test_relationship_criteria.py
@@ -1661,7 +1661,7 @@ class TemporalFixtureTest(testing.fixtures.DeclarativeMappedTest):
         class HasTemporal:
             """Mixin that identifies a class as having a timestamp column"""
 
-            utc = partial(datetime.datetime.now, datetime.UTC)
+            utc = partial(datetime.datetime.now, datetime.timezone.utc)
             timestamp = Column(DateTime, default=utc, nullable=False)
 
         cls.HasTemporal = HasTemporal

--- a/test/orm/test_relationship_criteria.py
+++ b/test/orm/test_relationship_criteria.py
@@ -1661,7 +1661,7 @@ class TemporalFixtureTest(testing.fixtures.DeclarativeMappedTest):
             """Mixin that identifies a class as having a timestamp column"""
 
             timestamp = Column(
-                DateTime, default=datetime.datetime.utcnow, nullable=False
+                DateTime, default=datetime.datetime.now(datetime.UTC), nullable=False
             )
 
         cls.HasTemporal = HasTemporal


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

I'm chasing some loose datetime.datetime.utcnow() deprecation warning in some test suites, and one of these was seemingly coming from sqlalchemy. It wasn't, but nevertheless these minor cleanup changes may still be found useful.


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed

**Have a nice day!**
