### PR TITLE
Add type annotations to CreateSchema & DropSchema

### DIFF
--- a/lib/sqlalchemy/sql/ddl.py
+++ b/lib/sqlalchemy/sql/ddl.py
@@ -470,8 +470,8 @@ class CreateSchema(_CreateBase):
 
     def __init__(
         self,
-        name,
-        if_not_exists=False,
+        name: str,
+        if_not_exists: bool = False,
     ):
         """Create a new :class:`.CreateSchema` construct."""
 
@@ -491,9 +491,9 @@ class DropSchema(_DropBase):
 
     def __init__(
         self,
-        name,
-        cascade=False,
-        if_exists=False,
+        name: str,
+        cascade: bool = False,
+        if_exists: bool = False,
     ):
         """Create a new :class:`.DropSchema` construct."""
 


### PR DESCRIPTION
### Description
[`CreateSchema`](https://docs.sqlalchemy.org/en/20/core/ddl.html#sqlalchemy.schema.CreateSchema) and [`DropSchema`](https://docs.sqlalchemy.org/en/20/core/ddl.html#sqlalchemy.schema.DropSchema) in `sqlalchemy.sql.ddl` lack type annotations for their constructors. This adds them.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
