### PR TITLE
Update MonetDB information in the dialects overview

### DIFF
--- a/doc/build/dialects/index.rst
+++ b/doc/build/dialects/index.rst
@@ -113,7 +113,7 @@ Currently maintained external dialect projects for SQLAlchemy include:
 +------------------------------------------------+---------------------------------------+
 | Microsoft SQL Server (via turbodbc)            | sqlalchemy-turbodbc_                  |
 +------------------------------------------------+---------------------------------------+
-| MonetDB [1]_                                   | sqlalchemy-monetdb_                   |
+| MonetDB                                        | sqlalchemy-monetdb_                   |
 +------------------------------------------------+---------------------------------------+
 | OpenGauss                                      | openGauss-sqlalchemy_                 |
 +------------------------------------------------+---------------------------------------+
@@ -148,7 +148,7 @@ Currently maintained external dialect projects for SQLAlchemy include:
 .. _sqlalchemy-solr: https://github.com/aadel/sqlalchemy-solr
 .. _sqlalchemy_exasol: https://github.com/blue-yonder/sqlalchemy_exasol
 .. _sqlalchemy-sqlany: https://github.com/sqlanywhere/sqlalchemy-sqlany
-.. _sqlalchemy-monetdb: https://github.com/gijzelaerr/sqlalchemy-monetdb
+.. _sqlalchemy-monetdb: https://github.com/MonetDB/sqlalchemy-monetdb
 .. _snowflake-sqlalchemy: https://github.com/snowflakedb/snowflake-sqlalchemy
 .. _sqlalchemy-pytds: https://pypi.org/project/sqlalchemy-pytds/
 .. _sqlalchemy-cratedb: https://github.com/crate/sqlalchemy-cratedb


### PR DESCRIPTION
The MonetDB's dialect github project has a new main location and it supports sqlalchemy 2.0.34.