### PR TITLE
Fix 'polymorphic' typo in a few places

### DIFF
--- a/doc/build/orm/declarative_tables.rst
+++ b/doc/build/orm/declarative_tables.rst
@@ -1519,7 +1519,7 @@ mapper configuration::
 
         __mapper_args__ = {
             "polymorphic_on": __table__.c.type,
-            "polymorhpic_identity": "person",
+            "polymorphic_identity": "person",
         }
 
 The "imperative table" form is also used when a non-:class:`_schema.Table`

--- a/lib/sqlalchemy/orm/path_registry.py
+++ b/lib/sqlalchemy/orm/path_registry.py
@@ -570,7 +570,7 @@ class _PropRegistry(PathRegistry):
             # entities are used.
             #
             # here we are trying to distinguish between a path that starts
-            # on a the with_polymorhpic entity vs. one that starts on a
+            # on a with_polymorphic entity vs. one that starts on a
             # normal entity that introduces a with_polymorphic() in the
             # middle using of_type():
             #

--- a/test/orm/test_core_compilation.py
+++ b/test/orm/test_core_compilation.py
@@ -1797,7 +1797,7 @@ class InheritedTest(_poly_fixtures._Polymorphic):
     run_setup_mappers = "once"
 
 
-class ExplicitWithPolymorhpicTest(
+class ExplicitWithPolymorphicTest(
     _poly_fixtures._PolymorphicUnions, AssertsCompiledSQL
 ):
     __dialect__ = "default"


### PR DESCRIPTION
### Description
I have fixed the spelling of "polymorphic" in the documentation, a comment and a test class name. 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
