### PR TITLE
MAINT: pytest doesn't have any more python 3.12 deprecations

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -101,11 +101,7 @@ setenv=
     PYTEST_COLOR={tty:--color=yes}
     MYPY_COLOR={tty:--color-output}
 
-    # pytest 'rewrite' is hitting lots of deprecation warnings under py312 and
-    # i can't find any way to ignore those warnings, so this turns it off
-    py312: PYTEST_ARGS=--assert plain
-
-    BASECOMMAND=python -m pytest {env:PYTEST_ARGS} {env:PYTEST_COLOR} --rootdir {toxinidir} --log-info=sqlalchemy.testing
+    BASECOMMAND=python -m pytest {env:PYTEST_COLOR} --rootdir {toxinidir} --log-info=sqlalchemy.testing
 
     WORKERS={env:TOX_WORKERS:-n4  --max-worker-restart=5}
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
I believe this workaround is not needed any more, pytest doesn't have any more python deprecations. (Arguably neither 3.13)

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] Tweek to the (testing) infrastructure
        - New category as I didn't think this PR fit in any of the 3 options offered.
        
        
- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
