### PR TITLE
Merge url query args to opts in mariadbconnector like mysqldb

### DIFF
--- a/doc/build/changelog/unreleased_20/11870.rst
+++ b/doc/build/changelog/unreleased_20/11870.rst
@@ -1,0 +1,9 @@
+.. change::
+    :tags: bug, mysql
+    :tickets: 11870
+
+    AddedFixed discepancy between mysqlclient and mariadbconnector where the
+    latter didn't merge url query options with the other args preventing options
+    like  ``?unix_socket=/path/to/socket.sock"`` being passed to the driver that
+    way. Pull request courtesy Tobias Alex-Petersen.
+

--- a/doc/build/changelog/unreleased_20/11870.rst
+++ b/doc/build/changelog/unreleased_20/11870.rst
@@ -2,7 +2,7 @@
     :tags: bug, mysql
     :tickets: 11870
 
-    AddedFixed discepancy between mysqlclient and mariadbconnector where the
+    Fixed discepancy between mysqlclient and mariadbconnector where the
     latter didn't merge url query options with the other args preventing options
     like  ``?unix_socket=/path/to/socket.sock"`` being passed to the driver that
     way. Pull request courtesy Tobias Alex-Petersen.

--- a/lib/sqlalchemy/dialects/mysql/mariadbconnector.py
+++ b/lib/sqlalchemy/dialects/mysql/mariadbconnector.py
@@ -166,6 +166,7 @@ class MySQLDialect_mariadbconnector(MySQLDialect):
 
     def create_connect_args(self, url):
         opts = url.translate_connect_args()
+        opts.update(url.query)
 
         int_params = [
             "connect_timeout",

--- a/test/dialect/mysql/test_dialect.py
+++ b/test/dialect/mysql/test_dialect.py
@@ -320,8 +320,10 @@ class DialectTest(fixtures.TestBase):
         [
             "mysql+mysqldb",
             "mysql+pymysql",
+            "mysql+mariadbconnector",
             "mariadb+mysqldb",
             "mariadb+pymysql",
+            "mariadb+mariadbconnector",
         ]
     )
     def test_random_arg(self):


### PR DESCRIPTION
### Description
Merges url query args to opts in in create_connect_args in mariadbconnector as mysqldb does

This was discussed in https://github.com/sqlalchemy/sqlalchemy/discussions/11868

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.
