### PR TITLE
Fixes: #12117 Unable to use InstrumentedAttribute to value mappings in mysql/mariadb on_duplicate_key_update

### DIFF
--- a/doc/build/changelog/unreleased_20/12117.rst
+++ b/doc/build/changelog/unreleased_20/12117.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: bug, dml, mariadb, mysql
+    :tickets: 12117
+
+    Fixed a bug where the :class:`MySQLCompiler` would not properly compile statements
+    that include the ``on_duplicate_key_update`` :class:`InstrumentedAttribute` object.

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1405,7 +1405,7 @@ class MySQLCompiler(compiler.SQLCompiler):
             coercions.expect_as_key(roles.DMLColumnRole, key): value
             for key, value in on_duplicate.update.items()
         }
-        
+
         # traverses through all table columns to preserve table column order
         for column in (col for col in cols if col.key in on_duplicate_update):
             val = on_duplicate_update[column.key]

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1097,7 +1097,6 @@ from ...engine import cursor as _cursor
 from ...engine import default
 from ...engine import reflection
 from ...engine.reflection import ReflectionDefaults
-from ...orm.attributes import InstrumentedAttribute
 from ...sql import coercions
 from ...sql import compiler
 from ...sql import elements
@@ -1403,7 +1402,7 @@ class MySQLCompiler(compiler.SQLCompiler):
                 _on_dup_alias_name = "new"
 
         on_duplicate_update = {
-            (key.key if isinstance(key, InstrumentedAttribute) else key): value
+            coercions.expect_as_key(roles.DMLColumnRole, key): value
             for key, value in on_duplicate.update.items()
         }
         

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -54,6 +54,9 @@ from sqlalchemy import VARCHAR
 from sqlalchemy.dialects.mysql import base as mysql
 from sqlalchemy.dialects.mysql import insert
 from sqlalchemy.dialects.mysql import match
+from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
 from sqlalchemy.sql import column
 from sqlalchemy.sql import delete
 from sqlalchemy.sql import table
@@ -1343,7 +1346,21 @@ class InsertOnDuplicateTest(fixtures.TestBase, AssertsCompiledSQL):
             },
             dialect=dialect,
         )
+    
+    def test_on_update_instrumented_attribute_dict(self):
+        class Base(DeclarativeBase):
+            pass
+        class T(Base):
+            __tablename__ = "table"
 
+            foo: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+        q = insert(T).values(foo=1).on_duplicate_key_update({T.foo: 2})
+        self.assert_compile(
+            q, 
+            "INSERT INTO `table` (foo) VALUES (%s) ON DUPLICATE KEY UPDATE foo = %s",
+            {"foo": 1, "param_1": 2}
+        )
 
 class RegexpCommon(testing.AssertsCompiledSQL):
     def setup_test(self):

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -1346,10 +1346,11 @@ class InsertOnDuplicateTest(fixtures.TestBase, AssertsCompiledSQL):
             },
             dialect=dialect,
         )
-    
+
     def test_on_update_instrumented_attribute_dict(self):
         class Base(DeclarativeBase):
             pass
+
         class T(Base):
             __tablename__ = "table"
 
@@ -1357,10 +1358,14 @@ class InsertOnDuplicateTest(fixtures.TestBase, AssertsCompiledSQL):
 
         q = insert(T).values(foo=1).on_duplicate_key_update({T.foo: 2})
         self.assert_compile(
-            q, 
-            "INSERT INTO `table` (foo) VALUES (%s) ON DUPLICATE KEY UPDATE foo = %s",
-            {"foo": 1, "param_1": 2}
+            q,
+            (
+                "INSERT INTO `table` (foo) VALUES (%s) "
+                "ON DUPLICATE KEY UPDATE foo = %s"
+            ),
+            {"foo": 1, "param_1": 2},
         )
+
 
 class RegexpCommon(testing.AssertsCompiledSQL):
     def setup_test(self):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Fix https://github.com/sqlalchemy/sqlalchemy/issues/12117. 
Unable to use InstrumentedAttribute to value mappings in mysql/mariadb on_duplicate_key_update

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.

**Have a nice day!**
