### PR TITLE
Fixed a bug that caused a syntax error when a function was specified to server_default when creating a column in MySQL.

### DIFF
--- a/doc/build/changelog/unreleased_20/11317.rst
+++ b/doc/build/changelog/unreleased_20/11317.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: bug, orm
+    :tickets: 11317
+
+    Fixed a bug that caused a syntax error
+    when a function was specified to server_default when creating a column in MySQL.

--- a/doc/build/changelog/unreleased_20/11317.rst
+++ b/doc/build/changelog/unreleased_20/11317.rst
@@ -1,5 +1,5 @@
 .. change::
-    :tags: bug, orm
+    :tags: bug, schema
     :tickets: 11317
 
     Fixed a bug that caused a syntax error

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1850,8 +1850,11 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
         else:
             default = self.get_column_default_string(column)
             if default is not None:
-                if isinstance(
-                    column.server_default.arg, functions.FunctionElement
+                if (
+                    isinstance(
+                        column.server_default.arg, functions.FunctionElement
+                    )
+                    and self.dialect._support_default_function
                 ):
                     colspec.append(f"DEFAULT ({default})")
                 else:
@@ -2899,6 +2902,17 @@ class MySQLDialect(default.DefaultDialect):
         else:
             # ref https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-17.html#mysqld-8-0-17-feature  # noqa
             return self.server_version_info >= (8, 0, 17)
+
+    @property
+    def _support_default_function(self):
+        if not self.server_version_info:
+            return False
+        elif self.is_mariadb:
+            # ref https://mariadb.com/kb/en/mariadb-1021-release-notes/
+            return self.server_version_info >= (10, 2, 1)
+        else:
+            # ref https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html # noqa
+            return self.server_version_info >= (8, 0, 13)
 
     @property
     def _is_mariadb(self):

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1855,7 +1855,7 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
 
     def get_column_default_string(self, column):
         if hasattr(column.server_default, 'arg') and isinstance(column.server_default.arg, functions.FunctionElement):
-            return f'({column.server_default.arg})'
+            return f'({super().get_column_default_string(column)})'
         return super().get_column_default_string(column)
 
     def post_create_table(self, table):

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1853,6 +1853,11 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
                 colspec.append("DEFAULT " + default)
         return " ".join(colspec)
 
+    def get_column_default_string(self, column):
+        if hasattr(column.server_default, 'arg') and isinstance(column.server_default.arg, functions.FunctionElement):
+            return f'({column.server_default.arg})'
+        return super().get_column_default_string(column)
+
     def post_create_table(self, table):
         """Build table-level CREATE options like ENGINE and COLLATE."""
 

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1850,13 +1850,11 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
         else:
             default = self.get_column_default_string(column)
             if default is not None:
-                colspec.append("DEFAULT " + default)
+                if isinstance(column.server_default.arg, functions.FunctionElement):
+                    colspec.append(f"DEFAULT ({default})")
+                else:
+                    colspec.append("DEFAULT " + default)
         return " ".join(colspec)
-
-    def get_column_default_string(self, column):
-        if hasattr(column.server_default, 'arg') and isinstance(column.server_default.arg, functions.FunctionElement):
-            return f'({super().get_column_default_string(column)})'
-        return super().get_column_default_string(column)
 
     def post_create_table(self, table):
         """Build table-level CREATE options like ENGINE and COLLATE."""

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1850,7 +1850,9 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
         else:
             default = self.get_column_default_string(column)
             if default is not None:
-                if isinstance(column.server_default.arg, functions.FunctionElement):
+                if isinstance(
+                    column.server_default.arg, functions.FunctionElement
+                ):
                     colspec.append(f"DEFAULT ({default})")
                 else:
                     colspec.append("DEFAULT " + default)

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -414,7 +414,9 @@ class CompileTest(ReservedWordFixture, fixtures.TestBase, AssertsCompiledSQL):
             m,
             Column("time", DateTime, server_default=func.current_timestamp()),
             Column("name", String(255), server_default="some str"),
-            Column("description", String(255), server_default=func.lower("hi")),
+            Column(
+                "description", String(255), server_default=func.lower("hi")
+            ),
             Column("data", JSON, server_default=func.json_object()),
         )
         self.assert_compile(

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -25,6 +25,7 @@ from sqlalchemy import Index
 from sqlalchemy import INT
 from sqlalchemy import Integer
 from sqlalchemy import Interval
+from sqlalchemy import JSON
 from sqlalchemy import LargeBinary
 from sqlalchemy import literal
 from sqlalchemy import MetaData
@@ -404,6 +405,24 @@ class CompileTest(ReservedWordFixture, fixtures.TestBase, AssertsCompiledSQL):
             schema.CreateTable(tbl),
             "CREATE TABLE testtbl (data VARCHAR(255) NOT NULL, "
             "PRIMARY KEY (data) USING btree)",
+        )
+
+    def test_create_server_default_with_function_using(self):
+        m = MetaData()
+        tbl = Table(
+            "testtbl",
+            m,
+            Column("time", DateTime, server_default=func.current_timestamp()),
+            Column("name", String(255), server_default="some str"),
+            Column("description", String(255), server_default=func.lower("hi")),
+            Column("data", JSON, server_default=func.json_object()),
+        )
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE testtbl (time DATETIME DEFAULT (CURRENT_TIMESTAMP), "
+            "name VARCHAR(255) DEFAULT 'some str', "
+            "description VARCHAR(255) DEFAULT (lower('hi')), "
+            "data JSON DEFAULT (json_object()))",
         )
 
     def test_create_index_expr(self):


### PR DESCRIPTION
Fixes #11317 

### Description
Fix a syntax error bug by inserting parentheses when a function is specified in the process of setting column default values during table creation within MySQLDDLCompiler.
I also added the corresponding test cases.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- issue is #11317 
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
