### PR TITLE
Permit optional types in type annotation map

### DIFF
--- a/lib/sqlalchemy/orm/decl_api.py
+++ b/lib/sqlalchemy/orm/decl_api.py
@@ -73,12 +73,12 @@ from ..util import hybridmethod
 from ..util import hybridproperty
 from ..util import typing as compat_typing
 from ..util.typing import CallableReference
+from ..util.typing import de_optionalize_union_types
 from ..util.typing import flatten_newtype
 from ..util.typing import is_generic
 from ..util.typing import is_literal
 from ..util.typing import is_newtype
 from ..util.typing import is_pep695
-from ..util.typing import is_union
 from ..util.typing import Literal
 from ..util.typing import Self
 
@@ -1222,11 +1222,8 @@ class registry:
 
         self.type_annotation_map.update(
             {
-                sub_type: sqltype
+                de_optionalize_union_types(typ): sqltype
                 for typ, sqltype in type_annotation_map.items()
-                for sub_type in compat_typing.expand_unions(
-                    typ, include_union=True, discard_none=True
-                )
             }
         )
 
@@ -1253,15 +1250,7 @@ class registry:
                 )
             else:
                 python_type_type = python_type_to_check.__origin__
-                if is_union(python_type_to_check):
-                    # Also search for an optional form of this type in case
-                    # that's what's in the type annotation map.
-                    search = (  # type: ignore[assignment]
-                        (python_type, python_type_type),
-                        (Optional[python_type], python_type_type),
-                    )
-                else:
-                    search = ((python_type, python_type_type),)
+                search = ((python_type, python_type_type),)
         elif is_newtype(python_type_to_check):
             python_type_type = flatten_newtype(python_type_to_check)
             search = ((python_type, python_type_type),)

--- a/lib/sqlalchemy/orm/decl_api.py
+++ b/lib/sqlalchemy/orm/decl_api.py
@@ -78,6 +78,7 @@ from ..util.typing import is_generic
 from ..util.typing import is_literal
 from ..util.typing import is_newtype
 from ..util.typing import is_pep695
+from ..util.typing import is_union
 from ..util.typing import Literal
 from ..util.typing import Self
 
@@ -1252,7 +1253,15 @@ class registry:
                 )
             else:
                 python_type_type = python_type_to_check.__origin__
-                search = ((python_type, python_type_type),)
+                if is_union(python_type_to_check):
+                    # Also search for an optional form of this type in case
+                    # that's what's in the type annotation map.
+                    search = (  # type: ignore[assignment]
+                        (python_type, python_type_type),
+                        (Optional[python_type], python_type_type),
+                    )
+                else:
+                    search = ((python_type, python_type_type),)
         elif is_newtype(python_type_to_check):
             python_type_type = flatten_newtype(python_type_to_check)
             search = ((python_type, python_type_type),)

--- a/lib/sqlalchemy/util/typing.py
+++ b/lib/sqlalchemy/util/typing.py
@@ -422,6 +422,9 @@ def de_optionalize_union_types(
 
     """
 
+    while is_pep695(type_):
+        type_ = type_.__value__
+
     if is_fwd_ref(type_):
         return de_optionalize_fwd_ref_union_types(type_)
 
@@ -476,26 +479,6 @@ def make_union_type(*types: _AnnotationScanType) -> Type[Any]:
 
     """
     return cast(Any, Union).__getitem__(types)  # type: ignore
-
-
-def expand_unions(
-    type_: Type[Any], include_union: bool = False, discard_none: bool = False
-) -> Tuple[Type[Any], ...]:
-    """Return a type as a tuple of individual types, expanding for
-    ``Union`` types."""
-
-    if is_union(type_):
-        typ = set(type_.__args__)
-
-        if discard_none:
-            typ.discard(NoneType)
-
-        if include_union:
-            return (type_,) + tuple(typ)  # type: ignore
-        else:
-            return tuple(typ)  # type: ignore
-    else:
-        return (type_,)
 
 
 def is_optional(type_: Any) -> TypeGuard[ArgsTypeProcotol]:

--- a/lib/sqlalchemy/util/typing.py
+++ b/lib/sqlalchemy/util/typing.py
@@ -512,7 +512,7 @@ def is_optional_union(type_: Any) -> bool:
 
 
 def is_union(type_: Any) -> TypeGuard[ArgsTypeProcotol]:
-    return is_origin_of(type_, "Union")
+    return is_origin_of(type_, "Union", "UnionType")
 
 
 def is_origin_of_cls(

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -4,6 +4,9 @@ import inspect
 from pathlib import Path
 import pickle
 import sys
+import typing
+
+import typing_extensions
 
 from sqlalchemy import exc
 from sqlalchemy import sql
@@ -38,6 +41,7 @@ from sqlalchemy.util import preloaded
 from sqlalchemy.util import WeakSequence
 from sqlalchemy.util._collections import merge_lists_w_ordering
 from sqlalchemy.util._has_cython import _all_cython_modules
+from sqlalchemy.util.typing import is_union
 
 
 class WeakSequenceTest(fixtures.TestBase):
@@ -3655,3 +3659,11 @@ class CyExtensionTest(fixtures.TestBase):
             print(expected)
             print(setup_modules)
             eq_(setup_modules, expected)
+
+
+class TypingTest(fixtures.TestBase):
+    def test_is_union(self):
+        assert is_union(typing.Union[str, int])
+        assert is_union(typing_extensions.Union[str, int])
+        if compat.py310:
+            assert is_union(str | int)

--- a/test/orm/declarative/test_tm_future_annotations_sync.py
+++ b/test/orm/declarative/test_tm_future_annotations_sync.py
@@ -131,6 +131,14 @@ _JsonObject: TypeAlias = Dict[str, "_Json"]
 _JsonArray: TypeAlias = List["_Json"]
 _Json: TypeAlias = Union[_JsonObject, _JsonArray, _JsonPrimitive]
 
+if compat.py310:
+    _JsonPrimitivePep604: TypeAlias = str | int | float | bool | None
+    _JsonObjectPep604: TypeAlias = dict[str, "_JsonPep604"]
+    _JsonArrayPep604: TypeAlias = list["_JsonPep604"]
+    _JsonPep604: TypeAlias = (
+        _JsonObjectPep604 | _JsonArrayPep604 | _JsonPrimitivePep604
+    )
+
 if compat.py312:
     exec(
         """
@@ -1804,7 +1812,8 @@ class MappedColumnTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         if compat.py312:
             is_(User.__table__.c.pep695_data.type, our_type)
 
-    def test_optional_in_annotation_map(self):
+    @testing.variation("union", ["union", "pep604"])
+    def test_optional_in_annotation_map(self, union):
         """SQLAlchemy's behaviour is clear: an optional type means the column
         is inferred as nullable. Some types which a user may want to put in the
         type annotation map are already optional. JSON is a good example
@@ -1818,16 +1827,33 @@ class MappedColumnTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         """
 
         class Base(DeclarativeBase):
-            type_annotation_map = {
-                _Json: JSON,
-            }
+            if union.union:
+                type_annotation_map = {
+                    _Json: JSON,
+                }
+            elif union.pep604:
+                if not compat.py310:
+                    skip_test("Requires Python 3.10+")
+                type_annotation_map = {
+                    _JsonPep604: JSON,
+                }
+            else:
+                union.fail()
 
         class A(Base):
             __tablename__ = "a"
 
             id: Mapped[int] = mapped_column(primary_key=True)
-            json1: Mapped[_Json]
-            json2: Mapped[_Json] = mapped_column(nullable=False)
+            if union.union:
+                json1: Mapped[_Json]
+                json2: Mapped[_Json] = mapped_column(nullable=False)
+            elif union.pep604:
+                if not compat.py310:
+                    skip_test("Requires Python 3.10+")
+                json1: Mapped[_JsonPep604]
+                json2: Mapped[_JsonPep604] = mapped_column(nullable=False)
+            else:
+                union.fail()
 
         is_(A.__table__.c.json1.type._type_affinity, JSON)
         is_(A.__table__.c.json2.type._type_affinity, JSON)

--- a/test/orm/declarative/test_tm_future_annotations_sync.py
+++ b/test/orm/declarative/test_tm_future_annotations_sync.py
@@ -34,6 +34,7 @@ import typing_extensions
 from typing_extensions import get_args as get_args
 from typing_extensions import Literal as Literal
 from typing_extensions import TypeAlias as TypeAlias
+from typing_extensions import TypeAliasType
 
 from sqlalchemy import BIGINT
 from sqlalchemy import BigInteger
@@ -41,6 +42,7 @@ from sqlalchemy import Column
 from sqlalchemy import DateTime
 from sqlalchemy import exc
 from sqlalchemy import exc as sa_exc
+from sqlalchemy import Float
 from sqlalchemy import ForeignKey
 from sqlalchemy import func
 from sqlalchemy import Identity
@@ -94,6 +96,7 @@ from sqlalchemy.testing import is_
 from sqlalchemy.testing import is_false
 from sqlalchemy.testing import is_not
 from sqlalchemy.testing import is_true
+from sqlalchemy.testing import skip_test
 from sqlalchemy.testing import Variation
 from sqlalchemy.testing.fixtures import fixture_session
 from sqlalchemy.util import compat
@@ -1703,11 +1706,30 @@ class MappedColumnTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         else:
             is_(getattr(Element.__table__.c.data, paramname), override_value)
 
-    def test_unions(self):
+    @testing.variation("union", ["union", "pep604"])
+    @testing.variation("typealias", ["legacy", "pep695"])
+    def test_unions(self, union, typealias):
         our_type = Numeric(10, 2)
 
+        if union.union:
+            UnionType = Union[float, Decimal]
+        elif union.pep604:
+            if not compat.py310:
+                skip_test("Required Python 3.10")
+            UnionType = float | Decimal
+        else:
+            union.fail()
+
+        if typealias.legacy:
+            UnionTypeAlias = UnionType
+        elif typealias.pep695:
+            # same as type UnionTypeAlias = UnionType
+            UnionTypeAlias = TypeAliasType("UnionTypeAlias", UnionType)
+        else:
+            typealias.fail()
+
         class Base(DeclarativeBase):
-            type_annotation_map = {Union[float, Decimal]: our_type}
+            type_annotation_map = {UnionTypeAlias: our_type}
 
         class User(Base):
             __tablename__ = "users"
@@ -1748,6 +1770,10 @@ class MappedColumnTest(fixtures.TestBase, testing.AssertsCompiledSQL):
                     mapped_column()
                 )
 
+            if compat.py312:
+                MyTypeAlias = TypeAliasType("MyTypeAlias", float | Decimal)
+                pep695_data: Mapped[MyTypeAlias] = mapped_column()
+
         is_(User.__table__.c.data.type, our_type)
         is_false(User.__table__.c.data.nullable)
         is_(User.__table__.c.reverse_data.type, our_type)
@@ -1759,8 +1785,9 @@ class MappedColumnTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         is_true(User.__table__.c.reverse_optional_data.nullable)
         is_true(User.__table__.c.reverse_u_optional_data.nullable)
 
-        is_(User.__table__.c.float_data.type, our_type)
-        is_(User.__table__.c.decimal_data.type, our_type)
+        is_true(isinstance(User.__table__.c.float_data.type, Float))
+        is_true(isinstance(User.__table__.c.float_data.type, Numeric))
+        is_not(User.__table__.c.decimal_data.type, our_type)
 
         if compat.py310:
             for suffix in ("", "_fwd"):
@@ -1773,6 +1800,9 @@ class MappedColumnTest(fixtures.TestBase, testing.AssertsCompiledSQL):
                 is_false(reverse_col.nullable)
                 is_(optional_col.type, our_type)
                 is_true(optional_col.nullable)
+
+        if compat.py312:
+            is_(User.__table__.c.pep695_data.type, our_type)
 
     def test_optional_in_annotation_map(self):
         """SQLAlchemy's behaviour is clear: an optional type means the column

--- a/test/orm/declarative/test_typed_mapping.py
+++ b/test/orm/declarative/test_typed_mapping.py
@@ -114,6 +114,11 @@ _Recursive695_2: TypeAlias = _Recursive695_1
 _TypingLiteral = typing.Literal["a", "b"]
 _TypingExtensionsLiteral = typing_extensions.Literal["a", "b"]
 
+_JsonPrimitive: TypeAlias = Union[str, int, float, bool, None]
+_JsonObject: TypeAlias = Dict[str, "_Json"]
+_JsonArray: TypeAlias = List["_Json"]
+_Json: TypeAlias = Union[_JsonObject, _JsonArray, _JsonPrimitive]
+
 if compat.py312:
     exec(
         """
@@ -1759,6 +1764,36 @@ class MappedColumnTest(fixtures.TestBase, testing.AssertsCompiledSQL):
                 is_false(reverse_col.nullable)
                 is_(optional_col.type, our_type)
                 is_true(optional_col.nullable)
+
+    def test_optional_in_annotation_map(self):
+        """SQLAlchemy's behaviour is clear: an optional type means the column
+        is inferred as nullable. Some types which a user may want to put in the
+        type annotation map are already optional. JSON is a good example
+        because without any constraint, the type can be None via JSON null or
+        SQL NULL.
+
+        By permitting optional types in the type annotation map, everything
+        just works, and mapped_column(nullable=False) is available if desired.
+
+        See issue #11370
+        """
+
+        class Base(DeclarativeBase):
+            type_annotation_map = {
+                _Json: JSON,
+            }
+
+        class A(Base):
+            __tablename__ = "a"
+
+            id: Mapped[int] = mapped_column(primary_key=True)
+            json1: Mapped[_Json]
+            json2: Mapped[_Json] = mapped_column(nullable=False)
+
+        is_(A.__table__.c.json1.type._type_affinity, JSON)
+        is_(A.__table__.c.json2.type._type_affinity, JSON)
+        is_true(A.__table__.c.json1.nullable)
+        is_false(A.__table__.c.json2.nullable)
 
     @testing.combinations(
         ("not_optional",),


### PR DESCRIPTION
Fixes #11370

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Some types which a user may want to put in the type annotation map are already optional. JSON is a good example because without any constraint, the type can be `None` via JSON `null` or SQL `NULL`.

By permitting optional types in the type annotation map, everything just works, and `mapped_column(nullable=False)` is available if desired.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
