### PR TITLE
 Fix use of typing.Literal on Python 3.8 and 3.9

### DIFF
--- a/doc/build/changelog/unreleased_20/11820.rst
+++ b/doc/build/changelog/unreleased_20/11820.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: bug, orm, typing
+    :tickets: 11814
+
+    Fixed issue where it was not possible to use ``typing.Literal`` with
+    ``Mapped[]`` on Python 3.8 and 3.9.
+
+

--- a/lib/sqlalchemy/util/typing.py
+++ b/lib/sqlalchemy/util/typing.py
@@ -12,6 +12,7 @@ import builtins
 import collections.abc as collections_abc
 import re
 import sys
+import typing
 from typing import Any
 from typing import Callable
 from typing import cast
@@ -63,6 +64,10 @@ _VT = TypeVar("_VT")
 _VT_co = TypeVar("_VT_co", covariant=True)
 
 TupleAny = Tuple[Any, ...]
+
+# typing_extensions.Literal is different from typing.Literal until
+# Python 3.10.1
+_LITERAL_TYPES = frozenset([typing.Literal, Literal])
 
 
 if compat.py310:
@@ -357,7 +362,7 @@ def is_non_string_iterable(obj: Any) -> TypeGuard[Iterable[Any]]:
 
 
 def is_literal(type_: _AnnotationScanType) -> bool:
-    return get_origin(type_) is Literal
+    return get_origin(type_) in _LITERAL_TYPES
 
 
 def is_newtype(type_: Optional[_AnnotationScanType]) -> TypeGuard[NewType]:

--- a/test/orm/declarative/test_tm_future_annotations_sync.py
+++ b/test/orm/declarative/test_tm_future_annotations_sync.py
@@ -30,6 +30,7 @@ from typing import TypeVar
 from typing import Union
 import uuid
 
+import typing_extensions
 from typing_extensions import get_args as get_args
 from typing_extensions import Literal as Literal
 from typing_extensions import TypeAlias as TypeAlias
@@ -118,6 +119,9 @@ _Literal695: TypeAlias = Literal["to-do", "in-progress", "done"]
 _Recursive695_0: TypeAlias = _Literal695
 _Recursive695_1: TypeAlias = _Recursive695_0
 _Recursive695_2: TypeAlias = _Recursive695_1
+
+_TypingLiteral = typing.Literal["a", "b"]
+_TypingExtensionsLiteral = typing_extensions.Literal["a", "b"]
 
 if compat.py312:
     exec(
@@ -895,6 +899,21 @@ class MappedColumnTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         for col in (Foo.__table__.c.status, Foo.__table__.c.r2):
             is_true(isinstance(col.type, Enum))
             eq_(col.type.enums, ["to-do", "in-progress", "done"])
+            is_(col.type.native_enum, False)
+
+    def test_typing_literal_identity(self, decl_base):
+        """See issue #11820"""
+
+        class Foo(decl_base):
+            __tablename__ = "footable"
+
+            id: Mapped[int] = mapped_column(primary_key=True)
+            t: Mapped[_TypingLiteral]
+            te: Mapped[_TypingExtensionsLiteral]
+
+        for col in (Foo.__table__.c.t, Foo.__table__.c.te):
+            is_true(isinstance(col.type, Enum))
+            eq_(col.type.enums, ["a", "b"])
             is_(col.type.native_enum, False)
 
     @testing.requires.python310

--- a/test/orm/declarative/test_typed_mapping.py
+++ b/test/orm/declarative/test_typed_mapping.py
@@ -21,6 +21,7 @@ from typing import TypeVar
 from typing import Union
 import uuid
 
+import typing_extensions
 from typing_extensions import get_args as get_args
 from typing_extensions import Literal as Literal
 from typing_extensions import TypeAlias as TypeAlias
@@ -109,6 +110,9 @@ _Literal695: TypeAlias = Literal["to-do", "in-progress", "done"]
 _Recursive695_0: TypeAlias = _Literal695
 _Recursive695_1: TypeAlias = _Recursive695_0
 _Recursive695_2: TypeAlias = _Recursive695_1
+
+_TypingLiteral = typing.Literal["a", "b"]
+_TypingExtensionsLiteral = typing_extensions.Literal["a", "b"]
 
 if compat.py312:
     exec(
@@ -886,6 +890,21 @@ class MappedColumnTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         for col in (Foo.__table__.c.status, Foo.__table__.c.r2):
             is_true(isinstance(col.type, Enum))
             eq_(col.type.enums, ["to-do", "in-progress", "done"])
+            is_(col.type.native_enum, False)
+
+    def test_typing_literal_identity(self, decl_base):
+        """See issue #11820"""
+
+        class Foo(decl_base):
+            __tablename__ = "footable"
+
+            id: Mapped[int] = mapped_column(primary_key=True)
+            t: Mapped[_TypingLiteral]
+            te: Mapped[_TypingExtensionsLiteral]
+
+        for col in (Foo.__table__.c.t, Foo.__table__.c.te):
+            is_true(isinstance(col.type, Enum))
+            eq_(col.type.enums, ["a", "b"])
             is_(col.type.native_enum, False)
 
     @testing.requires.python310


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Fixes #11820

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
