### PR TITLE
pg8000 dialect: Add do_terminate()

### DIFF
--- a/doc/build/changelog/unreleased_21/10795.rst
+++ b/doc/build/changelog/unreleased_21/10795.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: pg8000
+    :tickets: 10795
+
+    In the pg8000 dialect the `do_terminate()` is now overriden so that it
+    discards network errors or 'connection is closed' errors. The
+    `do_terminate()` method doesn't require a graceful disconnect so any
+    exceptions encountered shouldn't be propagated.

--- a/lib/sqlalchemy/dialects/postgresql/pg8000.py
+++ b/lib/sqlalchemy/dialects/postgresql/pg8000.py
@@ -658,5 +658,13 @@ class PGDialect_pg8000(PGDialect):
     def _dialect_specific_select_one(self):
         return ";"
 
+    def do_terminate(self, dbapi_connection) -> None:
+        try:
+            dbapi_connection.close()
+        except self.dbapi.InterfaceError as e:
+            msg = str(e)
+            if not ("network error" in msg or "connection is closed" in msg):
+                raise e
+
 
 dialect = PGDialect_pg8000


### PR DESCRIPTION
The do_terminate() of the pg8000 dialect now swallows network errors or 'connection is closed' errors.

### Description

This arose from the discussion at:

https://github.com/sqlalchemy/sqlalchemy/discussions/10795

In particular @zzzeek's comment:

> the pg8000 dialect in SQLAlchemy is not usually finely tuned for production workloads but it could benefit from having its "terminate()" sequence be more hardened, where if the connection was already shown to be network-disconnected, it could be thrown away, since terminate is not requiring that a graceful disconnect occurs.

This change implements the above suggestion.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
