### PR TITLE
Asyncpg null query fix

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/asyncpg.py
+++ b/lib/sqlalchemy/dialects/postgresql/asyncpg.py
@@ -584,6 +584,8 @@ class AsyncAdapt_asyncpg_cursor(AsyncAdapt_dbapi_cursor):
                 else:
                     self._rows = deque(await prepared_stmt.fetch(*parameters))
                     status = prepared_stmt.get_statusmsg()
+                    if status is None:
+                        status = ""
 
                     reg = re.match(
                         r"(?:SELECT|UPDATE|DELETE|INSERT \d+) (\d+)", status

--- a/test/dialect/postgresql/test_async_pg_py3k.py
+++ b/test/dialect/postgresql/test_async_pg_py3k.py
@@ -7,6 +7,7 @@ from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import MetaData
 from sqlalchemy import select
+from sqlalchemy import text
 from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy import testing
@@ -335,8 +336,6 @@ class AsyncPgTest(fixtures.TestBase):
     @async_test
     async def test_name_connection_func(self, metadata, async_testing_engine):
 
-        engine = async_testing_engine(
-            options={"connect_args": {"prepared_statement_name_func": name_f}},
-        )
+        engine = async_testing_engine()
         async with engine.begin() as conn:
-            await conn.execute("")
+            await conn.execute(text(""))

--- a/test/dialect/postgresql/test_async_pg_py3k.py
+++ b/test/dialect/postgresql/test_async_pg_py3k.py
@@ -332,10 +332,3 @@ class AsyncPgTest(fixtures.TestBase):
         async with engine.begin() as conn:
             await conn.execute(select(1))
             assert len(cache) > 0
-
-    @async_test
-    async def test_name_connection_func(self, metadata, async_testing_engine):
-
-        engine = async_testing_engine()
-        async with engine.begin() as conn:
-            await conn.execute(text(""))

--- a/test/dialect/postgresql/test_async_pg_py3k.py
+++ b/test/dialect/postgresql/test_async_pg_py3k.py
@@ -331,3 +331,12 @@ class AsyncPgTest(fixtures.TestBase):
         async with engine.begin() as conn:
             await conn.execute(select(1))
             assert len(cache) > 0
+
+    @async_test
+    async def test_name_connection_func(self, metadata, async_testing_engine):
+
+        engine = async_testing_engine(
+            options={"connect_args": {"prepared_statement_name_func": name_f}},
+        )
+        async with engine.begin() as conn:
+            await conn.execute("")

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -791,7 +791,7 @@ class MultiHostConnectTest(fixtures.TestBase):
 class NullQueryTest(fixtures.TestBase):
     __backend__ = True
 
-    @testing.only_on(["+psycopg", "+psycopg2", "+asyncpg"])
+    @testing.only_on(["+psycopg", "+asyncpg"])
     @testing.combinations(
         ("postgresql+D://U:PS@/DB?host=H:P&host=H:P&host=H:P"),
         argnames="pattern",

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -788,37 +788,26 @@ class MultiHostConnectTest(fixtures.TestBase):
         ):
             dialect.create_connect_args(u)
 
+
 class NullQueryTest(fixtures.TestBase):
     __backend__ = True
 
-    @testing.only_on(["+psycopg", "+asyncpg"])
-    @testing.combinations(
-        ("postgresql+D://U:PS@/DB?host=H:P&host=H:P&host=H:P"),
-        argnames="pattern",
-    )
-    def test_multiple_host_real_connect(
-        self, testing_engine, pattern
-    ):
-        tdb_url = testing.db.url
+    @testing.only_on(["+psycopg2"])
+    def test_nonfunctional(self, connection):
+        with expect_raises_message(
+            Exception, "can't execute an empty query"
+        ):
+            result = connection.exec_driver_sql("")
 
-        host = tdb_url.host
-        if host == "127.0.0.1":
-            host = "localhost"
-        port = str(tdb_url.port) if tdb_url.port else "5432"
 
-        url_string = (
-            pattern.replace("DB", tdb_url.database)
-            .replace("postgresql+D", tdb_url.drivername)
-            .replace("U", tdb_url.username)
-            .replace("PS", tdb_url.password)
-            .replace("H", host)
-            .replace("P", port)
-        )
+    @testing.only_on(["+psycopg", "+asyncpg", "+pg8000"])
+    def test_functional(self, connection):
 
-        e = testing_engine(url_string)
-        with e.connect() as conn:
-            conn.exec_driver_sql("")
-
+        result = connection.exec_driver_sql("")
+        with expect_raises_message(
+            exc.ResourceClosedError, ""
+        ):
+            result.all()
 
 class BackendDialectTest(fixtures.TestBase):
     __backend__ = True


### PR DESCRIPTION
This PR provides the ability to issue null queries in postgres via the asyncpg dialect.

### Description
Null queries are a useful feature because they are the most minimal query that you can send to the server in postgres. This makes them extremely useful in health checks. Currently sqlalchemy's implementation of asyncpg dialect does not support them because of a regex statement that sometimes tries to evaluate a regex on a value that can be null. This fixes this by changing any null value to an empty string before passing to the regex.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
