### PR TITLE
doc(reconecting_engine): fix re-raise after attempts

### DIFF
--- a/doc/build/faq/connections.rst
+++ b/doc/build/faq/connections.rst
@@ -259,10 +259,10 @@ statement executions::
                 except engine.dialect.dbapi.Error as raw_dbapi_err:
                     connection = context.root_connection
                     if engine.dialect.is_disconnect(raw_dbapi_err, connection, cursor_obj):
-                        if retry == num_retries:
-                            raise
                         engine.logger.error(
-                            "disconnection error, retrying operation",
+                            "disconnection error, attempt %d/%d",
+                            retry + 1,
+                            num_retries + 1,
                             exc_info=True,
                         )
                         connection.invalidate()
@@ -274,6 +274,9 @@ statement executions::
                             trans = connection.get_transaction()
                             if trans:
                                 trans.rollback()
+
+                        if retry == num_retries:
+                            raise
 
                         time.sleep(retry_interval)
                         context.cursor = cursor_obj = connection.connection.cursor()

--- a/doc/build/faq/connections.rst
+++ b/doc/build/faq/connections.rst
@@ -259,7 +259,7 @@ statement executions::
                 except engine.dialect.dbapi.Error as raw_dbapi_err:
                     connection = context.root_connection
                     if engine.dialect.is_disconnect(raw_dbapi_err, connection, cursor_obj):
-                        if retry > num_retries:
+                        if retry == num_retries:
                             raise
                         engine.logger.error(
                             "disconnection error, retrying operation",


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
It seems that there is an off-by-one error in this `reconnecting_engine` snippet. 
Taking an example of `num_retries=1`, `range(num_retries + 1)` would be `[0,1]`, so `retry > num_retries` never happens.
This means the error is not re-raised, and we needlessly `time.sleep(retry_interval)`, as there is no other attempt.


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
