### PR TITLE
Include operators in postgres JSONB documentation

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/json.py
+++ b/lib/sqlalchemy/dialects/postgresql/json.py
@@ -256,22 +256,27 @@ class JSONB(JSON):
         """Define comparison operations for :class:`_types.JSON`."""
 
         def has_key(self, other):
-            """Boolean expression.  Test for presence of a key.  Note that the
-            key may be a SQLA expression.
+            """Boolean expression.  Test for presence of a key (equivalent of
+            the ``?`` operator).  Note that the key may be a SQLA expression.
             """
             return self.operate(HAS_KEY, other, result_type=sqltypes.Boolean)
 
         def has_all(self, other):
-            """Boolean expression.  Test for presence of all keys in jsonb"""
+            """Boolean expression.  Test for presence of all keys in jsonb
+            (equivalent of the ``?&`` operator)
+            """
             return self.operate(HAS_ALL, other, result_type=sqltypes.Boolean)
 
         def has_any(self, other):
-            """Boolean expression.  Test for presence of any key in jsonb"""
+            """Boolean expression.  Test for presence of any key in jsonb
+            (equivalent of the ``?|`` operator)
+            """
             return self.operate(HAS_ANY, other, result_type=sqltypes.Boolean)
 
         def contains(self, other, **kwargs):
             """Boolean expression.  Test if keys (or array) are a superset
-            of/contained the keys of the argument jsonb expression.
+            of/contained the keys of the argument jsonb expression
+            (equivalent of the ``@>`` operator).
 
             kwargs may be ignored by this operator but are required for API
             conformance.
@@ -280,7 +285,8 @@ class JSONB(JSON):
 
         def contained_by(self, other):
             """Boolean expression.  Test if keys are a proper subset of the
-            keys of the argument jsonb expression.
+            keys of the argument jsonb expression
+            (equivalent of the ``<@`` operator).
             """
             return self.operate(
                 CONTAINED_BY, other, result_type=sqltypes.Boolean
@@ -288,7 +294,7 @@ class JSONB(JSON):
 
         def delete_path(self, array):
             """JSONB expression. Deletes field or array element specified in
-            the argument array.
+            the argument array (equivalent of the ``#-`` operator).
 
             The input may be a list of strings that will be coerced to an
             ``ARRAY`` or an instance of :meth:`_postgres.array`.
@@ -302,7 +308,7 @@ class JSONB(JSON):
 
         def path_exists(self, other):
             """Boolean expression. Test for presence of item given by the
-            argument JSONPath expression.
+            argument JSONPath expression (equivalent of the ``@?`` operator).
 
             .. versionadded:: 2.0
             """
@@ -312,7 +318,8 @@ class JSONB(JSON):
 
         def path_match(self, other):
             """Boolean expression. Test if JSONPath predicate given by the
-            argument JSONPath expression matches.
+            argument JSONPath expression matches
+            (equivalent of the ``@@`` operator).
 
             Only the first item of the result is taken into account.
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Documentation on [JSON field](https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#sqlalchemy.dialects.postgresql.JSON) list the operators generated behind the code, which is not the case for JSONB field. This PR adds those details.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
