### PR TITLE
Use AsyncAdaptedQueuePool in aiosqlite

### DIFF
--- a/doc/build/changelog/unreleased_20/12285.rst
+++ b/doc/build/changelog/unreleased_20/12285.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: change, sqlite, aiosqlite, asyncio, pool
+    :tickets: 12285
+
+    Changed default connection pool of aiosqlite from NullPool to AsyncAdaptedQueuePool for consistency with pysqlite.
+

--- a/lib/sqlalchemy/dialects/sqlite/aiosqlite.py
+++ b/lib/sqlalchemy/dialects/sqlite/aiosqlite.py
@@ -78,6 +78,28 @@ The solution is similar to :ref:`pysqlite_serializable`. This is achieved by the
    with the SQLite driver,
    as this function necessarily will also alter the ".isolation_level" setting.
 
+.. _aiosqlite_pooling:
+
+Pooling Behavior
+----------------
+
+The SQLAlchemy ``aiosqlite`` DBAPI establishes the connection pool differently
+based on the kind of SQLite database that's requested:
+
+* When a ``:memory:`` SQLite database is specified, the dialect by default
+  will use :class:`.StaticPool`. This pool maintains a single
+  connection, so that all access to the engine
+  use the same ``:memory:`` database.
+* When a file-based database is specified, the dialect will use
+  :class:`.AsyncAdaptedQueuePool` as the source of connections.
+
+  .. versionchanged:: 2.0.37
+
+    SQLite file database engines now use :class:`.AsyncAdaptedQueuePool` by default.
+    Previously, :class:`.NullPool` were used.  The :class:`.NullPool` class
+    may be used by specifying it via the
+    :paramref:`_sa.create_engine.poolclass` parameter.
+
 """  # noqa
 
 import asyncio
@@ -235,7 +257,7 @@ class SQLiteDialect_aiosqlite(SQLiteDialect_pysqlite):
     @classmethod
     def get_pool_class(cls, url):
         if cls._is_url_file_db(url):
-            return pool.NullPool
+            return pool.AsyncAdaptedQueuePool
         else:
             return pool.StaticPool
 

--- a/lib/sqlalchemy/dialects/sqlite/aiosqlite.py
+++ b/lib/sqlalchemy/dialects/sqlite/aiosqlite.py
@@ -93,7 +93,7 @@ based on the kind of SQLite database that's requested:
 * When a file-based database is specified, the dialect will use
   :class:`.AsyncAdaptedQueuePool` as the source of connections.
 
-  .. versionchanged:: 2.0.37
+  .. versionchanged:: 2.0.38
 
     SQLite file database engines now use :class:`.AsyncAdaptedQueuePool` by default.
     Previously, :class:`.NullPool` were used.  The :class:`.NullPool` class


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Change default pool in `aiosqlite` from `NullPool` to `AsyncAdaptedQueuePool`.
This ensures consistency with pysqlite and least surprise when migrating from sync to async.
See discussion in https://github.com/sqlalchemy/sqlalchemy/discussions/12285
Non regression tested by existing tests.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
