### PR TITLE
Update declarative_styles.rst: add missing import from typing in the example

### DIFF
--- a/doc/build/orm/declarative_styles.rst
+++ b/doc/build/orm/declarative_styles.rst
@@ -51,7 +51,7 @@ With the declarative base class, new mapped classes are declared as subclasses
 of the base::
 
     from datetime import datetime
-    from typing import Optional
+    from typing import Optional, List
 
     from sqlalchemy import ForeignKey
     from sqlalchemy import func

--- a/doc/build/orm/declarative_styles.rst
+++ b/doc/build/orm/declarative_styles.rst
@@ -51,7 +51,8 @@ With the declarative base class, new mapped classes are declared as subclasses
 of the base::
 
     from datetime import datetime
-    from typing import Optional, List
+    from typing import List
+    from typing import Optional
 
     from sqlalchemy import ForeignKey
     from sqlalchemy import func


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Add the import of List from typing in the example for Declarative Mapping Styles in the documentation

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
