### PR TITLE
refactor(mapped column): remove redundant checking nullable in kwargs

### DIFF
--- a/lib/sqlalchemy/orm/properties.py
+++ b/lib/sqlalchemy/orm/properties.py
@@ -584,7 +584,7 @@ class MappedColumn(
         self._sort_order = kw.pop("sort_order", _NoArg.NO_ARG)
         self.column = cast("Column[_T]", Column(*arg, **kw))
         self.foreign_keys = self.column.foreign_keys
-        self._has_nullable = "nullable" in kw and kw.get("nullable") not in (
+        self._has_nullable = kw.get("nullable") not in (
             None,
             SchemaConst.NULL_UNSPECIFIED,
         )


### PR DESCRIPTION
### Description
Remove redundant checking nullable in kwargs of class `MappedColumn`

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
- [x] A short code fix
- [ ] A new feature implementation

---
P.S. I saw that you want to see an issue for such one-line PR, however, none of the proposed issue categories are suitable for refactoring. However, it's ok if you reject the request, but maybe it's worth creating a new issue category for **refactoring**.
