### PR TITLE
fix PG enum reflection when schema is different

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3833,8 +3833,7 @@ class PGDialect(default.DefaultDialect):
                 args = tuple(enum["labels"])
                 kwargs["name"] = enum["name"]
 
-                if not enum["visible"]:
-                    kwargs["schema"] = enum["schema"]
+                kwargs["schema"] = enum["schema"]
                 args = tuple(enum["labels"])
             elif enum_or_domain_key in domains:
                 schema_type = DOMAIN


### PR DESCRIPTION
When an enum has a schema specified:
```
sqlalchemy.sql.sqltypes.Enum(MyEnum, schema="schema1")
```

Alembic always detects a type change in [alembic.ddl.impl.DefaultImpl.compare_type](https://github.com/sqlalchemy/alembic/blob/de3958bf414477010fe67d1fc925b63a8fae705c/alembic/ddl/impl.py#L591-L592):
```
inspector_params = Params(token0='myenum', tokens=[], args=[], kwargs={})
metadata_params = Params(token0='schema1', tokens=['myenum'], args=[], kwargs={})
```

I think this patch solves https://github.com/sqlalchemy/alembic/issues/899



### Checklist

- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.