### PR TITLE
asyncpg: shield connection close in terminate to avoid connection leak

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/asyncpg.py
+++ b/lib/sqlalchemy/dialects/postgresql/asyncpg.py
@@ -915,7 +915,7 @@ class AsyncAdapt_asyncpg_connection(AsyncAdapt_dbapi_connection):
             try:
                 # try to gracefully close; see #10717
                 # timeout added in asyncpg 0.14.0 December 2017
-                await_(self._connection.close(timeout=2))
+                await_(asyncio.shield(self._connection.close(timeout=2)))
             except (
                 asyncio.TimeoutError,
                 asyncio.CancelledError,


### PR DESCRIPTION
I hit a connection leak when cancelling a task in a fastapi + starlette + BaseHTTPMiddleware + SA + asyncpg setup and managed to reproduce it with the code below.

From my understanding, when cancelling an `anyio` taskgroup which contains a task that checked out a connection from the pool, SA tries to close the connection, but most (all?) `await` calls within that code path bail with `asyncio.CancelledError`, leading to SA and asyncpg thinking that the connection was closed / released, but the socket is still alive and idle from postgres's point of view.

This is related to https://github.com/MagicStack/asyncpg/issues/1156 which doesn't currently have a resolution.

The solution proposed here might not be the right place to fix this issue, but it does fix my reproducer :)


The following code leaks a connection on every loop iteration:
```
import asyncio
import asyncpg
import anyio

from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
from sqlalchemy.sql import text

SQLALCHEMY_DATABASE_URL = "postgresql+asyncpg://postgres:postgres@localhost/postgres"
engine = create_async_engine(SQLALCHEMY_DATABASE_URL, pool_size=1, max_overflow=0, echo_pool="debug")
async_session = async_sessionmaker(engine, expire_on_commit=False)

async def anyio_tg_wrapper(func, *args, **kwargs):
    async with anyio.create_task_group() as tg:
        tg.start_soon(func, *args, **kwargs)

async def tg_wrapper(f):
    async with asyncio.TaskGroup() as tg:
        tg.create_task(f)


async def querier():
    async with async_session() as session, session.begin():
        res = await session.execute(text("select 1"))
        print([row for row in res])
        
        # simulate other async io work while holding the session
        await asyncio.sleep(10)

async def main():
    while True:
        t = asyncio.create_task(anyio_tg_wrapper(querier))
        
        # asyncio task group does not lead to a leak
        #t = asyncio.create_task(tg_wrapper(querier()))

        async def timeouter():
            await asyncio.sleep(1)
            t.cancel()

        asyncio.create_task(timeouter())

        try:
            await t
        except asyncio.CancelledError:
            print("cancelled")

if __name__ == '__main__':
    asyncio.run(main())
```
### Description

If terminate is called from an asyncio.CancelledError exception handler, under an anyio task group, await will bail with asyncio.CancelledError right away, leading to a connection leak.

Shielding the close() call allows the connection to be properly closed in those cases.

Tentatively removed the asyncio.CancelledError except clause since close() doesn't raise it itself so it shouldn't be possible to get it.

Fixes #12077 