### PR TITLE
README.unittests: fixup for parallelized 'pytest' example

### DIFF
--- a/README.unittests.rst
+++ b/README.unittests.rst
@@ -49,7 +49,7 @@ database options and test selection.
 
 A generic pytest run looks like::
 
-    pytest - n4
+    pytest -n4
 
 Above, the full test suite will run against SQLite, using four processes.
 If the "-n" flag is not used, the pytest-xdist is skipped and the tests will


### PR DESCRIPTION
### Description
An extremely pedantic fixup noticed during code review of differences from v2.0.36 to v2.0.37.  It looks like some autoformatting misidentified `pytest -n4` as a mathematical expression (subtracting four from `pytest`).

### Checklist
This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed