### PR TITLE
Type mysql dialect

### DIFF
--- a/lib/sqlalchemy/dialects/__init__.py
+++ b/lib/sqlalchemy/dialects/__init__.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from typing import Callable
 from typing import Optional
 from typing import Type
@@ -39,7 +40,7 @@ def _auto_fn(name: str) -> Optional[Callable[[], Type[Dialect]]]:
             # hardcoded.   if mysql / mariadb etc were third party dialects
             # they would just publish all the entrypoints, which would actually
             # look much nicer.
-            module = __import__(
+            module: Any = __import__(
                 "sqlalchemy.dialects.mysql.mariadb"
             ).dialects.mysql.mariadb
             return module.loader(driver)  # type: ignore

--- a/lib/sqlalchemy/dialects/mysql/aiomysql.py
+++ b/lib/sqlalchemy/dialects/mysql/aiomysql.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 from types import ModuleType
 from typing import Any
+from typing import cast
 from typing import Optional
 from typing import TYPE_CHECKING
 
@@ -95,10 +96,10 @@ class AsyncAdapt_aiomysql_connection(AsyncAdapt_dbapi_connection):
 
     def terminate(self) -> None:
         # it's not awaitable.
-        self._connection.close()
+        cast(AiomysqlConnection, self._connection).close()
 
     def close(self) -> None:
-        await_(self._connection.ensure_closed())
+        await_(cast(AiomysqlConnection, self._connection).ensure_closed())
 
 
 class AsyncAdapt_aiomysql_dbapi:

--- a/lib/sqlalchemy/dialects/mysql/asyncmy.py
+++ b/lib/sqlalchemy/dialects/mysql/asyncmy.py
@@ -4,7 +4,7 @@
 #
 # This module is part of SQLAlchemy and is released under
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
-# mypy: ignore-errors
+# mypy: disable-error-code="import-not-found"
 
 r"""
 .. dialect:: mysql+asyncmy
@@ -29,12 +29,32 @@ This dialect should normally be used only with the
 """  # noqa
 from __future__ import annotations
 
+from types import ModuleType
+from typing import Any
+from typing import Iterable
+from typing import NoReturn
+from typing import Optional
+from typing import SupportsBytes
+from typing import SupportsIndex
+from typing import TYPE_CHECKING
+from typing import Union
+
 from .pymysql import MySQLDialect_pymysql
 from ... import util
 from ...connectors.asyncio import AsyncAdapt_dbapi_connection
 from ...connectors.asyncio import AsyncAdapt_dbapi_cursor
 from ...connectors.asyncio import AsyncAdapt_dbapi_ss_cursor
 from ...util.concurrency import await_
+
+if TYPE_CHECKING:
+    from _typeshed import ReadableBuffer
+    from asyncmy.connection import Connection as AsyncmyConnection
+    from asyncmy.pool import pool as AsyncmyPool
+
+    from ...connectors.asyncio import AsyncIODBAPIConnection
+    from ...connectors.asyncio import AsyncIODBAPICursor
+    from ...engine.interfaces import ConnectArgsType
+    from ...engine.url import URL
 
 
 class AsyncAdapt_asyncmy_cursor(AsyncAdapt_dbapi_cursor):
@@ -46,7 +66,9 @@ class AsyncAdapt_asyncmy_ss_cursor(
 ):
     __slots__ = ()
 
-    def _make_new_cursor(self, connection):
+    def _make_new_cursor(
+        self, connection: AsyncIODBAPIConnection
+    ) -> AsyncIODBAPICursor:
         return connection.cursor(
             self._adapt_connection.dbapi.asyncmy.cursors.SSCursor
         )
@@ -57,8 +79,9 @@ class AsyncAdapt_asyncmy_connection(AsyncAdapt_dbapi_connection):
 
     _cursor_cls = AsyncAdapt_asyncmy_cursor
     _ss_cursor_cls = AsyncAdapt_asyncmy_ss_cursor
+    _connection: AsyncmyConnection
 
-    def _handle_exception(self, error):
+    def _handle_exception(self, error: Exception) -> NoReturn:
         if isinstance(error, AttributeError):
             raise self.dbapi.InternalError(
                 "network operation failed due to asyncmy attribute error"
@@ -66,24 +89,24 @@ class AsyncAdapt_asyncmy_connection(AsyncAdapt_dbapi_connection):
 
         raise error
 
-    def ping(self, reconnect):
+    def ping(self, reconnect: bool) -> None:
         assert not reconnect
         return await_(self._do_ping())
 
-    async def _do_ping(self):
+    async def _do_ping(self) -> None:
         try:
             async with self._execute_mutex:
-                return await self._connection.ping(False)
+                await self._connection.ping(False)
         except Exception as error:
             self._handle_exception(error)
 
-    def character_set_name(self):
-        return self._connection.character_set_name()
+    def character_set_name(self) -> Optional[str]:
+        return self._connection.character_set_name()  # type: ignore[no-any-return]  # noqa: E501
 
-    def autocommit(self, value):
+    def autocommit(self, value: Any) -> None:
         await_(self._connection.autocommit(value))
 
-    def terminate(self):
+    def terminate(self) -> None:
         # it's not awaitable.
         self._connection.close()
 
@@ -91,18 +114,25 @@ class AsyncAdapt_asyncmy_connection(AsyncAdapt_dbapi_connection):
         await_(self._connection.ensure_closed())
 
 
-def _Binary(x):
+def _Binary(
+    x: Union[
+        Iterable[SupportsIndex],
+        SupportsIndex,
+        SupportsBytes,
+        ReadableBuffer,
+    ],
+) -> bytes:
     """Return x as a binary type."""
     return bytes(x)
 
 
 class AsyncAdapt_asyncmy_dbapi:
-    def __init__(self, asyncmy):
+    def __init__(self, asyncmy: ModuleType):
         self.asyncmy = asyncmy
         self.paramstyle = "format"
         self._init_dbapi_attributes()
 
-    def _init_dbapi_attributes(self):
+    def _init_dbapi_attributes(self) -> None:
         for name in (
             "Warning",
             "Error",
@@ -125,7 +155,7 @@ class AsyncAdapt_asyncmy_dbapi:
     TIMESTAMP = util.symbol("TIMESTAMP")
     Binary = staticmethod(_Binary)
 
-    def connect(self, *arg, **kw):
+    def connect(self, *arg: Any, **kw: Any) -> AsyncAdapt_asyncmy_connection:
         creator_fn = kw.pop("async_creator_fn", self.asyncmy.connect)
 
         return AsyncAdapt_asyncmy_connection(
@@ -138,25 +168,27 @@ class MySQLDialect_asyncmy(MySQLDialect_pymysql):
     driver = "asyncmy"
     supports_statement_cache = True
 
-    supports_server_side_cursors = True
+    supports_server_side_cursors = True  # type: ignore[assignment]
     _sscursor = AsyncAdapt_asyncmy_ss_cursor
 
     is_async = True
     has_terminate = True
 
     @classmethod
-    def import_dbapi(cls):
+    def import_dbapi(cls) -> AsyncAdapt_asyncmy_dbapi:  # type: ignore[override]  # noqa: E501
         return AsyncAdapt_asyncmy_dbapi(__import__("asyncmy"))
 
-    def do_terminate(self, dbapi_connection) -> None:
+    def do_terminate(self, dbapi_connection: AsyncmyPool) -> None:
         dbapi_connection.terminate()
 
-    def create_connect_args(self, url):
+    def create_connect_args(self, url: URL) -> ConnectArgsType:  # type: ignore[override]  # noqa: E501
         return super().create_connect_args(
             url, _translate_args=dict(username="user", database="db")
         )
 
-    def is_disconnect(self, e, connection, cursor):
+    def is_disconnect(
+        self, e: Exception, connection: Any, cursor: Any
+    ) -> bool:
         if super().is_disconnect(e, connection, cursor):
             return True
         else:
@@ -165,12 +197,14 @@ class MySQLDialect_asyncmy(MySQLDialect_pymysql):
                 "not connected" in str_e or "network operation failed" in str_e
             )
 
-    def _found_rows_client_flag(self):
+    def _found_rows_client_flag(self) -> int:
         from asyncmy.constants import CLIENT
 
-        return CLIENT.FOUND_ROWS
+        return CLIENT.FOUND_ROWS  # type: ignore[no-any-return]
 
-    def get_driver_connection(self, connection):
+    def get_driver_connection(  # type: ignore[override]
+        self, connection: AsyncAdapt_asyncmy_connection
+    ) -> AsyncmyConnection:
         return connection._connection
 
 

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -4,7 +4,6 @@
 #
 # This module is part of SQLAlchemy and is released under
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
-# mypy: ignore-errors
 
 
 r"""
@@ -1065,11 +1064,17 @@ output:
 """  # noqa
 from __future__ import annotations
 
-from array import array as _array
 from collections import defaultdict
 from itertools import compress
 import re
+from typing import Any
+from typing import Callable
 from typing import cast
+from typing import NoReturn
+from typing import Optional
+from typing import overload
+from typing import TYPE_CHECKING
+from typing import Union
 
 from . import reflection as _reflection
 from .enumerated import ENUM
@@ -1130,6 +1135,7 @@ from ...sql import roles
 from ...sql import sqltypes
 from ...sql import util as sql_util
 from ...sql import visitors
+from ...sql.base import ReadOnlyColumnCollection
 from ...sql.compiler import InsertmanyvaluesSentinelOpts
 from ...sql.compiler import SQLCompiler
 from ...sql.schema import SchemaConst
@@ -1137,9 +1143,53 @@ from ...types import BINARY
 from ...types import BLOB
 from ...types import BOOLEAN
 from ...types import DATE
+from ...types import LargeBinary
 from ...types import UUID
 from ...types import VARBINARY
 from ...util import topological
+
+if TYPE_CHECKING:
+    from typing import Sequence
+
+    from ...dialects.mysql import expression
+    from ...dialects.mysql.dml import DMLLimitClause
+    from ...dialects.mysql.dml import OnDuplicateClause
+    from ...engine.base import Connection
+    from ...engine.cursor import CursorResult
+    from ...engine.interfaces import DBAPIConnection
+    from ...engine.interfaces import DBAPICursor
+    from ...engine.interfaces import IsolationLevel
+    from ...engine.interfaces import ReflectedCheckConstraint
+    from ...engine.interfaces import ReflectedColumn
+    from ...engine.interfaces import ReflectedForeignKeyConstraint
+    from ...engine.interfaces import ReflectedIndex
+    from ...engine.interfaces import ReflectedPrimaryKeyConstraint
+    from ...engine.interfaces import ReflectedTableComment
+    from ...engine.interfaces import ReflectedUniqueConstraint
+    from ...engine.result import _Ts
+    from ...engine.row import Row
+    from ...engine.url import URL
+    from ...schema import Table
+    from ...sql import ddl
+    from ...sql import selectable
+    from ...sql.dml import _DMLTableElement
+    from ...sql.dml import Delete
+    from ...sql.dml import Update
+    from ...sql.dml import ValuesBase
+    from ...sql.functions import aggregate_strings
+    from ...sql.functions import random
+    from ...sql.functions import rollup
+    from ...sql.functions import sysdate
+    from ...sql.schema import Sequence as Sequence_SchemaItem
+    from ...sql.type_api import TypeEngine
+    from ...sql.visitors import ExternallyTraversible
+    from ...util.typing import TupleAny
+    from ...util.typing import Unpack
+
+    cols_type = Union[
+        Sequence[elements.KeyedColumnElement[Any]],
+        ReadOnlyColumnCollection[str, elements.KeyedColumnElement[Any]],
+    ]
 
 
 SET_RE = re.compile(
@@ -1236,7 +1286,7 @@ ischema_names = {
 
 
 class MySQLExecutionContext(default.DefaultExecutionContext):
-    def post_exec(self):
+    def post_exec(self) -> None:
         if (
             self.isdelete
             and cast(SQLCompiler, self.compiled).effective_returning
@@ -1253,7 +1303,7 @@ class MySQLExecutionContext(default.DefaultExecutionContext):
                 _cursor.FullyBufferedCursorFetchStrategy(
                     self.cursor,
                     [
-                        (entry.keyname, None)
+                        (entry.keyname, None)  # type: ignore[misc]
                         for entry in cast(
                             SQLCompiler, self.compiled
                         )._result_columns
@@ -1262,14 +1312,18 @@ class MySQLExecutionContext(default.DefaultExecutionContext):
                 )
             )
 
-    def create_server_side_cursor(self):
+    def create_server_side_cursor(self) -> DBAPICursor:
         if self.dialect.supports_server_side_cursors:
-            return self._dbapi_connection.cursor(self.dialect._sscursor)
+            return self._dbapi_connection.cursor(
+                self.dialect._sscursor  # type: ignore[attr-defined]
+            )
         else:
             raise NotImplementedError()
 
-    def fire_sequence(self, seq, type_):
-        return self._execute_scalar(
+    def fire_sequence(
+        self, seq: Sequence_SchemaItem, type_: sqltypes.Integer
+    ) -> int:
+        return self._execute_scalar(  # type: ignore[no-any-return]
             (
                 "select nextval(%s)"
                 % self.identifier_preparer.format_sequence(seq)
@@ -1279,46 +1333,51 @@ class MySQLExecutionContext(default.DefaultExecutionContext):
 
 
 class MySQLCompiler(compiler.SQLCompiler):
+    dialect: MySQLDialect
     render_table_with_column_in_update_from = True
     """Overridden from base SQLCompiler value"""
 
     extract_map = compiler.SQLCompiler.extract_map.copy()
     extract_map.update({"milliseconds": "millisecond"})
 
-    def default_from(self):
+    def default_from(self) -> str:
         """Called when a ``SELECT`` statement has no froms,
         and no ``FROM`` clause is to be appended.
 
         """
         if self.stack:
             stmt = self.stack[-1]["selectable"]
-            if stmt._where_criteria:
+            if stmt._where_criteria:  # type: ignore[attr-defined]
                 return " FROM DUAL"
 
         return ""
 
-    def visit_random_func(self, fn, **kw):
+    def visit_random_func(self, fn: random, **kw: Any) -> str:
         return "rand%s" % self.function_argspec(fn)
 
-    def visit_rollup_func(self, fn, **kw):
+    def visit_rollup_func(self, fn: rollup[Any], **kw: Any) -> str:
         clause = ", ".join(
             elem._compiler_dispatch(self, **kw) for elem in fn.clauses
         )
         return f"{clause} WITH ROLLUP"
 
-    def visit_aggregate_strings_func(self, fn, **kw):
+    def visit_aggregate_strings_func(
+        self, fn: aggregate_strings, **kw: Any
+    ) -> str:
         expr, delimeter = (
             elem._compiler_dispatch(self, **kw) for elem in fn.clauses
         )
         return f"group_concat({expr} SEPARATOR {delimeter})"
 
-    def visit_sequence(self, seq, **kw):
-        return "nextval(%s)" % self.preparer.format_sequence(seq)
+    def visit_sequence(self, sequence: sa_schema.Sequence, **kw: Any) -> str:
+        return "nextval(%s)" % self.preparer.format_sequence(sequence)
 
-    def visit_sysdate_func(self, fn, **kw):
+    def visit_sysdate_func(self, fn: sysdate, **kw: Any) -> str:
         return "SYSDATE()"
 
-    def _render_json_extract_from_binary(self, binary, operator, **kw):
+    def _render_json_extract_from_binary(
+        self, binary: elements.BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         # note we are intentionally calling upon the process() calls in the
         # order in which they appear in the SQL String as this is used
         # by positional parameter rendering
@@ -1345,9 +1404,10 @@ class MySQLCompiler(compiler.SQLCompiler):
                 )
             )
         elif binary.type._type_affinity in (sqltypes.Numeric, sqltypes.Float):
+            binary_type = cast(sqltypes.Numeric[Any], binary.type)
             if (
-                binary.type.scale is not None
-                and binary.type.precision is not None
+                binary_type.scale is not None
+                and binary_type.precision is not None
             ):
                 # using DECIMAL here because MySQL does not recognize NUMERIC
                 type_expression = (
@@ -1355,8 +1415,8 @@ class MySQLCompiler(compiler.SQLCompiler):
                     % (
                         self.process(binary.left, **kw),
                         self.process(binary.right, **kw),
-                        binary.type.precision,
-                        binary.type.scale,
+                        binary_type.precision,
+                        binary_type.scale,
                     )
                 )
             else:
@@ -1390,14 +1450,20 @@ class MySQLCompiler(compiler.SQLCompiler):
 
         return case_expression + " " + type_expression + " END"
 
-    def visit_json_getitem_op_binary(self, binary, operator, **kw):
+    def visit_json_getitem_op_binary(
+        self, binary: elements.BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         return self._render_json_extract_from_binary(binary, operator, **kw)
 
-    def visit_json_path_getitem_op_binary(self, binary, operator, **kw):
+    def visit_json_path_getitem_op_binary(
+        self, binary: elements.BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         return self._render_json_extract_from_binary(binary, operator, **kw)
 
-    def visit_on_duplicate_key_update(self, on_duplicate, **kw):
-        statement = self.current_executable
+    def visit_on_duplicate_key_update(
+        self, on_duplicate: OnDuplicateClause, **kw: Any
+    ) -> str:
+        statement: ValuesBase = self.current_executable
 
         if on_duplicate._parameter_ordering:
             parameter_ordering = [
@@ -1405,7 +1471,7 @@ class MySQLCompiler(compiler.SQLCompiler):
                 for key in on_duplicate._parameter_ordering
             ]
             ordered_keys = set(parameter_ordering)
-            cols = [
+            cols: cols_type = [
                 statement.table.c[key]
                 for key in parameter_ordering
                 if key in statement.table.c
@@ -1420,7 +1486,7 @@ class MySQLCompiler(compiler.SQLCompiler):
         )
 
         if requires_mysql8_alias:
-            if statement.table.name.lower() == "new":
+            if statement.table.name.lower() == "new":  # type: ignore[union-attr]  # noqa: E501
                 _on_dup_alias_name = "new_1"
             else:
                 _on_dup_alias_name = "new"
@@ -1434,24 +1500,26 @@ class MySQLCompiler(compiler.SQLCompiler):
         for column in (col for col in cols if col.key in on_duplicate_update):
             val = on_duplicate_update[column.key]
 
-            def replace(obj):
+            def replace(
+                element: ExternallyTraversible, **kw: Any
+            ) -> Optional[ExternallyTraversible]:
                 if (
-                    isinstance(obj, elements.BindParameter)
-                    and obj.type._isnull
+                    isinstance(element, elements.BindParameter)
+                    and element.type._isnull
                 ):
-                    return obj._with_binary_element_type(column.type)
+                    return element._with_binary_element_type(column.type)
                 elif (
-                    isinstance(obj, elements.ColumnClause)
-                    and obj.table is on_duplicate.inserted_alias
+                    isinstance(element, elements.ColumnClause)
+                    and element.table is on_duplicate.inserted_alias
                 ):
                     if requires_mysql8_alias:
                         column_literal_clause = (
                             f"{_on_dup_alias_name}."
-                            f"{self.preparer.quote(obj.name)}"
+                            f"{self.preparer.quote(element.name)}"
                         )
                     else:
                         column_literal_clause = (
-                            f"VALUES({self.preparer.quote(obj.name)})"
+                            f"VALUES({self.preparer.quote(element.name)})"
                         )
                     return literal_column(column_literal_clause)
                 else:
@@ -1470,7 +1538,7 @@ class MySQLCompiler(compiler.SQLCompiler):
                 "Additional column names not matching "
                 "any column keys in table '%s': %s"
                 % (
-                    self.statement.table.name,
+                    self.statement.table.name,  # type: ignore[union-attr]
                     (", ".join("'%s'" % c for c in non_matching)),
                 )
             )
@@ -1484,13 +1552,15 @@ class MySQLCompiler(compiler.SQLCompiler):
             return f"ON DUPLICATE KEY UPDATE {', '.join(clauses)}"
 
     def visit_concat_op_expression_clauselist(
-        self, clauselist, operator, **kw
-    ):
+        self, clauselist: elements.ClauseList, operator: Any, **kw: Any
+    ) -> str:
         return "concat(%s)" % (
             ", ".join(self.process(elem, **kw) for elem in clauselist.clauses)
         )
 
-    def visit_concat_op_binary(self, binary, operator, **kw):
+    def visit_concat_op_binary(
+        self, binary: elements.BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         return "concat(%s, %s)" % (
             self.process(binary.left, **kw),
             self.process(binary.right, **kw),
@@ -1513,10 +1583,12 @@ class MySQLCompiler(compiler.SQLCompiler):
         "WITH QUERY EXPANSION",
     )
 
-    def visit_mysql_match(self, element, **kw):
+    def visit_mysql_match(self, element: expression.match, **kw: Any) -> str:
         return self.visit_match_op_binary(element, element.operator, **kw)
 
-    def visit_match_op_binary(self, binary, operator, **kw):
+    def visit_match_op_binary(
+        self, binary: expression.match, operator: Any, **kw: Any
+    ) -> str:
         """
         Note that `mysql_boolean_mode` is enabled by default because of
         backward compatibility
@@ -1537,12 +1609,11 @@ class MySQLCompiler(compiler.SQLCompiler):
                 "with_query_expansion=%s" % query_expansion,
             )
 
-            flags = ", ".join(flags)
+            flags_str = ", ".join(flags)
 
-            raise exc.CompileError("Invalid MySQL match flags: %s" % flags)
+            raise exc.CompileError("Invalid MySQL match flags: %s" % flags_str)
 
-        match_clause = binary.left
-        match_clause = self.process(match_clause, **kw)
+        match_clause = self.process(binary.left, **kw)
         against_clause = self.process(binary.right, **kw)
 
         if any(flag_combination):
@@ -1551,21 +1622,25 @@ class MySQLCompiler(compiler.SQLCompiler):
                 flag_combination,
             )
 
-            against_clause = [against_clause]
-            against_clause.extend(flag_expressions)
-
-            against_clause = " ".join(against_clause)
+            against_clause = " ".join([against_clause, *flag_expressions])
 
         return "MATCH (%s) AGAINST (%s)" % (match_clause, against_clause)
 
-    def get_from_hint_text(self, table, text):
+    def get_from_hint_text(
+        self, table: selectable.FromClause, text: Optional[str]
+    ) -> Optional[str]:
         return text
 
-    def visit_typeclause(self, typeclause, type_=None, **kw):
+    def visit_typeclause(
+        self,
+        typeclause: elements.TypeClause,
+        type_: Optional[TypeEngine[Any]] = None,
+        **kw: Any,
+    ) -> Optional[str]:
         if type_ is None:
             type_ = typeclause.type.dialect_impl(self.dialect)
         if isinstance(type_, sqltypes.TypeDecorator):
-            return self.visit_typeclause(typeclause, type_.impl, **kw)
+            return self.visit_typeclause(typeclause, type_.impl, **kw)  # type: ignore[arg-type]  # noqa: E501
         elif isinstance(type_, sqltypes.Integer):
             if getattr(type_, "unsigned", False):
                 return "UNSIGNED INTEGER"
@@ -1604,7 +1679,7 @@ class MySQLCompiler(compiler.SQLCompiler):
         else:
             return None
 
-    def visit_cast(self, cast, **kw):
+    def visit_cast(self, cast: elements.Cast[Any], **kw: Any) -> str:
         type_ = self.process(cast.typeclause)
         if type_ is None:
             util.warn(
@@ -1618,7 +1693,9 @@ class MySQLCompiler(compiler.SQLCompiler):
 
         return "CAST(%s AS %s)" % (self.process(cast.clause, **kw), type_)
 
-    def render_literal_value(self, value, type_):
+    def render_literal_value(
+        self, value: Optional[str], type_: TypeEngine[Any]
+    ) -> str:
         value = super().render_literal_value(value, type_)
         if self.dialect._backslash_escapes:
             value = value.replace("\\", "\\\\")
@@ -1626,13 +1703,15 @@ class MySQLCompiler(compiler.SQLCompiler):
 
     # override native_boolean=False behavior here, as
     # MySQL still supports native boolean
-    def visit_true(self, element, **kw):
+    def visit_true(self, expr: elements.True_, **kw: Any) -> str:
         return "true"
 
-    def visit_false(self, element, **kw):
+    def visit_false(self, expr: elements.False_, **kw: Any) -> str:
         return "false"
 
-    def get_select_precolumns(self, select, **kw):
+    def get_select_precolumns(
+        self, select: selectable.Select[Any], **kw: Any
+    ) -> str:
         """Add special MySQL keywords in place of DISTINCT.
 
         .. deprecated:: 1.4 This usage is deprecated.
@@ -1652,7 +1731,13 @@ class MySQLCompiler(compiler.SQLCompiler):
 
         return super().get_select_precolumns(select, **kw)
 
-    def visit_join(self, join, asfrom=False, from_linter=None, **kwargs):
+    def visit_join(
+        self,
+        join: selectable.Join,
+        asfrom: bool = False,
+        from_linter: Optional[compiler.FromLinter] = None,
+        **kwargs: Any,
+    ) -> str:
         if from_linter:
             from_linter.edges.add((join.left, join.right))
 
@@ -1673,18 +1758,21 @@ class MySQLCompiler(compiler.SQLCompiler):
                     join.right, asfrom=True, from_linter=from_linter, **kwargs
                 ),
                 " ON ",
-                self.process(join.onclause, from_linter=from_linter, **kwargs),
+                self.process(join.onclause, from_linter=from_linter, **kwargs),  # type: ignore[arg-type]  # noqa: E501
             )
         )
 
-    def for_update_clause(self, select, **kw):
+    def for_update_clause(
+        self, select: selectable.GenerativeSelect, **kw: Any
+    ) -> str:
+        assert select._for_update_arg is not None
         if select._for_update_arg.read:
             tmp = " LOCK IN SHARE MODE"
         else:
             tmp = " FOR UPDATE"
 
         if select._for_update_arg.of and self.dialect.supports_for_update_of:
-            tables = util.OrderedSet()
+            tables: util.OrderedSet[elements.ClauseElement] = util.OrderedSet()
             for c in select._for_update_arg.of:
                 tables.update(sql_util.surface_selectables_only(c))
 
@@ -1701,7 +1789,9 @@ class MySQLCompiler(compiler.SQLCompiler):
 
         return tmp
 
-    def limit_clause(self, select, **kw):
+    def limit_clause(
+        self, select: selectable.GenerativeSelect, **kw: Any
+    ) -> str:
         # MySQL supports:
         #   LIMIT <limit>
         #   LIMIT <offset>, <limit>
@@ -1737,10 +1827,13 @@ class MySQLCompiler(compiler.SQLCompiler):
                     self.process(limit_clause, **kw),
                 )
         else:
+            assert limit_clause is not None
             # No offset provided, so just use the limit
             return " \n LIMIT %s" % (self.process(limit_clause, **kw),)
 
-    def update_post_criteria_clause(self, update_stmt, **kw):
+    def update_post_criteria_clause(
+        self, update_stmt: Update, **kw: Any
+    ) -> Optional[str]:
         limit = update_stmt.kwargs.get("%s_limit" % self.dialect.name, None)
         supertext = super().update_post_criteria_clause(update_stmt, **kw)
 
@@ -1753,7 +1846,9 @@ class MySQLCompiler(compiler.SQLCompiler):
         else:
             return supertext
 
-    def delete_post_criteria_clause(self, delete_stmt, **kw):
+    def delete_post_criteria_clause(
+        self, delete_stmt: Delete, **kw: Any
+    ) -> Optional[str]:
         limit = delete_stmt.kwargs.get("%s_limit" % self.dialect.name, None)
         supertext = super().delete_post_criteria_clause(delete_stmt, **kw)
 
@@ -1766,11 +1861,19 @@ class MySQLCompiler(compiler.SQLCompiler):
         else:
             return supertext
 
-    def visit_mysql_dml_limit_clause(self, element, **kw):
+    def visit_mysql_dml_limit_clause(
+        self, element: DMLLimitClause, **kw: Any
+    ) -> str:
         kw["literal_execute"] = True
         return f"LIMIT {self.process(element._limit_clause, **kw)}"
 
-    def update_tables_clause(self, update_stmt, from_table, extra_froms, **kw):
+    def update_tables_clause(
+        self,
+        update_stmt: Update,
+        from_table: _DMLTableElement,
+        extra_froms: list[selectable.FromClause],
+        **kw: Any,
+    ) -> str:
         kw["asfrom"] = True
         return ", ".join(
             t._compiler_dispatch(self, **kw)
@@ -1778,11 +1881,22 @@ class MySQLCompiler(compiler.SQLCompiler):
         )
 
     def update_from_clause(
-        self, update_stmt, from_table, extra_froms, from_hints, **kw
-    ):
+        self,
+        update_stmt: Update,
+        from_table: _DMLTableElement,
+        extra_froms: list[selectable.FromClause],
+        from_hints: Any,
+        **kw: Any,
+    ) -> None:
         return None
 
-    def delete_table_clause(self, delete_stmt, from_table, extra_froms, **kw):
+    def delete_table_clause(
+        self,
+        delete_stmt: Delete,
+        from_table: _DMLTableElement,
+        extra_froms: list[selectable.FromClause],
+        **kw: Any,
+    ) -> str:
         """If we have extra froms make sure we render any alias as hint."""
         ashint = False
         if extra_froms:
@@ -1792,8 +1906,13 @@ class MySQLCompiler(compiler.SQLCompiler):
         )
 
     def delete_extra_from_clause(
-        self, delete_stmt, from_table, extra_froms, from_hints, **kw
-    ):
+        self,
+        delete_stmt: Delete,
+        from_table: _DMLTableElement,
+        extra_froms: list[selectable.FromClause],
+        from_hints: Any,
+        **kw: Any,
+    ) -> str:
         """Render the DELETE .. USING clause specific to MySQL."""
         kw["asfrom"] = True
         return "USING " + ", ".join(
@@ -1801,7 +1920,9 @@ class MySQLCompiler(compiler.SQLCompiler):
             for t in [from_table] + extra_froms
         )
 
-    def visit_empty_set_expr(self, element_types, **kw):
+    def visit_empty_set_expr(
+        self, element_types: list[TypeEngine[Any]], **kw: Any
+    ) -> str:
         return (
             "SELECT %(outer)s FROM (SELECT %(inner)s) "
             "as _empty_set WHERE 1!=1"
@@ -1816,25 +1937,38 @@ class MySQLCompiler(compiler.SQLCompiler):
             }
         )
 
-    def visit_is_distinct_from_binary(self, binary, operator, **kw):
+    def visit_is_distinct_from_binary(
+        self, binary: elements.BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         return "NOT (%s <=> %s)" % (
             self.process(binary.left),
             self.process(binary.right),
         )
 
-    def visit_is_not_distinct_from_binary(self, binary, operator, **kw):
+    def visit_is_not_distinct_from_binary(
+        self, binary: elements.BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         return "%s <=> %s" % (
             self.process(binary.left),
             self.process(binary.right),
         )
 
-    def _mariadb_regexp_flags(self, flags, pattern, **kw):
+    def _mariadb_regexp_flags(
+        self, flags: str, pattern: elements.ColumnElement[Any], **kw: Any
+    ) -> str:
         return "CONCAT('(?', %s, ')', %s)" % (
             self.render_literal_value(flags, sqltypes.STRINGTYPE),
             self.process(pattern, **kw),
         )
 
-    def _regexp_match(self, op_string, binary, operator, **kw):
+    def _regexp_match(
+        self,
+        op_string: str,
+        binary: elements.BinaryExpression[Any],
+        operator: Any,
+        **kw: Any,
+    ) -> str:
+        assert binary.modifiers is not None
         flags = binary.modifiers["flags"]
         if flags is None:
             return self._generate_generic_binary(binary, op_string, **kw)
@@ -1855,13 +1989,20 @@ class MySQLCompiler(compiler.SQLCompiler):
             else:
                 return text
 
-    def visit_regexp_match_op_binary(self, binary, operator, **kw):
+    def visit_regexp_match_op_binary(
+        self, binary: elements.BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         return self._regexp_match(" REGEXP ", binary, operator, **kw)
 
-    def visit_not_regexp_match_op_binary(self, binary, operator, **kw):
+    def visit_not_regexp_match_op_binary(
+        self, binary: elements.BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         return self._regexp_match(" NOT REGEXP ", binary, operator, **kw)
 
-    def visit_regexp_replace_op_binary(self, binary, operator, **kw):
+    def visit_regexp_replace_op_binary(
+        self, binary: elements.BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
+        assert binary.modifiers is not None
         flags = binary.modifiers["flags"]
         if flags is None:
             return "REGEXP_REPLACE(%s, %s)" % (
@@ -1883,7 +2024,11 @@ class MySQLCompiler(compiler.SQLCompiler):
 
 
 class MySQLDDLCompiler(compiler.DDLCompiler):
-    def get_column_specification(self, column, **kw):
+    dialect: MySQLDialect
+
+    def get_column_specification(
+        self, column: sa_schema.Column[Any], **kw: Any
+    ) -> str:
         """Builds column DDL."""
         if (
             self.dialect.is_mariadb is True
@@ -1949,7 +2094,7 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
                     colspec.append("DEFAULT " + default)
         return " ".join(colspec)
 
-    def post_create_table(self, table):
+    def post_create_table(self, table: sa_schema.Table) -> str:
         """Build table-level CREATE options like ENGINE and COLLATE."""
 
         table_opts = []
@@ -2033,16 +2178,16 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
 
         return " ".join(table_opts)
 
-    def visit_create_index(self, create, **kw):
+    def visit_create_index(self, create: ddl.CreateIndex, **kw: Any) -> str:  # type: ignore[override]  # noqa: E501
         index = create.element
         self._verify_index_table(index)
         preparer = self.preparer
-        table = preparer.format_table(index.table)
+        table = preparer.format_table(index.table)  # type: ignore[arg-type]
 
         columns = [
             self.sql_compiler.process(
                 (
-                    elements.Grouping(expr)
+                    elements.Grouping(expr)  # type: ignore[arg-type]
                     if (
                         isinstance(expr, elements.BinaryExpression)
                         or (
@@ -2081,10 +2226,10 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
                 # length value can be a (column_name --> integer value)
                 # mapping specifying the prefix length for each column of the
                 # index
-                columns = ", ".join(
+                columns_str = ", ".join(
                     (
-                        "%s(%d)" % (expr, length[col.name])
-                        if col.name in length
+                        "%s(%d)" % (expr, length[col.name])  # type: ignore[union-attr]  # noqa: E501
+                        if col.name in length  # type: ignore[union-attr]
                         else (
                             "%s(%d)" % (expr, length[expr])
                             if expr in length
@@ -2096,12 +2241,12 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
             else:
                 # or can be an integer value specifying the same
                 # prefix length for all columns of the index
-                columns = ", ".join(
+                columns_str = ", ".join(
                     "%s(%d)" % (col, length) for col in columns
                 )
         else:
-            columns = ", ".join(columns)
-        text += "(%s)" % columns
+            columns_str = ", ".join(columns)
+        text += "(%s)" % columns_str
 
         parser = index.dialect_options["mysql"]["with_parser"]
         if parser is not None:
@@ -2113,14 +2258,16 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
 
         return text
 
-    def visit_primary_key_constraint(self, constraint, **kw):
+    def visit_primary_key_constraint(
+        self, constraint: sa_schema.PrimaryKeyConstraint, **kw: Any
+    ) -> str:
         text = super().visit_primary_key_constraint(constraint)
         using = constraint.dialect_options["mysql"]["using"]
         if using:
             text += " USING %s" % (self.preparer.quote(using))
         return text
 
-    def visit_drop_index(self, drop, **kw):
+    def visit_drop_index(self, drop: ddl.DropIndex, **kw: Any) -> str:
         index = drop.element
         text = "\nDROP INDEX "
         if drop.if_exists:
@@ -2128,10 +2275,12 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
 
         return text + "%s ON %s" % (
             self._prepared_index_name(index, include_schema=False),
-            self.preparer.format_table(index.table),
+            self.preparer.format_table(index.table),  # type: ignore[arg-type]
         )
 
-    def visit_drop_constraint(self, drop, **kw):
+    def visit_drop_constraint(
+        self, drop: ddl.DropConstraint, **kw: Any
+    ) -> str:
         constraint = drop.element
         if isinstance(constraint, sa_schema.ForeignKeyConstraint):
             qual = "FOREIGN KEY "
@@ -2157,7 +2306,9 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
             const,
         )
 
-    def define_constraint_match(self, constraint):
+    def define_constraint_match(
+        self, constraint: sa_schema.ForeignKeyConstraint
+    ) -> str:
         if constraint.match is not None:
             raise exc.CompileError(
                 "MySQL ignores the 'MATCH' keyword while at the same time "
@@ -2165,7 +2316,9 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
             )
         return ""
 
-    def visit_set_table_comment(self, create, **kw):
+    def visit_set_table_comment(
+        self, create: ddl.SetTableComment, **kw: Any
+    ) -> str:
         return "ALTER TABLE %s COMMENT %s" % (
             self.preparer.format_table(create.element),
             self.sql_compiler.render_literal_value(
@@ -2173,12 +2326,16 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
             ),
         )
 
-    def visit_drop_table_comment(self, create, **kw):
+    def visit_drop_table_comment(
+        self, drop: ddl.DropTableComment, **kw: Any
+    ) -> str:
         return "ALTER TABLE %s COMMENT ''" % (
-            self.preparer.format_table(create.element)
+            self.preparer.format_table(drop.element)
         )
 
-    def visit_set_column_comment(self, create, **kw):
+    def visit_set_column_comment(
+        self, create: ddl.SetColumnComment, **kw: Any
+    ) -> str:
         return "ALTER TABLE %s CHANGE %s %s" % (
             self.preparer.format_table(create.element.table),
             self.preparer.format_column(create.element),
@@ -2187,7 +2344,7 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
 
 
 class MySQLTypeCompiler(compiler.GenericTypeCompiler):
-    def _extend_numeric(self, type_, spec):
+    def _extend_numeric(self, type_: _NumericCommonType, spec: str) -> str:
         "Extend a numeric-type declaration with MySQL specific extensions."
 
         if not self._mysql_type(type_):
@@ -2199,13 +2356,15 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
             spec += " ZEROFILL"
         return spec
 
-    def _extend_string(self, type_, defaults, spec):
+    def _extend_string(
+        self, type_: _StringType, defaults: dict[str, Any], spec: str
+    ) -> str:
         """Extend a string-type declaration with standard SQL CHARACTER SET /
         COLLATE annotations and MySQL specific extensions.
 
         """
 
-        def attr(name):
+        def attr(name: str) -> Any:
             return getattr(type_, name, defaults.get(name))
 
         if attr("charset"):
@@ -2215,6 +2374,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
         elif attr("unicode"):
             charset = "UNICODE"
         else:
+
             charset = None
 
         if attr("collation"):
@@ -2233,10 +2393,10 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
             [c for c in (spec, charset, collation) if c is not None]
         )
 
-    def _mysql_type(self, type_):
+    def _mysql_type(self, type_: Any) -> bool:
         return isinstance(type_, (_StringType, _NumericCommonType))
 
-    def visit_NUMERIC(self, type_, **kw):
+    def visit_NUMERIC(self, type_: NUMERIC, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if type_.precision is None:
             return self._extend_numeric(type_, "NUMERIC")
         elif type_.scale is None:
@@ -2251,7 +2411,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
                 % {"precision": type_.precision, "scale": type_.scale},
             )
 
-    def visit_DECIMAL(self, type_, **kw):
+    def visit_DECIMAL(self, type_: DECIMAL, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if type_.precision is None:
             return self._extend_numeric(type_, "DECIMAL")
         elif type_.scale is None:
@@ -2266,7 +2426,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
                 % {"precision": type_.precision, "scale": type_.scale},
             )
 
-    def visit_DOUBLE(self, type_, **kw):
+    def visit_DOUBLE(self, type_: DOUBLE, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if type_.precision is not None and type_.scale is not None:
             return self._extend_numeric(
                 type_,
@@ -2276,7 +2436,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
         else:
             return self._extend_numeric(type_, "DOUBLE")
 
-    def visit_REAL(self, type_, **kw):
+    def visit_REAL(self, type_: REAL, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if type_.precision is not None and type_.scale is not None:
             return self._extend_numeric(
                 type_,
@@ -2286,7 +2446,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
         else:
             return self._extend_numeric(type_, "REAL")
 
-    def visit_FLOAT(self, type_, **kw):
+    def visit_FLOAT(self, type_: FLOAT, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if (
             self._mysql_type(type_)
             and type_.scale is not None
@@ -2302,7 +2462,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
         else:
             return self._extend_numeric(type_, "FLOAT")
 
-    def visit_INTEGER(self, type_, **kw):
+    def visit_INTEGER(self, type_: INTEGER, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if self._mysql_type(type_) and type_.display_width is not None:
             return self._extend_numeric(
                 type_,
@@ -2312,7 +2472,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
         else:
             return self._extend_numeric(type_, "INTEGER")
 
-    def visit_BIGINT(self, type_, **kw):
+    def visit_BIGINT(self, type_: BIGINT, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if self._mysql_type(type_) and type_.display_width is not None:
             return self._extend_numeric(
                 type_,
@@ -2322,7 +2482,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
         else:
             return self._extend_numeric(type_, "BIGINT")
 
-    def visit_MEDIUMINT(self, type_, **kw):
+    def visit_MEDIUMINT(self, type_: MEDIUMINT, **kw: Any) -> str:
         if self._mysql_type(type_) and type_.display_width is not None:
             return self._extend_numeric(
                 type_,
@@ -2332,7 +2492,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
         else:
             return self._extend_numeric(type_, "MEDIUMINT")
 
-    def visit_TINYINT(self, type_, **kw):
+    def visit_TINYINT(self, type_: TINYINT, **kw: Any) -> str:
         if self._mysql_type(type_) and type_.display_width is not None:
             return self._extend_numeric(
                 type_, "TINYINT(%s)" % type_.display_width
@@ -2340,7 +2500,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
         else:
             return self._extend_numeric(type_, "TINYINT")
 
-    def visit_SMALLINT(self, type_, **kw):
+    def visit_SMALLINT(self, type_: SMALLINT, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if self._mysql_type(type_) and type_.display_width is not None:
             return self._extend_numeric(
                 type_,
@@ -2350,55 +2510,55 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
         else:
             return self._extend_numeric(type_, "SMALLINT")
 
-    def visit_BIT(self, type_, **kw):
+    def visit_BIT(self, type_: BIT, **kw: Any) -> str:
         if type_.length is not None:
             return "BIT(%s)" % type_.length
         else:
             return "BIT"
 
-    def visit_DATETIME(self, type_, **kw):
+    def visit_DATETIME(self, type_: DATETIME, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if getattr(type_, "fsp", None):
-            return "DATETIME(%d)" % type_.fsp
+            return "DATETIME(%d)" % type_.fsp  # type: ignore[str-format]
         else:
             return "DATETIME"
 
-    def visit_DATE(self, type_, **kw):
+    def visit_DATE(self, type_: DATE, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         return "DATE"
 
-    def visit_TIME(self, type_, **kw):
+    def visit_TIME(self, type_: TIME, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if getattr(type_, "fsp", None):
-            return "TIME(%d)" % type_.fsp
+            return "TIME(%d)" % type_.fsp  # type: ignore[str-format]
         else:
             return "TIME"
 
-    def visit_TIMESTAMP(self, type_, **kw):
+    def visit_TIMESTAMP(self, type_: TIMESTAMP, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if getattr(type_, "fsp", None):
-            return "TIMESTAMP(%d)" % type_.fsp
+            return "TIMESTAMP(%d)" % type_.fsp  # type: ignore[str-format]
         else:
             return "TIMESTAMP"
 
-    def visit_YEAR(self, type_, **kw):
+    def visit_YEAR(self, type_: YEAR, **kw: Any) -> str:
         if type_.display_width is None:
             return "YEAR"
         else:
             return "YEAR(%s)" % type_.display_width
 
-    def visit_TEXT(self, type_, **kw):
+    def visit_TEXT(self, type_: TEXT, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if type_.length is not None:
             return self._extend_string(type_, {}, "TEXT(%d)" % type_.length)
         else:
             return self._extend_string(type_, {}, "TEXT")
 
-    def visit_TINYTEXT(self, type_, **kw):
+    def visit_TINYTEXT(self, type_: TINYTEXT, **kw: Any) -> str:
         return self._extend_string(type_, {}, "TINYTEXT")
 
-    def visit_MEDIUMTEXT(self, type_, **kw):
+    def visit_MEDIUMTEXT(self, type_: MEDIUMTEXT, **kw: Any) -> str:
         return self._extend_string(type_, {}, "MEDIUMTEXT")
 
-    def visit_LONGTEXT(self, type_, **kw):
+    def visit_LONGTEXT(self, type_: LONGTEXT, **kw: Any) -> str:
         return self._extend_string(type_, {}, "LONGTEXT")
 
-    def visit_VARCHAR(self, type_, **kw):
+    def visit_VARCHAR(self, type_: VARCHAR, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if type_.length is not None:
             return self._extend_string(type_, {}, "VARCHAR(%d)" % type_.length)
         else:
@@ -2406,7 +2566,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
                 "VARCHAR requires a length on dialect %s" % self.dialect.name
             )
 
-    def visit_CHAR(self, type_, **kw):
+    def visit_CHAR(self, type_: CHAR, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if type_.length is not None:
             return self._extend_string(
                 type_, {}, "CHAR(%(length)s)" % {"length": type_.length}
@@ -2414,7 +2574,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
         else:
             return self._extend_string(type_, {}, "CHAR")
 
-    def visit_NVARCHAR(self, type_, **kw):
+    def visit_NVARCHAR(self, type_: NVARCHAR, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         # We'll actually generate the equiv. "NATIONAL VARCHAR" instead
         # of "NVARCHAR".
         if type_.length is not None:
@@ -2428,7 +2588,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
                 "NVARCHAR requires a length on dialect %s" % self.dialect.name
             )
 
-    def visit_NCHAR(self, type_, **kw):
+    def visit_NCHAR(self, type_: NCHAR, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         # We'll actually generate the equiv.
         # "NATIONAL CHAR" instead of "NCHAR".
         if type_.length is not None:
@@ -2440,40 +2600,42 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
         else:
             return self._extend_string(type_, {"national": True}, "CHAR")
 
-    def visit_UUID(self, type_, **kw):
+    def visit_UUID(self, type_: UUID[Any], **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         return "UUID"
 
-    def visit_VARBINARY(self, type_, **kw):
-        return "VARBINARY(%d)" % type_.length
+    def visit_VARBINARY(self, type_: VARBINARY, **kw: Any) -> str:
+        return "VARBINARY(%d)" % type_.length  # type: ignore[str-format]
 
-    def visit_JSON(self, type_, **kw):
+    def visit_JSON(self, type_: JSON, **kw: Any) -> str:
         return "JSON"
 
-    def visit_large_binary(self, type_, **kw):
+    def visit_large_binary(self, type_: LargeBinary, **kw: Any) -> str:
         return self.visit_BLOB(type_)
 
-    def visit_enum(self, type_, **kw):
+    def visit_enum(self, type_: ENUM, **kw: Any) -> str:  # type: ignore[override]  # NOQA: E501
         if not type_.native_enum:
             return super().visit_enum(type_)
         else:
             return self._visit_enumerated_values("ENUM", type_, type_.enums)
 
-    def visit_BLOB(self, type_, **kw):
+    def visit_BLOB(self, type_: LargeBinary, **kw: Any) -> str:
         if type_.length is not None:
             return "BLOB(%d)" % type_.length
         else:
             return "BLOB"
 
-    def visit_TINYBLOB(self, type_, **kw):
+    def visit_TINYBLOB(self, type_: TINYBLOB, **kw: Any) -> str:
         return "TINYBLOB"
 
-    def visit_MEDIUMBLOB(self, type_, **kw):
+    def visit_MEDIUMBLOB(self, type_: MEDIUMBLOB, **kw: Any) -> str:
         return "MEDIUMBLOB"
 
-    def visit_LONGBLOB(self, type_, **kw):
+    def visit_LONGBLOB(self, type_: LONGBLOB, **kw: Any) -> str:
         return "LONGBLOB"
 
-    def _visit_enumerated_values(self, name, type_, enumerated_values):
+    def _visit_enumerated_values(
+        self, name: str, type_: _StringType, enumerated_values: Sequence[str]
+    ) -> str:
         quoted_enums = []
         for e in enumerated_values:
             if self.dialect.identifier_preparer._double_percents:
@@ -2483,20 +2645,25 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
             type_, {}, "%s(%s)" % (name, ",".join(quoted_enums))
         )
 
-    def visit_ENUM(self, type_, **kw):
+    def visit_ENUM(self, type_: ENUM, **kw: Any) -> str:
         return self._visit_enumerated_values("ENUM", type_, type_.enums)
 
-    def visit_SET(self, type_, **kw):
+    def visit_SET(self, type_: SET, **kw: Any) -> str:
         return self._visit_enumerated_values("SET", type_, type_.values)
 
-    def visit_BOOLEAN(self, type_, **kw):
+    def visit_BOOLEAN(self, type_: sqltypes.Boolean, **kw: Any) -> str:
         return "BOOL"
 
 
 class MySQLIdentifierPreparer(compiler.IdentifierPreparer):
     reserved_words = RESERVED_WORDS_MYSQL
 
-    def __init__(self, dialect, server_ansiquotes=False, **kw):
+    def __init__(
+        self,
+        dialect: default.DefaultDialect,
+        server_ansiquotes: bool = False,
+        **kw: Any,
+    ):
         if not server_ansiquotes:
             quote = "`"
         else:
@@ -2504,7 +2671,7 @@ class MySQLIdentifierPreparer(compiler.IdentifierPreparer):
 
         super().__init__(dialect, initial_quote=quote, escape_quote=quote)
 
-    def _quote_free_identifiers(self, *ids):
+    def _quote_free_identifiers(self, *ids: Optional[str]) -> tuple[str, ...]:
         """Unilaterally identifier-quote any number of strings."""
 
         return tuple([self.quote_identifier(i) for i in ids if i is not None])
@@ -2515,7 +2682,7 @@ class MariaDBIdentifierPreparer(MySQLIdentifierPreparer):
 
 
 @log.class_logger
-class MySQLDialect(default.DefaultDialect):
+class MySQLDialect(default.DefaultDialect, log.Identified):
     """Details of the MySQL dialect.
     Not used directly in application code.
     """
@@ -2581,9 +2748,9 @@ class MySQLDialect(default.DefaultDialect):
     ddl_compiler = MySQLDDLCompiler
     type_compiler_cls = MySQLTypeCompiler
     ischema_names = ischema_names
-    preparer = MySQLIdentifierPreparer
+    preparer: type[MySQLIdentifierPreparer] = MySQLIdentifierPreparer
 
-    is_mariadb = False
+    is_mariadb: bool = False
     _mariadb_normalized_version_info = None
 
     # default SQL compilation settings -
@@ -2591,6 +2758,9 @@ class MySQLDialect(default.DefaultDialect):
     # i.e. first connect
     _backslash_escapes = True
     _server_ansiquotes = False
+
+    server_version_info: tuple[int, ...]
+    identifier_preparer: MySQLIdentifierPreparer
 
     construct_arguments = [
         (sa_schema.Table, {"*": None}),
@@ -2610,18 +2780,20 @@ class MySQLDialect(default.DefaultDialect):
 
     def __init__(
         self,
-        json_serializer=None,
-        json_deserializer=None,
-        is_mariadb=None,
-        **kwargs,
-    ):
+        json_serializer: Optional[Callable[..., Any]] = None,
+        json_deserializer: Optional[Callable[..., Any]] = None,
+        is_mariadb: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> None:
         kwargs.pop("use_ansiquotes", None)  # legacy
         default.DefaultDialect.__init__(self, **kwargs)
         self._json_serializer = json_serializer
         self._json_deserializer = json_deserializer
-        self._set_mariadb(is_mariadb, None)
+        self._set_mariadb(is_mariadb, ())
 
-    def get_isolation_level_values(self, dbapi_conn):
+    def get_isolation_level_values(
+        self, dbapi_conn: DBAPIConnection
+    ) -> Sequence[IsolationLevel]:
         return (
             "SERIALIZABLE",
             "READ UNCOMMITTED",
@@ -2629,13 +2801,17 @@ class MySQLDialect(default.DefaultDialect):
             "REPEATABLE READ",
         )
 
-    def set_isolation_level(self, dbapi_connection, level):
+    def set_isolation_level(
+        self, dbapi_connection: DBAPIConnection, level: IsolationLevel
+    ) -> None:
         cursor = dbapi_connection.cursor()
         cursor.execute(f"SET SESSION TRANSACTION ISOLATION LEVEL {level}")
         cursor.execute("COMMIT")
         cursor.close()
 
-    def get_isolation_level(self, dbapi_connection):
+    def get_isolation_level(
+        self, dbapi_connection: DBAPIConnection
+    ) -> IsolationLevel:
         cursor = dbapi_connection.cursor()
         if self._is_mysql and self.server_version_info >= (5, 7, 20):
             cursor.execute("SELECT @@transaction_isolation")
@@ -2652,10 +2828,10 @@ class MySQLDialect(default.DefaultDialect):
         cursor.close()
         if isinstance(val, bytes):
             val = val.decode()
-        return val.upper().replace("-", " ")
+        return val.upper().replace("-", " ")  # type: ignore[no-any-return]
 
     @classmethod
-    def _is_mariadb_from_url(cls, url):
+    def _is_mariadb_from_url(cls, url: URL) -> bool:
         dbapi = cls.import_dbapi()
         dialect = cls(dbapi=dbapi)
 
@@ -2664,7 +2840,7 @@ class MySQLDialect(default.DefaultDialect):
         try:
             cursor = conn.cursor()
             cursor.execute("SELECT VERSION() LIKE '%MariaDB%'")
-            val = cursor.fetchone()[0]
+            val = cursor.fetchone()[0]  # type: ignore[index]
         except:
             raise
         else:
@@ -2672,22 +2848,25 @@ class MySQLDialect(default.DefaultDialect):
         finally:
             conn.close()
 
-    def _get_server_version_info(self, connection):
+    def _get_server_version_info(
+        self, connection: Connection
+    ) -> tuple[int, ...]:
         # get database server version info explicitly over the wire
         # to avoid proxy servers like MaxScale getting in the
         # way with their own values, see #4205
         dbapi_con = connection.connection
         cursor = dbapi_con.cursor()
         cursor.execute("SELECT VERSION()")
-        val = cursor.fetchone()[0]
+
+        val = cursor.fetchone()[0]  # type: ignore[index]
         cursor.close()
         if isinstance(val, bytes):
             val = val.decode()
 
         return self._parse_server_version(val)
 
-    def _parse_server_version(self, val):
-        version = []
+    def _parse_server_version(self, val: str) -> tuple[int, ...]:
+        version: list[int] = []
         is_mariadb = False
 
         r = re.compile(r"[.\-+]")
@@ -2708,7 +2887,7 @@ class MySQLDialect(default.DefaultDialect):
         server_version_info = tuple(version)
 
         self._set_mariadb(
-            server_version_info and is_mariadb, server_version_info
+            bool(server_version_info and is_mariadb), server_version_info
         )
 
         if not is_mariadb:
@@ -2724,7 +2903,9 @@ class MySQLDialect(default.DefaultDialect):
         self.server_version_info = server_version_info
         return server_version_info
 
-    def _set_mariadb(self, is_mariadb, server_version_info):
+    def _set_mariadb(
+        self, is_mariadb: Optional[bool], server_version_info: tuple[int, ...]
+    ) -> None:
         if is_mariadb is None:
             return
 
@@ -2748,38 +2929,48 @@ class MySQLDialect(default.DefaultDialect):
 
         self.is_mariadb = is_mariadb
 
-    def do_begin_twophase(self, connection, xid):
+    def do_begin_twophase(self, connection: Connection, xid: Any) -> None:
         connection.execute(sql.text("XA BEGIN :xid"), dict(xid=xid))
 
-    def do_prepare_twophase(self, connection, xid):
+    def do_prepare_twophase(self, connection: Connection, xid: Any) -> None:
         connection.execute(sql.text("XA END :xid"), dict(xid=xid))
         connection.execute(sql.text("XA PREPARE :xid"), dict(xid=xid))
 
     def do_rollback_twophase(
-        self, connection, xid, is_prepared=True, recover=False
-    ):
+        self,
+        connection: Connection,
+        xid: Any,
+        is_prepared: bool = True,
+        recover: bool = False,
+    ) -> None:
         if not is_prepared:
             connection.execute(sql.text("XA END :xid"), dict(xid=xid))
         connection.execute(sql.text("XA ROLLBACK :xid"), dict(xid=xid))
 
     def do_commit_twophase(
-        self, connection, xid, is_prepared=True, recover=False
-    ):
+        self,
+        connection: Connection,
+        xid: Any,
+        is_prepared: bool = True,
+        recover: bool = False,
+    ) -> None:
         if not is_prepared:
             self.do_prepare_twophase(connection, xid)
         connection.execute(sql.text("XA COMMIT :xid"), dict(xid=xid))
 
-    def do_recover_twophase(self, connection):
+    def do_recover_twophase(self, connection: Connection) -> list[Any]:
         resultset = connection.exec_driver_sql("XA RECOVER")
         return [row["data"][0 : row["gtrid_length"]] for row in resultset]
 
-    def is_disconnect(self, e, connection, cursor):
+    def is_disconnect(
+        self, e: Exception, connection: Any, cursor: Any
+    ) -> bool:
         if isinstance(
             e,
             (
-                self.dbapi.OperationalError,
-                self.dbapi.ProgrammingError,
-                self.dbapi.InterfaceError,
+                self.dbapi.OperationalError,  # type: ignore
+                self.dbapi.ProgrammingError,  # type: ignore
+                self.dbapi.InterfaceError,  # type: ignore
             ),
         ) and self._extract_error_code(e) in (
             1927,
@@ -2792,7 +2983,7 @@ class MySQLDialect(default.DefaultDialect):
         ):
             return True
         elif isinstance(
-            e, (self.dbapi.InterfaceError, self.dbapi.InternalError)
+            e, (self.dbapi.InterfaceError, self.dbapi.InternalError)  # type: ignore  # noqa: E501
         ):
             # if underlying connection is closed,
             # this is the error you get
@@ -2800,13 +2991,17 @@ class MySQLDialect(default.DefaultDialect):
         else:
             return False
 
-    def _compat_fetchall(self, rp, charset=None):
+    def _compat_fetchall(
+        self, rp: CursorResult[Unpack[TupleAny]], charset: Optional[str] = None
+    ) -> Union[Sequence[Row[Unpack[TupleAny]]], Sequence[_DecodingRow]]:
         """Proxy result rows to smooth over MySQL-Python driver
         inconsistencies."""
 
         return [_DecodingRow(row, charset) for row in rp.fetchall()]
 
-    def _compat_fetchone(self, rp, charset=None):
+    def _compat_fetchone(
+        self, rp: CursorResult[Unpack[TupleAny]], charset: Optional[str] = None
+    ) -> Union[Row[Unpack[TupleAny]], None, _DecodingRow]:
         """Proxy a result row to smooth over MySQL-Python driver
         inconsistencies."""
 
@@ -2816,7 +3011,9 @@ class MySQLDialect(default.DefaultDialect):
         else:
             return None
 
-    def _compat_first(self, rp, charset=None):
+    def _compat_first(
+        self, rp: CursorResult[Unpack[TupleAny]], charset: Optional[str] = None
+    ) -> Optional[_DecodingRow]:
         """Proxy a result row to smooth over MySQL-Python driver
         inconsistencies."""
 
@@ -2826,14 +3023,20 @@ class MySQLDialect(default.DefaultDialect):
         else:
             return None
 
-    def _extract_error_code(self, exception):
+    def _extract_error_code(self, exception: BaseException) -> Optional[int]:
         raise NotImplementedError()
 
-    def _get_default_schema_name(self, connection):
-        return connection.exec_driver_sql("SELECT DATABASE()").scalar()
+    def _get_default_schema_name(self, connection: Connection) -> str:
+        return connection.exec_driver_sql("SELECT DATABASE()").scalar()  # type: ignore[return-value]  # noqa: E501
 
     @reflection.cache
-    def has_table(self, connection, table_name, schema=None, **kw):
+    def has_table(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> bool:
         self._ensure_has_table_connection(connection)
 
         if schema is None:
@@ -2874,12 +3077,18 @@ class MySQLDialect(default.DefaultDialect):
             #
             # there's more "doesn't exist" kinds of messages but they are
             # less clear if mysql 8 would suddenly start using one of those
-            if self._extract_error_code(e.orig) in (1146, 1049, 1051):
+            if self._extract_error_code(e.orig) in (1146, 1049, 1051):  # type: ignore  # noqa: E501
                 return False
             raise
 
     @reflection.cache
-    def has_sequence(self, connection, sequence_name, schema=None, **kw):
+    def has_sequence(
+        self,
+        connection: Connection,
+        sequence_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> bool:
         if not self.supports_sequences:
             self._sequences_not_supported()
         if not schema:
@@ -2899,14 +3108,16 @@ class MySQLDialect(default.DefaultDialect):
         )
         return cursor.first() is not None
 
-    def _sequences_not_supported(self):
+    def _sequences_not_supported(self) -> NoReturn:
         raise NotImplementedError(
             "Sequences are supported only by the "
             "MariaDB series 10.3 or greater"
         )
 
     @reflection.cache
-    def get_sequence_names(self, connection, schema=None, **kw):
+    def get_sequence_names(
+        self, connection: Connection, schema: Optional[str] = None, **kw: Any
+    ) -> list[str]:
         if not self.supports_sequences:
             self._sequences_not_supported()
         if not schema:
@@ -2926,10 +3137,12 @@ class MySQLDialect(default.DefaultDialect):
             )
         ]
 
-    def initialize(self, connection):
+    def initialize(self, connection: Connection) -> None:
         # this is driver-based, does not need server version info
         # and is fairly critical for even basic SQL operations
-        self._connection_charset = self._detect_charset(connection)
+        self._connection_charset: Optional[str] = self._detect_charset(
+            connection
+        )
 
         # call super().initialize() because we need to have
         # server_version_info set up.  in 1.4 under python 2 only this does the
@@ -2973,9 +3186,10 @@ class MySQLDialect(default.DefaultDialect):
 
         self._warn_for_known_db_issues()
 
-    def _warn_for_known_db_issues(self):
+    def _warn_for_known_db_issues(self) -> None:
         if self.is_mariadb:
             mdb_version = self._mariadb_normalized_version_info
+            assert mdb_version is not None
             if mdb_version > (10, 2) and mdb_version < (10, 2, 9):
                 util.warn(
                     "MariaDB %r before 10.2.9 has known issues regarding "
@@ -2988,7 +3202,7 @@ class MySQLDialect(default.DefaultDialect):
                 )
 
     @property
-    def _support_float_cast(self):
+    def _support_float_cast(self) -> bool:
         if not self.server_version_info:
             return False
         elif self.is_mariadb:
@@ -2999,7 +3213,7 @@ class MySQLDialect(default.DefaultDialect):
             return self.server_version_info >= (8, 0, 17)
 
     @property
-    def _support_default_function(self):
+    def _support_default_function(self) -> bool:
         if not self.server_version_info:
             return False
         elif self.is_mariadb:
@@ -3010,32 +3224,38 @@ class MySQLDialect(default.DefaultDialect):
             return self.server_version_info >= (8, 0, 13)
 
     @property
-    def _is_mariadb(self):
+    def _is_mariadb(self) -> bool:
         return self.is_mariadb
 
     @property
-    def _is_mysql(self):
+    def _is_mysql(self) -> bool:
         return not self.is_mariadb
 
     @property
-    def _is_mariadb_102(self):
-        return self.is_mariadb and self._mariadb_normalized_version_info > (
-            10,
-            2,
+    def _is_mariadb_102(self) -> bool:
+        return (
+            self.is_mariadb
+            and self._mariadb_normalized_version_info  # type:ignore[operator]
+            > (
+                10,
+                2,
+            )
         )
 
     @reflection.cache
-    def get_schema_names(self, connection, **kw):
+    def get_schema_names(self, connection: Connection, **kw: Any) -> list[str]:
         rp = connection.exec_driver_sql("SHOW schemas")
         return [r[0] for r in rp]
 
     @reflection.cache
-    def get_table_names(self, connection, schema=None, **kw):
+    def get_table_names(
+        self, connection: Connection, schema: Optional[str] = None, **kw: Any
+    ) -> list[str]:
         """Return a Unicode SHOW TABLES from a given schema."""
         if schema is not None:
-            current_schema = schema
+            current_schema: str = schema
         else:
-            current_schema = self.default_schema_name
+            current_schema = self.default_schema_name  # type: ignore
 
         charset = self._connection_charset
 
@@ -3051,9 +3271,12 @@ class MySQLDialect(default.DefaultDialect):
         ]
 
     @reflection.cache
-    def get_view_names(self, connection, schema=None, **kw):
+    def get_view_names(
+        self, connection: Connection, schema: Optional[str] = None, **kw: Any
+    ) -> list[str]:
         if schema is None:
             schema = self.default_schema_name
+        assert schema is not None
         charset = self._connection_charset
         rp = connection.exec_driver_sql(
             "SHOW FULL TABLES FROM %s"
@@ -3066,7 +3289,13 @@ class MySQLDialect(default.DefaultDialect):
         ]
 
     @reflection.cache
-    def get_table_options(self, connection, table_name, schema=None, **kw):
+    def get_table_options(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> dict[str, Any]:
         parsed_state = self._parsed_state_or_create(
             connection, table_name, schema, **kw
         )
@@ -3076,7 +3305,13 @@ class MySQLDialect(default.DefaultDialect):
             return ReflectionDefaults.table_options()
 
     @reflection.cache
-    def get_columns(self, connection, table_name, schema=None, **kw):
+    def get_columns(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> list[ReflectedColumn]:
         parsed_state = self._parsed_state_or_create(
             connection, table_name, schema, **kw
         )
@@ -3086,7 +3321,13 @@ class MySQLDialect(default.DefaultDialect):
             return ReflectionDefaults.columns()
 
     @reflection.cache
-    def get_pk_constraint(self, connection, table_name, schema=None, **kw):
+    def get_pk_constraint(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> ReflectedPrimaryKeyConstraint:
         parsed_state = self._parsed_state_or_create(
             connection, table_name, schema, **kw
         )
@@ -3098,13 +3339,19 @@ class MySQLDialect(default.DefaultDialect):
         return ReflectionDefaults.pk_constraint()
 
     @reflection.cache
-    def get_foreign_keys(self, connection, table_name, schema=None, **kw):
+    def get_foreign_keys(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> list[ReflectedForeignKeyConstraint]:
         parsed_state = self._parsed_state_or_create(
             connection, table_name, schema, **kw
         )
         default_schema = None
 
-        fkeys = []
+        fkeys: list[ReflectedForeignKeyConstraint] = []
 
         for spec in parsed_state.fk_constraints:
             ref_name = spec["table"][-1]
@@ -3124,7 +3371,7 @@ class MySQLDialect(default.DefaultDialect):
                 if spec.get(opt, False) not in ("NO ACTION", None):
                     con_kw[opt] = spec[opt]
 
-            fkey_d = {
+            fkey_d: ReflectedForeignKeyConstraint = {
                 "name": spec["name"],
                 "constrained_columns": loc_names,
                 "referred_schema": ref_schema,
@@ -3139,7 +3386,11 @@ class MySQLDialect(default.DefaultDialect):
 
         return fkeys if fkeys else ReflectionDefaults.foreign_keys()
 
-    def _correct_for_mysql_bugs_88718_96365(self, fkeys, connection):
+    def _correct_for_mysql_bugs_88718_96365(
+        self,
+        fkeys: list[ReflectedForeignKeyConstraint],
+        connection: Connection,
+    ) -> None:
         # Foreign key is always in lower case (MySQL 8.0)
         # https://bugs.mysql.com/bug.php?id=88718
         # issue #4344 for SQLAlchemy
@@ -3155,22 +3406,24 @@ class MySQLDialect(default.DefaultDialect):
 
         if self._casing in (1, 2):
 
-            def lower(s):
+            def lower(s: str) -> str:
                 return s.lower()
 
         else:
             # if on case sensitive, there can be two tables referenced
             # with the same name different casing, so we need to use
             # case-sensitive matching.
-            def lower(s):
+            def lower(s: str) -> str:
                 return s
 
-        default_schema_name = connection.dialect.default_schema_name
+        default_schema_name: str = connection.dialect.default_schema_name  # type: ignore  # noqa: E501
 
         # NOTE: using (table_schema, table_name, lower(column_name)) in (...)
         # is very slow since mysql does not seem able to properly use indexse.
         # Unpack the where condition instead.
-        schema_by_table_by_column = defaultdict(lambda: defaultdict(list))
+        schema_by_table_by_column: defaultdict[
+            str, defaultdict[str, list[str]]
+        ] = defaultdict(lambda: defaultdict(list))
         for rec in fkeys:
             sch = lower(rec["referred_schema"] or default_schema_name)
             tbl = lower(rec["referred_table"])
@@ -3205,7 +3458,9 @@ class MySQLDialect(default.DefaultDialect):
                 _info_columns.c.column_name,
             ).where(condition)
 
-            correct_for_wrong_fk_case = connection.execute(select)
+            correct_for_wrong_fk_case: CursorResult[str, str, str] = (
+                connection.execute(select)
+            )
 
             # in casing=0, table name and schema name come back in their
             # exact case.
@@ -3217,35 +3472,41 @@ class MySQLDialect(default.DefaultDialect):
             # SHOW CREATE TABLE converts them to *lower case*, therefore
             # not matching.  So for this case, case-insensitive lookup
             # is necessary
-            d = defaultdict(dict)
+            d: defaultdict[tuple[str, str], dict[str, str]] = defaultdict(dict)
             for schema, tname, cname in correct_for_wrong_fk_case:
                 d[(lower(schema), lower(tname))]["SCHEMANAME"] = schema
                 d[(lower(schema), lower(tname))]["TABLENAME"] = tname
                 d[(lower(schema), lower(tname))][cname.lower()] = cname
 
             for fkey in fkeys:
-                rec = d[
+                rec_b = d[
                     (
                         lower(fkey["referred_schema"] or default_schema_name),
                         lower(fkey["referred_table"]),
                     )
                 ]
 
-                fkey["referred_table"] = rec["TABLENAME"]
+                fkey["referred_table"] = rec_b["TABLENAME"]
                 if fkey["referred_schema"] is not None:
-                    fkey["referred_schema"] = rec["SCHEMANAME"]
+                    fkey["referred_schema"] = rec_b["SCHEMANAME"]
 
                 fkey["referred_columns"] = [
-                    rec[col.lower()] for col in fkey["referred_columns"]
+                    rec_b[col.lower()] for col in fkey["referred_columns"]
                 ]
 
     @reflection.cache
-    def get_check_constraints(self, connection, table_name, schema=None, **kw):
+    def get_check_constraints(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> list[ReflectedCheckConstraint]:
         parsed_state = self._parsed_state_or_create(
             connection, table_name, schema, **kw
         )
 
-        cks = [
+        cks: list[ReflectedCheckConstraint] = [
             {"name": spec["name"], "sqltext": spec["sqltext"]}
             for spec in parsed_state.ck_constraints
         ]
@@ -3253,7 +3514,13 @@ class MySQLDialect(default.DefaultDialect):
         return cks if cks else ReflectionDefaults.check_constraints()
 
     @reflection.cache
-    def get_table_comment(self, connection, table_name, schema=None, **kw):
+    def get_table_comment(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> ReflectedTableComment:
         parsed_state = self._parsed_state_or_create(
             connection, table_name, schema, **kw
         )
@@ -3264,12 +3531,18 @@ class MySQLDialect(default.DefaultDialect):
             return ReflectionDefaults.table_comment()
 
     @reflection.cache
-    def get_indexes(self, connection, table_name, schema=None, **kw):
+    def get_indexes(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> list[ReflectedIndex]:
         parsed_state = self._parsed_state_or_create(
             connection, table_name, schema, **kw
         )
 
-        indexes = []
+        indexes: list[ReflectedIndex] = []
 
         for spec in parsed_state.keys:
             dialect_options = {}
@@ -3294,19 +3567,20 @@ class MySQLDialect(default.DefaultDialect):
                     "parser"
                 ]
 
-            index_d = {}
+            index_d: ReflectedIndex = {
+                "name": spec["name"],
+                "column_names": [s[0] for s in spec["columns"]],
+                "unique": unique,
+            }
 
-            index_d["name"] = spec["name"]
-            index_d["column_names"] = [s[0] for s in spec["columns"]]
             mysql_length = {
                 s[0]: s[1] for s in spec["columns"] if s[1] is not None
             }
             if mysql_length:
                 dialect_options["%s_length" % self.name] = mysql_length
 
-            index_d["unique"] = unique
             if flavor:
-                index_d["type"] = flavor
+                index_d["type"] = flavor  # type: ignore[typeddict-unknown-key]
 
             if dialect_options:
                 index_d["dialect_options"] = dialect_options
@@ -3317,13 +3591,17 @@ class MySQLDialect(default.DefaultDialect):
 
     @reflection.cache
     def get_unique_constraints(
-        self, connection, table_name, schema=None, **kw
-    ):
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> list[ReflectedUniqueConstraint]:
         parsed_state = self._parsed_state_or_create(
             connection, table_name, schema, **kw
         )
 
-        ucs = [
+        ucs: list[ReflectedUniqueConstraint] = [
             {
                 "name": key["name"],
                 "column_names": [col[0] for col in key["columns"]],
@@ -3339,7 +3617,13 @@ class MySQLDialect(default.DefaultDialect):
             return ReflectionDefaults.unique_constraints()
 
     @reflection.cache
-    def get_view_definition(self, connection, view_name, schema=None, **kw):
+    def get_view_definition(
+        self,
+        connection: Connection,
+        view_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> str:
         charset = self._connection_charset
         full_name = ".".join(
             self.identifier_preparer._quote_free_identifiers(schema, view_name)
@@ -3353,8 +3637,12 @@ class MySQLDialect(default.DefaultDialect):
         return sql
 
     def _parsed_state_or_create(
-        self, connection, table_name, schema=None, **kw
-    ):
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> _reflection.ReflectedState:
         return self._setup_parser(
             connection,
             table_name,
@@ -3363,7 +3651,7 @@ class MySQLDialect(default.DefaultDialect):
         )
 
     @util.memoized_property
-    def _tabledef_parser(self):
+    def _tabledef_parser(self) -> _reflection.MySQLTableDefinitionParser:
         """return the MySQLTableDefinitionParser, generate if needed.
 
         The deferred creation ensures that the dialect has
@@ -3374,7 +3662,13 @@ class MySQLDialect(default.DefaultDialect):
         return _reflection.MySQLTableDefinitionParser(self, preparer)
 
     @reflection.cache
-    def _setup_parser(self, connection, table_name, schema=None, **kw):
+    def _setup_parser(
+        self,
+        connection: Connection,
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> _reflection.ReflectedState:
         charset = self._connection_charset
         parser = self._tabledef_parser
         full_name = ".".join(
@@ -3390,10 +3684,14 @@ class MySQLDialect(default.DefaultDialect):
             columns = self._describe_table(
                 connection, None, charset, full_name=full_name
             )
-            sql = parser._describe_to_create(table_name, columns)
+            sql = parser._describe_to_create(
+                table_name, columns  # type: ignore[arg-type]
+            )
         return parser.parse(sql, charset)
 
-    def _fetch_setting(self, connection, setting_name):
+    def _fetch_setting(
+        self, connection: Connection, setting_name: str
+    ) -> Optional[str]:
         charset = self._connection_charset
 
         if self.server_version_info and self.server_version_info < (5, 6):
@@ -3410,10 +3708,10 @@ class MySQLDialect(default.DefaultDialect):
         else:
             return row[fetch_col]
 
-    def _detect_charset(self, connection):
+    def _detect_charset(self, connection: Connection) -> str:
         raise NotImplementedError()
 
-    def _detect_casing(self, connection):
+    def _detect_casing(self, connection: Connection) -> int:
         """Sniff out identifier case sensitivity.
 
         Cached per-connection. This value can not change without a server
@@ -3437,7 +3735,7 @@ class MySQLDialect(default.DefaultDialect):
         self._casing = cs
         return cs
 
-    def _detect_collations(self, connection):
+    def _detect_collations(self, connection: Connection) -> dict[str, str]:
         """Pull the active COLLATIONS list from the server.
 
         Cached per-connection.
@@ -3450,7 +3748,7 @@ class MySQLDialect(default.DefaultDialect):
             collations[row[0]] = row[1]
         return collations
 
-    def _detect_sql_mode(self, connection):
+    def _detect_sql_mode(self, connection: Connection) -> None:
         setting = self._fetch_setting(connection, "sql_mode")
 
         if setting is None:
@@ -3462,7 +3760,7 @@ class MySQLDialect(default.DefaultDialect):
         else:
             self._sql_mode = setting or ""
 
-    def _detect_ansiquotes(self, connection):
+    def _detect_ansiquotes(self, connection: Connection) -> None:
         """Detect and adjust for the ANSI_QUOTES sql mode."""
 
         mode = self._sql_mode
@@ -3477,12 +3775,35 @@ class MySQLDialect(default.DefaultDialect):
         # as of MySQL 5.0.1
         self._backslash_escapes = "NO_BACKSLASH_ESCAPES" not in mode
 
+    @overload
     def _show_create_table(
-        self, connection, table, charset=None, full_name=None
-    ):
+        self,
+        connection: Connection,
+        table: Optional[Table],
+        charset: Optional[str],
+        full_name: str,
+    ) -> str: ...
+
+    @overload
+    def _show_create_table(
+        self,
+        connection: Connection,
+        table: Table,
+        charset: Optional[str] = None,
+        full_name: None = None,
+    ) -> str: ...
+
+    def _show_create_table(
+        self,
+        connection: Connection,
+        table: Optional[Table],
+        charset: Optional[str] = None,
+        full_name: Optional[str] = None,
+    ) -> str:
         """Run SHOW CREATE TABLE for a ``Table``."""
 
         if full_name is None:
+            assert table is not None
             full_name = self.identifier_preparer.format_table(table)
         st = "SHOW CREATE TABLE %s" % full_name
 
@@ -3491,7 +3812,7 @@ class MySQLDialect(default.DefaultDialect):
                 skip_user_error_events=True
             ).exec_driver_sql(st)
         except exc.DBAPIError as e:
-            if self._extract_error_code(e.orig) == 1146:
+            if self._extract_error_code(e.orig) == 1146:  # type: ignore[arg-type] # noqa: E501
                 raise exc.NoSuchTableError(full_name) from e
             else:
                 raise
@@ -3500,10 +3821,35 @@ class MySQLDialect(default.DefaultDialect):
             raise exc.NoSuchTableError(full_name)
         return row[1].strip()
 
-    def _describe_table(self, connection, table, charset=None, full_name=None):
+    @overload
+    def _describe_table(
+        self,
+        connection: Connection,
+        table: Optional[Table],
+        charset: Optional[str],
+        full_name: str,
+    ) -> Union[Sequence[Row[Unpack[TupleAny]]], Sequence[_DecodingRow]]: ...
+
+    @overload
+    def _describe_table(
+        self,
+        connection: Connection,
+        table: Table,
+        charset: Optional[str] = None,
+        full_name: None = None,
+    ) -> Union[Sequence[Row[Unpack[TupleAny]]], Sequence[_DecodingRow]]: ...
+
+    def _describe_table(
+        self,
+        connection: Connection,
+        table: Optional[Table],
+        charset: Optional[str] = None,
+        full_name: Optional[str] = None,
+    ) -> Union[Sequence[Row[Unpack[TupleAny]]], Sequence[_DecodingRow]]:
         """Run DESCRIBE for a ``Table`` and return processed rows."""
 
         if full_name is None:
+            assert table is not None
             full_name = self.identifier_preparer.format_table(table)
         st = "DESCRIBE %s" % full_name
 
@@ -3514,7 +3860,7 @@ class MySQLDialect(default.DefaultDialect):
                     skip_user_error_events=True
                 ).exec_driver_sql(st)
             except exc.DBAPIError as e:
-                code = self._extract_error_code(e.orig)
+                code = self._extract_error_code(e.orig)  # type: ignore[arg-type] # noqa: E501
                 if code == 1146:
                     raise exc.NoSuchTableError(full_name) from e
 
@@ -3546,7 +3892,9 @@ class _DecodingRow:
     # sets.Set(['value']) (seriously) but thankfully that doesn't
     # seem to come up in DDL queries.
 
-    _encoding_compat = {
+    _encoding_compat: dict[Optional[str], str] = {
+        # this dict should be [str, str] but mypy will not allow to call
+        # _encoding_compat.get(None, None)
         "koi8r": "koi8_r",
         "koi8u": "koi8_u",
         "utf16": "utf-16-be",  # MySQL's uft16 is always bigendian
@@ -3556,24 +3904,19 @@ class _DecodingRow:
         "eucjpms": "ujis",
     }
 
-    def __init__(self, rowproxy, charset):
+    def __init__(self, rowproxy: Row[Unpack[_Ts]], charset: Optional[str]):
         self.rowproxy = rowproxy
         self.charset = self._encoding_compat.get(charset, charset)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> str:
         item = self.rowproxy[index]
-        if isinstance(item, _array):
-            item = item.tostring()
-
         if self.charset and isinstance(item, bytes):
             return item.decode(self.charset)
         else:
-            return item
+            return item  # type: ignore[return-value]
 
-    def __getattr__(self, attr):
+    def __getattr__(self, attr: str) -> Any:
         item = getattr(self.rowproxy, attr)
-        if isinstance(item, _array):
-            item = item.tostring()
         if self.charset and isinstance(item, bytes):
             return item.decode(self.charset)
         else:

--- a/lib/sqlalchemy/dialects/mysql/cymysql.py
+++ b/lib/sqlalchemy/dialects/mysql/cymysql.py
@@ -4,7 +4,7 @@
 #
 # This module is part of SQLAlchemy and is released under
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
-# mypy: ignore-errors
+# mypy: disable-error-code="import-untyped,import-not-found"
 
 r"""
 
@@ -21,18 +21,34 @@ r"""
     dialects are mysqlclient and PyMySQL.
 
 """  # noqa
+from __future__ import annotations
 
-from .base import BIT
+from types import ModuleType
+from typing import Any
+from typing import Iterable
+from typing import Optional
+from typing import TYPE_CHECKING
+
 from .base import MySQLDialect
 from .mysqldb import MySQLDialect_mysqldb
+from .types import BIT
 from ... import util
+
+if TYPE_CHECKING:
+    import cymysql
+
+    from ...engine.base import Connection
+    from ...engine.interfaces import Dialect
+    from ...sql.type_api import _ResultProcessorType
 
 
 class _cymysqlBIT(BIT):
-    def result_processor(self, dialect, coltype):
+    def result_processor(
+        self, dialect: Dialect, coltype: object
+    ) -> Optional[_ResultProcessorType[Any]]:
         """Convert MySQL's 64 bit, variable length binary string to a long."""
 
-        def process(value):
+        def process(value: Optional[Iterable[int]]) -> Optional[int]:
             if value is not None:
                 v = 0
                 for i in iter(value):
@@ -51,20 +67,23 @@ class MySQLDialect_cymysql(MySQLDialect_mysqldb):
     supports_sane_rowcount = True
     supports_sane_multi_rowcount = False
     supports_unicode_statements = True
+    dbapi: cymysql
 
     colspecs = util.update_copy(MySQLDialect.colspecs, {BIT: _cymysqlBIT})
 
     @classmethod
-    def import_dbapi(cls):
+    def import_dbapi(cls) -> ModuleType:
         return __import__("cymysql")
 
-    def _detect_charset(self, connection):
-        return connection.connection.charset
+    def _detect_charset(self, connection: Connection) -> str:
+        return connection.connection.charset  # type: ignore
 
-    def _extract_error_code(self, exception):
-        return exception.errno
+    def _extract_error_code(self, exception: BaseException) -> int:
+        return exception.errno  # type: ignore
 
-    def is_disconnect(self, e, connection, cursor):
+    def is_disconnect(
+        self, e: Exception, connection: Any, cursor: Any
+    ) -> bool:
         if isinstance(e, self.dbapi.OperationalError):
             return self._extract_error_code(e) in (
                 2006,

--- a/lib/sqlalchemy/dialects/mysql/expression.py
+++ b/lib/sqlalchemy/dialects/mysql/expression.py
@@ -4,8 +4,10 @@
 #
 # This module is part of SQLAlchemy and is released under
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
-# mypy: ignore-errors
 
+from __future__ import annotations
+
+from typing import Any
 
 from ... import exc
 from ... import util
@@ -18,7 +20,7 @@ from ...sql.base import Generative
 from ...util.typing import Self
 
 
-class match(Generative, elements.BinaryExpression):
+class match(Generative, elements.BinaryExpression[Any]):
     """Produce a ``MATCH (X, Y) AGAINST ('TEXT')`` clause.
 
     E.g.::
@@ -73,8 +75,9 @@ class match(Generative, elements.BinaryExpression):
     __visit_name__ = "mysql_match"
 
     inherit_cache = True
+    modifiers: util.immutabledict[str, Any]
 
-    def __init__(self, *cols, **kw):
+    def __init__(self, *cols: elements.ColumnElement[Any], **kw: Any):
         if not cols:
             raise exc.ArgumentError("columns are required")
 

--- a/lib/sqlalchemy/dialects/mysql/mysqlconnector.py
+++ b/lib/sqlalchemy/dialects/mysql/mysqlconnector.py
@@ -4,7 +4,7 @@
 #
 # This module is part of SQLAlchemy and is released under
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
-# mypy: ignore-errors
+# mypy: disable-error-code="import-not-found"
 
 
 r"""
@@ -46,29 +46,58 @@ charset/collation will allow connectivity.
 
 
 """  # noqa
+from __future__ import annotations
 
 import re
+from types import ModuleType
+from typing import Any
+from typing import Optional
+from typing import Sequence
+from typing import TYPE_CHECKING
+from typing import Union
 
-from .base import BIT
 from .base import MariaDBIdentifierPreparer
 from .base import MySQLCompiler
 from .base import MySQLDialect
 from .base import MySQLExecutionContext
 from .base import MySQLIdentifierPreparer
 from .mariadb import MariaDBDialect
+from .types import BIT
 from ... import util
+from ...util.typing import Unpack
+
+if TYPE_CHECKING:
+    from mysql import connector
+    from mysql.connector.abstracts import MySQLConnectionAbstract
+
+    from ...engine.base import Connection
+    from ...engine.cursor import CursorResult
+    from ...engine.interfaces import ConnectArgsType
+    from ...engine.interfaces import DBAPIConnection
+    from ...engine.interfaces import DBAPICursor
+    from ...engine.interfaces import IsolationLevel
+    from ...engine.row import Row
+    from ...engine.url import URL
+    from ...sql.elements import BinaryExpression
+    from ...util.typing import TupleAny
+
+    dbapi_connection = Union[
+        connector.pooling.PooledMySQLConnection, MySQLConnectionAbstract
+    ]
 
 
 class MySQLExecutionContext_mysqlconnector(MySQLExecutionContext):
-    def create_server_side_cursor(self):
+    def create_server_side_cursor(self) -> DBAPICursor:
         return self._dbapi_connection.cursor(buffered=False)
 
-    def create_default_cursor(self):
+    def create_default_cursor(self) -> DBAPICursor:
         return self._dbapi_connection.cursor(buffered=True)
 
 
 class MySQLCompiler_mysqlconnector(MySQLCompiler):
-    def visit_mod_binary(self, binary, operator, **kw):
+    def visit_mod_binary(
+        self, binary: BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         return (
             self.process(binary.left, **kw)
             + " % "
@@ -78,32 +107,35 @@ class MySQLCompiler_mysqlconnector(MySQLCompiler):
 
 class IdentifierPreparerCommon_mysqlconnector:
     @property
-    def _double_percents(self):
+    def _double_percents(self) -> bool:
         return False
 
     @_double_percents.setter
-    def _double_percents(self, value):
+    def _double_percents(self, value: Any) -> None:
         pass
 
-    def _escape_identifier(self, value):
-        value = value.replace(self.escape_quote, self.escape_to_quote)
+    def _escape_identifier(self, value: str) -> str:
+        value = value.replace(
+            self.escape_quote,  # type:ignore[attr-defined]
+            self.escape_to_quote,  # type:ignore[attr-defined]
+        )
         return value
 
 
-class MySQLIdentifierPreparer_mysqlconnector(
+class MySQLIdentifierPreparer_mysqlconnector(  # type:ignore[misc]
     IdentifierPreparerCommon_mysqlconnector, MySQLIdentifierPreparer
 ):
     pass
 
 
-class MariaDBIdentifierPreparer_mysqlconnector(
+class MariaDBIdentifierPreparer_mysqlconnector(  # type:ignore[misc]
     IdentifierPreparerCommon_mysqlconnector, MariaDBIdentifierPreparer
 ):
     pass
 
 
 class _myconnpyBIT(BIT):
-    def result_processor(self, dialect, coltype):
+    def result_processor(self, dialect: Any, coltype: Any) -> None:
         """MySQL-connector already converts mysql bits, so."""
 
         return None
@@ -128,21 +160,24 @@ class MySQLDialect_mysqlconnector(MySQLDialect):
 
     execution_ctx_cls = MySQLExecutionContext_mysqlconnector
 
-    preparer = MySQLIdentifierPreparer_mysqlconnector
+    preparer: type[MySQLIdentifierPreparer] = (
+        MySQLIdentifierPreparer_mysqlconnector
+    )
 
     colspecs = util.update_copy(MySQLDialect.colspecs, {BIT: _myconnpyBIT})
+    dbapi: connector
 
     @classmethod
-    def import_dbapi(cls):
+    def import_dbapi(cls) -> ModuleType:
         from mysql import connector
 
-        return connector
+        return connector  # type:ignore[no-any-return]
 
-    def do_ping(self, dbapi_connection):
+    def do_ping(self, dbapi_connection: dbapi_connection) -> bool:
         dbapi_connection.ping(False)
         return True
 
-    def create_connect_args(self, url):
+    def create_connect_args(self, url: URL) -> ConnectArgsType:
         opts = url.translate_connect_args(username="user")
 
         opts.update(url.query)
@@ -187,25 +222,28 @@ class MySQLDialect_mysqlconnector(MySQLDialect):
             except Exception:
                 pass
 
-        return [[], opts]
+        return [], opts
 
     @util.memoized_property
-    def _mysqlconnector_version_info(self):
+    def _mysqlconnector_version_info(self) -> Optional[tuple[int, ...]]:
         if self.dbapi and hasattr(self.dbapi, "__version__"):
             m = re.match(r"(\d+)\.(\d+)(?:\.(\d+))?", self.dbapi.__version__)
             if m:
                 return tuple(int(x) for x in m.group(1, 2, 3) if x is not None)
+        return None
 
-    def _detect_charset(self, connection):
-        return connection.connection.charset
+    def _detect_charset(self, connection: Connection) -> str:
+        return connection.connection.charset  # type: ignore
 
-    def _extract_error_code(self, exception):
-        return exception.errno
+    def _extract_error_code(self, exception: BaseException) -> int:
+        return exception.errno  # type: ignore
 
-    def is_disconnect(self, e, connection, cursor):
+    def is_disconnect(
+        self, e: Exception, connection: Any, cursor: Any
+    ) -> bool:
         errnos = (2006, 2013, 2014, 2045, 2055, 2048)
         exceptions = (
-            self.dbapi.OperationalError,
+            self.dbapi.OperationalError,  #
             self.dbapi.InterfaceError,
             self.dbapi.ProgrammingError,
         )
@@ -218,13 +256,23 @@ class MySQLDialect_mysqlconnector(MySQLDialect):
         else:
             return False
 
-    def _compat_fetchall(self, rp, charset=None):
+    def _compat_fetchall(
+        self,
+        rp: CursorResult[Unpack[TupleAny]],
+        charset: Optional[str] = None,
+    ) -> Sequence[Row[Unpack[TupleAny]]]:
         return rp.fetchall()
 
-    def _compat_fetchone(self, rp, charset=None):
+    def _compat_fetchone(
+        self,
+        rp: CursorResult[Unpack[TupleAny]],
+        charset: Optional[str] = None,
+    ) -> Optional[Row[Unpack[TupleAny]]]:
         return rp.fetchone()
 
-    def get_isolation_level_values(self, dbapi_connection):
+    def get_isolation_level_values(
+        self, dbapi_connection: DBAPIConnection
+    ) -> Sequence[IsolationLevel]:
         return (
             "SERIALIZABLE",
             "READ UNCOMMITTED",
@@ -233,12 +281,14 @@ class MySQLDialect_mysqlconnector(MySQLDialect):
             "AUTOCOMMIT",
         )
 
-    def set_isolation_level(self, connection, level):
+    def set_isolation_level(
+        self, dbapi_connection: DBAPIConnection, level: IsolationLevel
+    ) -> None:
         if level == "AUTOCOMMIT":
-            connection.autocommit = True
+            dbapi_connection.autocommit = True
         else:
-            connection.autocommit = False
-            super().set_isolation_level(connection, level)
+            dbapi_connection.autocommit = False
+            super().set_isolation_level(dbapi_connection, level)
 
 
 class MariaDBDialect_mysqlconnector(

--- a/lib/sqlalchemy/dialects/mysql/mysqldb.py
+++ b/lib/sqlalchemy/dialects/mysql/mysqldb.py
@@ -4,8 +4,7 @@
 #
 # This module is part of SQLAlchemy and is released under
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
-# mypy: ignore-errors
-
+# mypy: disable-error-code="import-untyped"
 
 """
 
@@ -86,16 +85,32 @@ Server Side Cursors
 The mysqldb dialect supports server-side cursors. See :ref:`mysql_ss_cursors`.
 
 """
+from __future__ import annotations
 
 import re
+from types import ModuleType
+from typing import Any
+from typing import Callable
+from typing import Iterable
+from typing import Literal
+from typing import Optional
+from typing import TYPE_CHECKING
 
 from .base import MySQLCompiler
 from .base import MySQLDialect
 from .base import MySQLExecutionContext
 from .base import MySQLIdentifierPreparer
-from .base import TEXT
-from ... import sql
 from ... import util
+from ...util.typing import LiteralString
+
+if TYPE_CHECKING:
+    import MySQLdb
+
+    from ...engine.base import Connection
+    from ...engine.interfaces import ConnectArgsType
+    from ...engine.interfaces import DBAPIConnection
+    from ...engine.interfaces import IsolationLevel
+    from ...engine.url import URL
 
 
 class MySQLExecutionContext_mysqldb(MySQLExecutionContext):
@@ -119,8 +134,9 @@ class MySQLDialect_mysqldb(MySQLDialect):
     execution_ctx_cls = MySQLExecutionContext_mysqldb
     statement_compiler = MySQLCompiler_mysqldb
     preparer = MySQLIdentifierPreparer
+    server_version_info: tuple[int, ...]
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
         self._mysql_dbapi_version = (
             self._parse_dbapi_version(self.dbapi.__version__)
@@ -128,7 +144,7 @@ class MySQLDialect_mysqldb(MySQLDialect):
             else (0, 0, 0)
         )
 
-    def _parse_dbapi_version(self, version):
+    def _parse_dbapi_version(self, version: str) -> tuple[int, ...]:
         m = re.match(r"(\d+)\.(\d+)(?:\.(\d+))?", version)
         if m:
             return tuple(int(x) for x in m.group(1, 2, 3) if x is not None)
@@ -136,7 +152,7 @@ class MySQLDialect_mysqldb(MySQLDialect):
             return (0, 0, 0)
 
     @util.langhelpers.memoized_property
-    def supports_server_side_cursors(self):
+    def supports_server_side_cursors(self) -> bool:  # type: ignore[override]
         try:
             cursors = __import__("MySQLdb.cursors").cursors
             self._sscursor = cursors.SSCursor
@@ -145,13 +161,13 @@ class MySQLDialect_mysqldb(MySQLDialect):
             return False
 
     @classmethod
-    def import_dbapi(cls):
+    def import_dbapi(cls) -> ModuleType:
         return __import__("MySQLdb")
 
-    def on_connect(self):
+    def on_connect(self) -> Callable[[MySQLdb.Connection], None]:
         super_ = super().on_connect()
 
-        def on_connect(conn):
+        def on_connect(conn: MySQLdb.Connection) -> None:
             if super_ is not None:
                 super_(conn)
 
@@ -164,43 +180,24 @@ class MySQLDialect_mysqldb(MySQLDialect):
 
         return on_connect
 
-    def do_ping(self, dbapi_connection):
+    def do_ping(self, dbapi_connection: MySQLdb.Connection) -> Literal[True]:
         dbapi_connection.ping()
         return True
 
-    def do_executemany(self, cursor, statement, parameters, context=None):
+    def do_executemany(
+        self,
+        cursor: MySQLdb.cursors.Cursor,
+        statement: LiteralString,
+        parameters: Iterable[Any],
+        context: Optional[MySQLExecutionContext_mysqldb] = None,  # type: ignore # NOQA: E501
+    ) -> None:
         rowcount = cursor.executemany(statement, parameters)
         if context is not None:
             context._rowcount = rowcount
 
-    def _check_unicode_returns(self, connection):
-        # work around issue fixed in
-        # https://github.com/farcepest/MySQLdb1/commit/cd44524fef63bd3fcb71947392326e9742d520e8
-        # specific issue w/ the utf8mb4_bin collation and unicode returns
-
-        collation = connection.exec_driver_sql(
-            "show collation where %s = 'utf8mb4' and %s = 'utf8mb4_bin'"
-            % (
-                self.identifier_preparer.quote("Charset"),
-                self.identifier_preparer.quote("Collation"),
-            )
-        ).scalar()
-        has_utf8mb4_bin = self.server_version_info > (5,) and collation
-        if has_utf8mb4_bin:
-            additional_tests = [
-                sql.collate(
-                    sql.cast(
-                        sql.literal_column("'test collated returns'"),
-                        TEXT(charset="utf8mb4"),
-                    ),
-                    "utf8mb4_bin",
-                )
-            ]
-        else:
-            additional_tests = []
-        return super()._check_unicode_returns(connection, additional_tests)
-
-    def create_connect_args(self, url, _translate_args=None):
+    def create_connect_args(
+        self, url: URL, _translate_args: Optional[dict[str, Any]] = None
+    ) -> ConnectArgsType:
         if _translate_args is None:
             _translate_args = dict(
                 database="db", username="user", password="passwd"
@@ -249,31 +246,32 @@ class MySQLDialect_mysqldb(MySQLDialect):
         if client_flag_found_rows is not None:
             client_flag |= client_flag_found_rows
             opts["client_flag"] = client_flag
-        return [[], opts]
+        return [], opts
 
-    def _found_rows_client_flag(self):
+    def _found_rows_client_flag(self) -> Optional[int]:
         if self.dbapi is not None:
             try:
-                CLIENT_FLAGS = __import__(
+                CLIENT_FLAGS: MySQLdb.constants.CLIENT = __import__(
                     self.dbapi.__name__ + ".constants.CLIENT"
                 ).constants.CLIENT
             except (AttributeError, ImportError):
                 return None
             else:
-                return CLIENT_FLAGS.FOUND_ROWS
+                return CLIENT_FLAGS.FOUND_ROWS  # type: ignore
         else:
             return None
 
-    def _extract_error_code(self, exception):
-        return exception.args[0]
+    def _extract_error_code(self, exception: BaseException) -> int:
+        return exception.args[0]  # type: ignore[no-any-return]
 
-    def _detect_charset(self, connection):
+    def _detect_charset(self, connection: Connection) -> str:
         """Sniff out the character set in use for connection results."""
 
         try:
             # note: the SQL here would be
             # "SHOW VARIABLES LIKE 'character_set%%'"
-            cset_name = connection.connection.character_set_name
+
+            cset_name: Callable[[], str] = connection.connection.character_set_name  # type: ignore[attr-defined]  # noqa: E501
         except AttributeError:
             util.warn(
                 "No 'character_set_name' can be detected with "
@@ -285,7 +283,9 @@ class MySQLDialect_mysqldb(MySQLDialect):
         else:
             return cset_name()
 
-    def get_isolation_level_values(self, dbapi_connection):
+    def get_isolation_level_values(
+        self, dbapi_conn: DBAPIConnection
+    ) -> tuple[IsolationLevel, ...]:
         return (
             "SERIALIZABLE",
             "READ UNCOMMITTED",
@@ -294,7 +294,9 @@ class MySQLDialect_mysqldb(MySQLDialect):
             "AUTOCOMMIT",
         )
 
-    def set_isolation_level(self, dbapi_connection, level):
+    def set_isolation_level(
+        self, dbapi_connection: MySQLdb.Connection, level: IsolationLevel
+    ) -> None:
         if level == "AUTOCOMMIT":
             dbapi_connection.autocommit(True)
         else:

--- a/lib/sqlalchemy/dialects/mysql/provision.py
+++ b/lib/sqlalchemy/dialects/mysql/provision.py
@@ -5,7 +5,6 @@
 # This module is part of SQLAlchemy and is released under
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
 # mypy: ignore-errors
-
 from ... import exc
 from ...testing.provision import configure_follower
 from ...testing.provision import create_db

--- a/lib/sqlalchemy/dialects/mysql/pymysql.py
+++ b/lib/sqlalchemy/dialects/mysql/pymysql.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 
 from types import ModuleType
 from typing import Any
+from typing import cast
 from typing import Literal
 from typing import Optional
 from typing import TYPE_CHECKING
@@ -116,9 +117,9 @@ class MySQLDialect_pymysql(MySQLDialect_mysqldb):
 
     def do_ping(self, dbapi_connection: pymysql.Connection) -> Literal[True]:  # type: ignore # noqa: E501
         if self._send_false_to_ping:
-            dbapi_connection.ping(False)
+            cast("pymysql.Connection[Any]", dbapi_connection).ping(False)
         else:
-            dbapi_connection.ping()
+            cast("pymysql.Connection[Any]", dbapi_connection).ping()
 
         return True
 
@@ -130,6 +131,7 @@ class MySQLDialect_pymysql(MySQLDialect_mysqldb):
         return super().create_connect_args(
             url, _translate_args=_translate_args
         )
+
 
     def is_disconnect(
         self, e: Exception, connection: Any, cursor: Any

--- a/lib/sqlalchemy/dialects/mysql/pymysql.py
+++ b/lib/sqlalchemy/dialects/mysql/pymysql.py
@@ -132,7 +132,6 @@ class MySQLDialect_pymysql(MySQLDialect_mysqldb):
             url, _translate_args=_translate_args
         )
 
-
     def is_disconnect(
         self, e: Exception, connection: Any, cursor: Any
     ) -> bool:

--- a/lib/sqlalchemy/dialects/mysql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mysql/pyodbc.py
@@ -4,11 +4,10 @@
 #
 # This module is part of SQLAlchemy and is released under
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
-# mypy: ignore-errors
+# mypy: disable-error-code="import-not-found"
 
 
 r"""
-
 
 .. dialect:: mysql+pyodbc
     :name: PyODBC
@@ -44,8 +43,15 @@ Pass through exact pyodbc connection string::
     connection_uri = "mysql+pyodbc:///?odbc_connect=%s" % params
 
 """  # noqa
+from __future__ import annotations
 
+import datetime
 import re
+from typing import Any
+from typing import Callable
+from typing import Optional
+from typing import TYPE_CHECKING
+from typing import Union
 
 from .base import MySQLDialect
 from .base import MySQLExecutionContext
@@ -55,23 +61,32 @@ from ... import util
 from ...connectors.pyodbc import PyODBCConnector
 from ...sql.sqltypes import Time
 
+if TYPE_CHECKING:
+    import pyodbc
+
+    from ...engine import Connection
+    from ...engine.interfaces import Dialect
+    from ...sql.type_api import _ResultProcessorType
+
 
 class _pyodbcTIME(TIME):
-    def result_processor(self, dialect, coltype):
-        def process(value):
+    def result_processor(
+        self, dialect: Dialect, coltype: object
+    ) -> _ResultProcessorType[datetime.time]:
+        def process(value: Any) -> Union[datetime.time, None]:
             # pyodbc returns a datetime.time object; no need to convert
-            return value
+            return value  # type: ignore[no-any-return]
 
         return process
 
 
 class MySQLExecutionContext_pyodbc(MySQLExecutionContext):
-    def get_lastrowid(self):
+    def get_lastrowid(self) -> int:
         cursor = self.create_cursor()
         cursor.execute("SELECT LAST_INSERT_ID()")
-        lastrowid = cursor.fetchone()[0]
+        lastrowid = cursor.fetchone()[0]  # type: ignore[index]
         cursor.close()
-        return lastrowid
+        return lastrowid  # type: ignore[no-any-return]
 
 
 class MySQLDialect_pyodbc(PyODBCConnector, MySQLDialect):
@@ -82,7 +97,7 @@ class MySQLDialect_pyodbc(PyODBCConnector, MySQLDialect):
 
     pyodbc_driver_name = "MySQL"
 
-    def _detect_charset(self, connection):
+    def _detect_charset(self, connection: Connection) -> str:
         """Sniff out the character set in use for connection results."""
 
         # Prefer 'character_set_results' for the current connection over the
@@ -107,21 +122,25 @@ class MySQLDialect_pyodbc(PyODBCConnector, MySQLDialect):
         )
         return "latin1"
 
-    def _get_server_version_info(self, connection):
+    def _get_server_version_info(
+        self, connection: Connection
+    ) -> tuple[int, ...]:
         return MySQLDialect._get_server_version_info(self, connection)
 
-    def _extract_error_code(self, exception):
+    def _extract_error_code(self, exception: BaseException) -> Optional[int]:
         m = re.compile(r"\((\d+)\)").search(str(exception.args))
-        c = m.group(1)
+        if m is None:
+            return None
+        c: Optional[str] = m.group(1)
         if c:
             return int(c)
         else:
             return None
 
-    def on_connect(self):
+    def on_connect(self) -> Callable[[pyodbc.Connection], None]:
         super_ = super().on_connect()
 
-        def on_connect(conn):
+        def on_connect(conn: pyodbc.Connection) -> None:
             if super_ is not None:
                 super_(conn)
 

--- a/lib/sqlalchemy/dialects/mysql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mysql/pyodbc.py
@@ -48,8 +48,8 @@ from __future__ import annotations
 import datetime
 import re
 from typing import Any
-from typing import cast
 from typing import Callable
+from typing import cast
 from typing import Optional
 from typing import TYPE_CHECKING
 from typing import Union

--- a/lib/sqlalchemy/dialects/mysql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mysql/pyodbc.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import datetime
 import re
 from typing import Any
+from typing import cast
 from typing import Callable
 from typing import Optional
 from typing import TYPE_CHECKING
@@ -148,9 +149,13 @@ class MySQLDialect_pyodbc(PyODBCConnector, MySQLDialect):
             #   https://github.com/mkleehammer/pyodbc/wiki/Unicode
             pyodbc_SQL_CHAR = 1  # pyodbc.SQL_CHAR
             pyodbc_SQL_WCHAR = -8  # pyodbc.SQL_WCHAR
-            conn.setdecoding(pyodbc_SQL_CHAR, encoding="utf-8")
-            conn.setdecoding(pyodbc_SQL_WCHAR, encoding="utf-8")
-            conn.setencoding(encoding="utf-8")
+            cast("pyodbc.Connection", conn).setdecoding(
+                pyodbc_SQL_CHAR, encoding="utf-8"
+            )
+            cast("pyodbc.Connection", conn).setdecoding(
+                pyodbc_SQL_WCHAR, encoding="utf-8"
+            )
+            cast("pyodbc.Connection", conn).setencoding(encoding="utf-8")
 
         return on_connect
 

--- a/lib/sqlalchemy/dialects/mysql/reflection.py
+++ b/lib/sqlalchemy/dialects/mysql/reflection.py
@@ -4,10 +4,17 @@
 #
 # This module is part of SQLAlchemy and is released under
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
-# mypy: ignore-errors
-
+from __future__ import annotations
 
 import re
+from typing import Any
+from typing import Callable
+from typing import Literal
+from typing import Optional
+from typing import overload
+from typing import Sequence
+from typing import TYPE_CHECKING
+from typing import Union
 
 from .enumerated import ENUM
 from .enumerated import SET
@@ -18,29 +25,40 @@ from ... import log
 from ... import types as sqltypes
 from ... import util
 
+if TYPE_CHECKING:
+    from .base import MySQLDialect
+    from .base import MySQLIdentifierPreparer
+    from ...engine.interfaces import ReflectedColumn
+
 
 class ReflectedState:
     """Stores raw information about a SHOW CREATE TABLE statement."""
 
-    def __init__(self):
-        self.columns = []
-        self.table_options = {}
-        self.table_name = None
-        self.keys = []
-        self.fk_constraints = []
-        self.ck_constraints = []
+    charset: Optional[str]
+
+    def __init__(self) -> None:
+        self.columns: list[ReflectedColumn] = []
+        self.table_options: dict[str, str] = {}
+        self.table_name: Optional[str] = None
+        self.keys: list[dict[str, Any]] = []
+        self.fk_constraints: list[dict[str, Any]] = []
+        self.ck_constraints: list[dict[str, Any]] = []
 
 
 @log.class_logger
-class MySQLTableDefinitionParser:
+class MySQLTableDefinitionParser:  # type: ignore[type-var]
     """Parses the results of a SHOW CREATE TABLE statement."""
 
-    def __init__(self, dialect, preparer):
+    def __init__(
+        self, dialect: MySQLDialect, preparer: MySQLIdentifierPreparer
+    ):
         self.dialect = dialect
         self.preparer = preparer
         self._prep_regexes()
 
-    def parse(self, show_create, charset):
+    def parse(
+        self, show_create: str, charset: Optional[str]
+    ) -> ReflectedState:
         state = ReflectedState()
         state.charset = charset
         for line in re.split(r"\r?\n", show_create):
@@ -65,11 +83,11 @@ class MySQLTableDefinitionParser:
                 if type_ is None:
                     util.warn("Unknown schema content: %r" % line)
                 elif type_ == "key":
-                    state.keys.append(spec)
+                    state.keys.append(spec)  # type: ignore[arg-type]
                 elif type_ == "fk_constraint":
-                    state.fk_constraints.append(spec)
+                    state.fk_constraints.append(spec)  # type: ignore[arg-type]
                 elif type_ == "ck_constraint":
-                    state.ck_constraints.append(spec)
+                    state.ck_constraints.append(spec)  # type: ignore[arg-type]
                 else:
                     pass
         return state
@@ -77,7 +95,13 @@ class MySQLTableDefinitionParser:
     def _check_view(self, sql: str) -> bool:
         return bool(self._re_is_view.match(sql))
 
-    def _parse_constraints(self, line):
+    def _parse_constraints(self, line: str) -> Union[
+        tuple[None, str],
+        tuple[Literal["partition"], str],
+        tuple[
+            Literal["ck_constraint", "fk_constraint", "key"], dict[str, str]
+        ],
+    ]:
         """Parse a KEY or CONSTRAINT line.
 
         :param line: A line of SHOW CREATE TABLE output
@@ -127,7 +151,7 @@ class MySQLTableDefinitionParser:
         # No match.
         return (None, line)
 
-    def _parse_table_name(self, line, state):
+    def _parse_table_name(self, line: str, state: ReflectedState) -> None:
         """Extract the table name.
 
         :param line: The first line of SHOW CREATE TABLE
@@ -138,7 +162,7 @@ class MySQLTableDefinitionParser:
         if m:
             state.table_name = cleanup(m.group("name"))
 
-    def _parse_table_options(self, line, state):
+    def _parse_table_options(self, line: str, state: ReflectedState) -> None:
         """Build a dictionary of all reflected table-level options.
 
         :param line: The final line of SHOW CREATE TABLE output.
@@ -164,7 +188,9 @@ class MySQLTableDefinitionParser:
         for opt, val in options.items():
             state.table_options["%s_%s" % (self.dialect.name, opt)] = val
 
-    def _parse_partition_options(self, line, state):
+    def _parse_partition_options(
+        self, line: str, state: ReflectedState
+    ) -> None:
         options = {}
         new_line = line[:]
 
@@ -220,7 +246,7 @@ class MySQLTableDefinitionParser:
             else:
                 state.table_options["%s_%s" % (self.dialect.name, opt)] = val
 
-    def _parse_column(self, line, state):
+    def _parse_column(self, line: str, state: ReflectedState) -> None:
         """Extract column details.
 
         Falls back to a 'minimal support' variant if full parse fails.
@@ -283,7 +309,7 @@ class MySQLTableDefinitionParser:
 
         type_instance = col_type(*type_args, **type_kw)
 
-        col_kw = {}
+        col_kw: dict[str, Any] = {}
 
         # NOT NULL
         col_kw["nullable"] = True
@@ -324,9 +350,13 @@ class MySQLTableDefinitionParser:
             name=name, type=type_instance, default=default, comment=comment
         )
         col_d.update(col_kw)
-        state.columns.append(col_d)
+        state.columns.append(col_d)  # type: ignore[arg-type]
 
-    def _describe_to_create(self, table_name, columns):
+    def _describe_to_create(
+        self,
+        table_name: str,
+        columns: Sequence[tuple[str, str, str, str, str, str]],
+    ) -> str:
         """Re-format DESCRIBE output as a SHOW CREATE TABLE string.
 
         DESCRIBE is a much simpler reflection and is sufficient for
@@ -379,7 +409,9 @@ class MySQLTableDefinitionParser:
             ]
         )
 
-    def _parse_keyexprs(self, identifiers):
+    def _parse_keyexprs(
+        self, identifiers: str
+    ) -> list[tuple[str, Optional[int], str]]:
         """Unpack '"col"(2),"col" ASC'-ish strings into components."""
 
         return [
@@ -389,11 +421,12 @@ class MySQLTableDefinitionParser:
             )
         ]
 
-    def _prep_regexes(self):
+    def _prep_regexes(self) -> None:
         """Pre-compile regular expressions."""
 
-        self._re_columns = []
-        self._pr_options = []
+        self._pr_options: list[
+            tuple[re.Pattern[Any], Optional[Callable[[str], str]]]
+        ] = []
 
         _final = self.preparer.final_quote
 
@@ -582,21 +615,21 @@ class MySQLTableDefinitionParser:
 
     _optional_equals = r"(?:\s*(?:=\s*)|\s+)"
 
-    def _add_option_string(self, directive):
+    def _add_option_string(self, directive: str) -> None:
         regex = r"(?P<directive>%s)%s" r"'(?P<val>(?:[^']|'')*?)'(?!')" % (
             re.escape(directive),
             self._optional_equals,
         )
         self._pr_options.append(_pr_compile(regex, cleanup_text))
 
-    def _add_option_word(self, directive):
+    def _add_option_word(self, directive: str) -> None:
         regex = r"(?P<directive>%s)%s" r"(?P<val>\w+)" % (
             re.escape(directive),
             self._optional_equals,
         )
         self._pr_options.append(_pr_compile(regex))
 
-    def _add_partition_option_word(self, directive):
+    def _add_partition_option_word(self, directive: str) -> None:
         if directive == "PARTITION BY" or directive == "SUBPARTITION BY":
             regex = r"(?<!\S)(?P<directive>%s)%s" r"(?P<val>\w+.*)" % (
                 re.escape(directive),
@@ -611,7 +644,7 @@ class MySQLTableDefinitionParser:
             regex = r"(?<!\S)(?P<directive>%s)(?!\S)" % (re.escape(directive),)
         self._pr_options.append(_pr_compile(regex))
 
-    def _add_option_regex(self, directive, regex):
+    def _add_option_regex(self, directive: str, regex: str) -> None:
         regex = r"(?P<directive>%s)%s" r"(?P<val>%s)" % (
             re.escape(directive),
             self._optional_equals,
@@ -629,21 +662,35 @@ _options_of_type_string = (
 )
 
 
-def _pr_compile(regex, cleanup=None):
+@overload
+def _pr_compile(
+    regex: str, cleanup: Callable[[str], str]
+) -> tuple[re.Pattern[Any], Callable[[str], str]]: ...
+
+
+@overload
+def _pr_compile(
+    regex: str, cleanup: None = None
+) -> tuple[re.Pattern[Any], None]: ...
+
+
+def _pr_compile(
+    regex: str, cleanup: Optional[Callable[[str], str]] = None
+) -> tuple[re.Pattern[Any], Optional[Callable[[str], str]]]:
     """Prepare a 2-tuple of compiled regex and callable."""
 
     return (_re_compile(regex), cleanup)
 
 
-def _re_compile(regex):
+def _re_compile(regex: str) -> re.Pattern[Any]:
     """Compile a string to regex, I and UNICODE."""
 
     return re.compile(regex, re.I | re.UNICODE)
 
 
-def _strip_values(values):
+def _strip_values(values: Sequence[str]) -> list[str]:
     "Strip reflected values quotes"
-    strip_values = []
+    strip_values: list[str] = []
     for a in values:
         if a[0:1] == '"' or a[0:1] == "'":
             # strip enclosing quotes and unquote interior
@@ -655,7 +702,9 @@ def _strip_values(values):
 def cleanup_text(raw_text: str) -> str:
     if "\\" in raw_text:
         raw_text = re.sub(
-            _control_char_regexp, lambda s: _control_char_map[s[0]], raw_text
+            _control_char_regexp,
+            lambda s: _control_char_map[s[0]],  # type: ignore[index]
+            raw_text,
         )
     return raw_text.replace("''", "'")
 

--- a/lib/sqlalchemy/dialects/mysql/reserved_words.py
+++ b/lib/sqlalchemy/dialects/mysql/reserved_words.py
@@ -11,7 +11,6 @@
 # https://mariadb.com/kb/en/reserved-words/
 # includes: Reserved Words, Oracle Mode (separate set unioned)
 # excludes: Exceptions, Function Names
-# mypy: ignore-errors
 
 RESERVED_WORDS_MARIADB = {
     "accessible",

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -563,7 +563,7 @@ class DefaultDialect(Dialect):
                 % (self.label_length, self.max_identifier_length)
             )
 
-    def on_connect(self) -> Optional[Callable[[Any], Any]]:
+    def on_connect(self) -> Optional[Callable[[Any], None]]:
         # inherits the docstring from interfaces.Dialect.on_connect
         return None
 

--- a/lib/sqlalchemy/engine/interfaces.py
+++ b/lib/sqlalchemy/engine/interfaces.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     from .base import Engine
     from .cursor import CursorResult
     from .url import URL
+    from ..connectors.asyncio import AsyncIODBAPIConnection
     from ..event import _ListenerFnType
     from ..event import dispatcher
     from ..exc import StatementError
@@ -3357,7 +3358,7 @@ class AdaptedConnection:
 
     __slots__ = ("_connection",)
 
-    _connection: Any
+    _connection: AsyncIODBAPIConnection
 
     @property
     def driver_connection(self) -> Any:

--- a/lib/sqlalchemy/engine/interfaces.py
+++ b/lib/sqlalchemy/engine/interfaces.py
@@ -70,6 +70,7 @@ if TYPE_CHECKING:
     from ..sql.sqltypes import Integer
     from ..sql.type_api import _TypeMemoDict
     from ..sql.type_api import TypeEngine
+    from ..util.langhelpers import generic_fn_descriptor
 
 ConnectArgsType = Tuple[Sequence[str], MutableMapping[str, Any]]
 
@@ -781,7 +782,7 @@ class Dialect(EventTarget):
     """The maximum length of constraint names if different from
     ``max_identifier_length``."""
 
-    supports_server_side_cursors: bool
+    supports_server_side_cursors: Union[generic_fn_descriptor[bool], bool]
     """indicates if the dialect supports server side cursors"""
 
     server_side_cursors: bool
@@ -2306,7 +2307,7 @@ class Dialect(EventTarget):
         """
         return self.on_connect()
 
-    def on_connect(self) -> Optional[Callable[[Any], Any]]:
+    def on_connect(self) -> Optional[Callable[[Any], None]]:
         """return a callable which sets up a newly created DBAPI connection.
 
         The callable should accept a single argument "conn" which is the

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -95,6 +95,7 @@ if typing.TYPE_CHECKING:
     from .base import Executable
     from .cache_key import CacheKey
     from .ddl import ExecutableDDLElement
+    from .dml import Delete
     from .dml import Insert
     from .dml import Update
     from .dml import UpdateBase
@@ -6180,7 +6181,9 @@ class SQLCompiler(Compiled):
             "criteria within UPDATE"
         )
 
-    def update_post_criteria_clause(self, update_stmt, **kw):
+    def update_post_criteria_clause(
+        self, update_stmt: Update, **kw: Any
+    ) -> Optional[str]:
         """provide a hook to override generation after the WHERE criteria
         in an UPDATE statement
 
@@ -6195,7 +6198,9 @@ class SQLCompiler(Compiled):
         else:
             return None
 
-    def delete_post_criteria_clause(self, delete_stmt, **kw):
+    def delete_post_criteria_clause(
+        self, delete_stmt: Delete, **kw: Any
+    ) -> Optional[str]:
         """provide a hook to override generation after the WHERE criteria
         in a DELETE statement
 
@@ -6881,7 +6886,7 @@ class DDLCompiler(Compiled):
         else:
             schema_name = None
 
-        index_name = self.preparer.format_index(index)
+        index_name: str = self.preparer.format_index(index)
 
         if schema_name:
             index_name = schema_name + "." + index_name

--- a/lib/sqlalchemy/sql/ddl.py
+++ b/lib/sqlalchemy/sql/ddl.py
@@ -432,6 +432,8 @@ class _CreateDropBase(ExecutableDDLElement, Generic[_SI]):
 
     """
 
+    element: _SI
+
     def __init__(self, element: _SI) -> None:
         self.element = self.target = element
         self._ddl_if = getattr(element, "_ddl_if", None)

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -82,6 +82,7 @@ from ..util.typing import Self
 from ..util.typing import TupleAny
 from ..util.typing import Unpack
 
+
 if typing.TYPE_CHECKING:
     from ._typing import _ByArgument
     from ._typing import _ColumnExpressionArgument
@@ -118,6 +119,7 @@ if typing.TYPE_CHECKING:
     from ..engine.interfaces import CoreExecuteOptionsParameter
     from ..engine.interfaces import SchemaTranslateMapType
     from ..engine.result import Result
+
 
 _NUMERIC = Union[float, Decimal]
 _NUMBER = Union[float, int, Decimal]
@@ -2127,8 +2129,8 @@ class BindParameter(roles.InElementRole, KeyedColumnElement[_T]):
         else:
             return self
 
-    def _with_binary_element_type(self, type_):
-        c: Self = ClauseElement._clone(self)  # type: ignore[assignment]
+    def _with_binary_element_type(self, type_: TypeEngine[Any]) -> Self:
+        c: Self = ClauseElement._clone(self)
         c.type = type_
         return c
 

--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -787,7 +787,7 @@ class FunctionAsBinary(BinaryExpression[Any]):
         self.type = sqltypes.BOOLEANTYPE
         self.negate = None
         self._is_implicitly_boolean = True
-        self.modifiers = {}
+        self.modifiers = util.immutabledict({})
 
     @property
     def left_expr(self) -> ColumnElement[Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ Discussions = "https://github.com/sqlalchemy/sqlalchemy/discussions"
 asyncio = ["greenlet>=1"]
 mypy = [
     "mypy >= 1.7",
-    "types-greenlet >= 2"
+    "types-greenlet >= 2",
 ]
 mssql = ["pyodbc"]
 mssql-pymssql = ["pymssql"]
@@ -67,6 +67,7 @@ postgresql-psycopg2cffi = ["psycopg2cffi"]
 postgresql-psycopg = ["psycopg>=3.0.7,!=3.1.15"]
 postgresql-psycopgbinary = ["psycopg[binary]>=3.0.7,!=3.1.15"]
 pymysql = ["pymysql"]
+cymysql = ["cymysql"]
 aiomysql = [
     "greenlet>=1",  # same as ".[asyncio]" if this syntax were supported
     "aiomysql",


### PR DESCRIPTION
Tipyng of mysql dialect.

possible breaking changes:

- on `visit_sequence`, `visit_true` and `visit_false` I changed the param names to be the same tht in the super class.
- Removed  `tostring` on `array`. `tostring` is deprecated since Python 3.2 and removed in Python3.9 so i guess we can remove that option altogheter.
- create_connect_args on aiomysql, added an unused param _translate_args, only to have same signature as super class.
-  delete _check_unicode_returns method. on MySQLDialect_mysqldb. I think is not used after https://gerrit.sqlalchemy.org/c/sqlalchemy/sqlalchemy/+/1946, and is calling to a super that I think doesnt exist anymore.
- delete _set_isolation_level, is unused, and has a super that doesnt exists anymore: 
https://github.com/sqlalchemy/sqlalchemy/commit/af1b91626f63e00e11d07ad378d23198abc7f91f
- Separate _bitmap in enumerated to _bitmap and _inversed_bitmap to have type safety
- Add inheritance from log.Identified to MySQLTableDefinitionParser, because has the decorathor @log.class_logger

Related to issue :
https://github.com/sqlalchemy/sqlalchemy/issues/6810