### PR TITLE
New SQLite DDL feature for tables: STRICT

### DIFF
--- a/doc/build/changelog/unreleased_20/7398.rst
+++ b/doc/build/changelog/unreleased_20/7398.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: usecase, sqlite
+    :ticket: 7398
+
+    New SQLite DDL feature for tables: STRICT.
+    Pull request courtesy of Guilherme Crocetti.

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -836,6 +836,13 @@ dialect in conjunction with the :class:`_schema.Table` construct:
     `SQLite CREATE TABLE options
     <https://www.sqlite.org/lang_createtable.html>`_
 
+* ``STRICT``::
+
+    Table("some_table", metadata, ..., sqlite_strict=True)
+
+   The ``sqlite_strict`` parameter is a boolean set to ``False`` by default.
+
+..versionadded:: 2.0.37
 
 .. _sqlite_include_internal:
 
@@ -1707,9 +1714,12 @@ class SQLiteDDLCompiler(compiler.DDLCompiler):
         return text
 
     def post_create_table(self, table):
+        text = ""
         if table.dialect_options["sqlite"]["with_rowid"] is False:
-            return "\n WITHOUT ROWID"
-        return ""
+            text += "\n WITHOUT ROWID"
+        if table.dialect_options["sqlite"]["strict"] is True:
+            text += "\n STRICT"
+        return text
 
 
 class SQLiteTypeCompiler(compiler.GenericTypeCompiler):
@@ -1944,6 +1954,7 @@ class SQLiteDialect(default.DefaultDialect):
             {
                 "autoincrement": False,
                 "with_rowid": True,
+                "strict": False,
             },
         ),
         (sa_schema.Index, {"where": None}),

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -1145,6 +1145,14 @@ class SQLTest(fixtures.TestBase, AssertsCompiledSQL):
             "CREATE TABLE atable (id INTEGER) WITHOUT ROWID",
         )
 
+    def test_create_table_strict(self):
+        m = MetaData()
+        table = Table("atable", m, Column("id", Integer), sqlite_strict=True)
+        self.assert_compile(
+            schema.CreateTable(table),
+            "CREATE TABLE atable (id INTEGER) STRICT",
+        )
+
 
 class OnConflictDDLTest(fixtures.TestBase, AssertsCompiledSQL):
     __dialect__ = sqlite.dialect()


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Add a new parameter for SQLite tables: `sqlite_strict`. It adds the `STRICT` keyword at the end of the `CREATE TABLE` DDL statement.

More on strict tables: https://www.sqlite.org/stricttables.html

Fixes #7398 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
