### PR TITLE
Skip mypy plugin tests if incompatible or missing

### DIFF
--- a/test/ext/mypy/test_mypy_plugin_py3k.py
+++ b/test/ext/mypy/test_mypy_plugin_py3k.py
@@ -2,6 +2,13 @@ import os
 import pathlib
 import shutil
 
+try:
+    from mypy.version import __version__ as _mypy_version_str
+except ImportError:
+    _mypy_version = None
+else:
+    _mypy_version = tuple(int(x) for x in _mypy_version_str.split("."))
+
 from sqlalchemy import testing
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
@@ -24,7 +31,15 @@ def _incremental_dirs():
     return files
 
 
+def _mypy_missing_or_incompatible():
+    return not _mypy_version or _mypy_version > (1, 10, 1)
+
+
 class MypyPluginTest(fixtures.MypyTest):
+    @testing.skip_if(
+        _mypy_missing_or_incompatible,
+        "Mypy must be present and compatible (<= 1.10.1)",
+    )
     @testing.combinations(
         *[
             (pathlib.Path(pathname).name, pathname)
@@ -75,6 +90,10 @@ class MypyPluginTest(fixtures.MypyTest):
                 % (patchfile, result[0]),
             )
 
+    @testing.skip_if(
+        _mypy_missing_or_incompatible,
+        "Mypy must be present and compatible (<= 1.10.1)",
+    )
     @testing.combinations(
         *(
             (os.path.basename(path), path, True)


### PR DESCRIPTION
Fixes: #12287

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

This skips Mypy plugin tests if mypy is missing or an unsupported version.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
