### PR TITLE
fix: update documentation about disabling prepared statement caching

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/asyncpg.py
+++ b/lib/sqlalchemy/dialects/postgresql/asyncpg.py
@@ -119,25 +119,20 @@ By default, asyncpg enumerates prepared statements in numeric order, which
 can lead to errors if a name has already been taken for another prepared
 statement. This issue can arise if your application uses database proxies
 such as PgBouncer to handle connections. One possible workaround is to
-use dynamic prepared statement names, which asyncpg now supports through
-an optional ``name`` value for the statement name. This allows you to
-generate your own unique names that won't conflict with existing ones.
-To achieve this, you can provide a function that will be called every time
-a prepared statement is prepared::
-
-    from uuid import uuid4
+disable prepared statement caching, which asyncpg now supports through
+setting ``statement_cache_size`` to ``0``::
 
     engine = create_async_engine(
         "postgresql+asyncpg://user:pass@somepgbouncer/dbname",
         poolclass=NullPool,
         connect_args={
-            'prepared_statement_name_func': lambda:  f'__asyncpg_{uuid4()}__',
+            'statement_cache_size': 0,
         },
     )
 
 .. seealso::
 
-   https://github.com/MagicStack/asyncpg/issues/837
+   https://github.com/MagicStack/asyncpg/issues/1058
 
    https://github.com/sqlalchemy/sqlalchemy/issues/6467
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
asyncpg supports disabling statement caching by setting `statement_cache_size=0`. The previous method of using `prepared_statement_name_func` is no longer necessary.

See: https://magicstack.github.io/asyncpg/current/api/index.html

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
