### PR TITLE
before_mapper_configured event doc fixes

### DIFF
--- a/lib/sqlalchemy/orm/events.py
+++ b/lib/sqlalchemy/orm/events.py
@@ -976,7 +976,7 @@ class MapperEvents(event.Events[mapperlib.Mapper[Any]]):
         symbol which indicates to the :func:`.configure_mappers` call that this
         particular mapper (or hierarchy of mappers, if ``propagate=True`` is
         used) should be skipped in the current configuration run. When one or
-        more mappers are skipped, the he "new mappers" flag will remain set,
+        more mappers are skipped, the "new mappers" flag will remain set,
         meaning the :func:`.configure_mappers` function will continue to be
         called when mappers are used, to continue to try to configure all
         available mappers.

--- a/lib/sqlalchemy/orm/events.py
+++ b/lib/sqlalchemy/orm/events.py
@@ -985,7 +985,7 @@ class MapperEvents(event.Events[mapperlib.Mapper[Any]]):
         :meth:`.MapperEvents.before_configured`,
         :meth:`.MapperEvents.after_configured`, and
         :meth:`.MapperEvents.mapper_configured`, the
-        :meth;`.MapperEvents.before_mapper_configured` event provides for a
+        :meth:`.MapperEvents.before_mapper_configured` event provides for a
         meaningful return value when it is registered with the ``retval=True``
         parameter.
 


### PR DESCRIPTION
### Description
Two minor fixes to the [before_mapper_configured event docstring](https://docs.sqlalchemy.org/en/20/orm/events.html#sqlalchemy.orm.MapperEvents.before_mapper_configured), a spurious  ~~he~~ in `the he “new mappers”`, and a typo in reST role: `:meth;` instead of `:meth:`.

### Checklist
This pull request is:

- [X] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Happy xmas!**
