### PR TITLE
Added INET6 type for MariaDB

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/mariadb.py
+++ b/lib/sqlalchemy/dialects/mysql/mariadb.py
@@ -7,9 +7,18 @@
 # mypy: ignore-errors
 from .base import MariaDBIdentifierPreparer
 from .base import MySQLDialect
+from .base import MySQLTypeCompiler
 from ... import util
+from ...sql import sqltypes
 from ...sql.sqltypes import UUID
 from ...sql.sqltypes import Uuid
+
+
+class INET6(sqltypes.TypeEngine[str]):
+    """
+    INET6 column type for MariaDB
+    """
+    __visit_name__ = "INET6"
 
 
 class _MariaDBUUID(UUID):
@@ -36,6 +45,11 @@ class _MariaDBUUID(UUID):
             return super().bind_processor(dialect)
         else:
             return None
+
+
+class MariaDBTypeCompiler(MySQLTypeCompiler):
+    def visit_INET6(self, type_, **kwargs) -> str:
+        return "INET6"
 
 
 class MariaDBDialect(MySQLDialect):

--- a/lib/sqlalchemy/dialects/mysql/mariadbconnector.py
+++ b/lib/sqlalchemy/dialects/mysql/mariadbconnector.py
@@ -118,6 +118,7 @@ class MySQLDialect_mariadbconnector(MySQLDialect):
     supports_native_decimal = True
     default_paramstyle = "qmark"
     execution_ctx_cls = MySQLExecutionContext_mariadbconnector
+    type_compiler_cls = MariaDBTypeCompiler
     statement_compiler = MySQLCompiler_mariadbconnector
 
     supports_server_side_cursors = True

--- a/test/dialect/mysql/test_types.py
+++ b/test/dialect/mysql/test_types.py
@@ -21,7 +21,7 @@ from sqlalchemy import TypeDecorator
 from sqlalchemy import types as sqltypes
 from sqlalchemy import UnicodeText
 from sqlalchemy.dialects.mysql import base as mysql
-from sqlalchemy.dialects.mysql.mariadb import MariaDBDialect
+from sqlalchemy.dialects.mysql.mariadb import MariaDBDialect, INET6 as MariadbINET6
 from sqlalchemy.testing import assert_raises
 from sqlalchemy.testing import assert_raises_message
 from sqlalchemy.testing import AssertsCompiledSQL
@@ -506,6 +506,13 @@ class MariaDBUUIDTest(fixtures.TestBase, AssertsCompiledSQL):
         dialect = MariaDBDialect()
         dialect.server_version_info = version
         dialect.supports_native_uuid = version >= (10, 7)
+        self.assert_compile(type_, res, dialect=dialect)
+
+    @testing.combinations(
+        (MariadbINET6, "INET6"),
+    )
+    def test_mariadb_inet6(self, type_, res):
+        dialect = MariaDBDialect()
         self.assert_compile(type_, res, dialect=dialect)
 
     @testing.combinations(


### PR DESCRIPTION
### Description
INET6 column type was added in MariaDB 10.5.0 https://mariadb.com/kb/en/inet6/

Related issue https://github.com/sqlalchemy/sqlalchemy/issues/10720 which mentions INET4 and INET6, while this MR adds just INET6.