### PR TITLE
Support generic types for union and union_all

### DIFF
--- a/doc/build/changelog/unreleased_20/11922.rst
+++ b/doc/build/changelog/unreleased_20/11922.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: typing, use case
+    :tickets: 11922
+
+    Support generic types for :func:`union`` and :func:`union_all`.
+    :func:`union`` and :func:`union_all` follow the type of the first select.
+    :class:`CompoundSelect` now inherit :class:`TypedReturnsRows[Unpack[_Ts]]`.

--- a/lib/sqlalchemy/sql/_selectable_constructors.py
+++ b/lib/sqlalchemy/sql/_selectable_constructors.py
@@ -109,7 +109,7 @@ def cte(
 
 def except_(
     *selects: _SelectStatementForCompoundArgument,
-) -> CompoundSelect:
+) -> CompoundSelect[Unpack[TupleAny]]:
     r"""Return an ``EXCEPT`` of multiple selectables.
 
     The returned object is an instance of
@@ -124,7 +124,7 @@ def except_(
 
 def except_all(
     *selects: _SelectStatementForCompoundArgument,
-) -> CompoundSelect:
+) -> CompoundSelect[Unpack[TupleAny]]:
     r"""Return an ``EXCEPT ALL`` of multiple selectables.
 
     The returned object is an instance of
@@ -185,7 +185,7 @@ def exists(
 
 def intersect(
     *selects: _SelectStatementForCompoundArgument,
-) -> CompoundSelect:
+) -> CompoundSelect[Unpack[TupleAny]]:
     r"""Return an ``INTERSECT`` of multiple selectables.
 
     The returned object is an instance of
@@ -200,7 +200,7 @@ def intersect(
 
 def intersect_all(
     *selects: _SelectStatementForCompoundArgument,
-) -> CompoundSelect:
+) -> CompoundSelect[Unpack[TupleAny]]:
     r"""Return an ``INTERSECT ALL`` of multiple selectables.
 
     The returned object is an instance of
@@ -569,9 +569,91 @@ def tablesample(
     return TableSample._factory(selectable, sampling, name=name, seed=seed)
 
 
+@overload
+def union(
+    select1: Select[_T0],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0]: ...
+
+
+@overload
+def union(
+    select1: Select[_T0, _T1],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1]: ...
+
+
+@overload
+def union(
+    select1: Select[_T0, _T1, _T2],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1, _T2]: ...
+
+
+@overload
+def union(
+    select1: Select[_T0, _T1, _T2, _T3],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1, _T2, _T3]: ...
+
+
+@overload
+def union(
+    select1: Select[_T0, _T1, _T2, _T3, _T4],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1, _T2, _T3, _T4]: ...
+
+
+@overload
+def union(
+    select1: Select[_T0, _T1, _T2, _T3, _T4, _T5],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1, _T2, _T3, _T4, _T5]: ...
+
+
+@overload
+def union(
+    select1: Select[_T0, _T1, _T2, _T3, _T4, _T5, _T6],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1, _T2, _T3, _T4, _T5, _T6]: ...
+
+
+@overload
+def union(
+    select1: Select[_T0, _T1, _T2, _T3, _T4, _T5, _T6, _T7],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1, _T2, _T3, _T4, _T5, _T6, _T7]: ...
+
+
+@overload
+def union(
+    select1: Select[_T0, _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8]: ...
+
+
+@overload
+def union(
+    select1: Select[_T0, _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[
+    _T0, _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, Unpack[TupleAny]
+]: ...
+
+
 def union(
     *selects: _SelectStatementForCompoundArgument,
-) -> CompoundSelect:
+) -> CompoundSelect[Unpack[TupleAny]]:
     r"""Return a ``UNION`` of multiple selectables.
 
     The returned object is an instance of
@@ -591,9 +673,91 @@ def union(
     return CompoundSelect._create_union(*selects)
 
 
+@overload
+def union_all(
+    select1: Select[_T0],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0]: ...
+
+
+@overload
+def union_all(
+    select1: Select[_T0, _T1],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1]: ...
+
+
+@overload
+def union_all(
+    select1: Select[_T0, _T1, _T2],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1, _T2]: ...
+
+
+@overload
+def union_all(
+    select1: Select[_T0, _T1, _T2, _T3],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1, _T2, _T3]: ...
+
+
+@overload
+def union_all(
+    select1: Select[_T0, _T1, _T2, _T3, _T4],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1, _T2, _T3, _T4]: ...
+
+
+@overload
+def union_all(
+    select1: Select[_T0, _T1, _T2, _T3, _T4, _T5],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1, _T2, _T3, _T4, _T5]: ...
+
+
+@overload
+def union_all(
+    select1: Select[_T0, _T1, _T2, _T3, _T4, _T5, _T6],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1, _T2, _T3, _T4, _T5, _T6]: ...
+
+
+@overload
+def union_all(
+    select1: Select[_T0, _T1, _T2, _T3, _T4, _T5, _T6, _T7],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1, _T2, _T3, _T4, _T5, _T6, _T7]: ...
+
+
+@overload
+def union_all(
+    select1: Select[_T0, _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[_T0, _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8]: ...
+
+
+@overload
+def union_all(
+    select1: Select[_T0, _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9],
+    /,
+    *selects: _SelectStatementForCompoundArgument,
+) -> CompoundSelect[
+    _T0, _T1, _T2, _T3, _T4, _T5, _T6, _T7, _T8, _T9, Unpack[TupleAny]
+]: ...
+
+
 def union_all(
     *selects: _SelectStatementForCompoundArgument,
-) -> CompoundSelect:
+) -> CompoundSelect[Unpack[TupleAny]]:
     r"""Return a ``UNION ALL`` of multiple selectables.
 
     The returned object is an instance of

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -4416,7 +4416,9 @@ class _CompoundSelectKeyword(Enum):
     INTERSECT_ALL = "INTERSECT ALL"
 
 
-class CompoundSelect(HasCompileState, GenerativeSelect, ExecutableReturnsRows):
+class CompoundSelect(
+    HasCompileState, GenerativeSelect, TypedReturnsRows[Unpack[_Ts]]
+):
     """Forms the basis of ``UNION``, ``UNION ALL``, and other
     SELECT-based set operations.
 
@@ -4478,37 +4480,37 @@ class CompoundSelect(HasCompileState, GenerativeSelect, ExecutableReturnsRows):
     @classmethod
     def _create_union(
         cls, *selects: _SelectStatementForCompoundArgument
-    ) -> CompoundSelect:
+    ) -> CompoundSelect[Unpack[_Ts]]:
         return CompoundSelect(_CompoundSelectKeyword.UNION, *selects)
 
     @classmethod
     def _create_union_all(
         cls, *selects: _SelectStatementForCompoundArgument
-    ) -> CompoundSelect:
+    ) -> CompoundSelect[Unpack[_Ts]]:
         return CompoundSelect(_CompoundSelectKeyword.UNION_ALL, *selects)
 
     @classmethod
     def _create_except(
         cls, *selects: _SelectStatementForCompoundArgument
-    ) -> CompoundSelect:
+    ) -> CompoundSelect[Unpack[_Ts]]:
         return CompoundSelect(_CompoundSelectKeyword.EXCEPT, *selects)
 
     @classmethod
     def _create_except_all(
         cls, *selects: _SelectStatementForCompoundArgument
-    ) -> CompoundSelect:
+    ) -> CompoundSelect[Unpack[_Ts]]:
         return CompoundSelect(_CompoundSelectKeyword.EXCEPT_ALL, *selects)
 
     @classmethod
     def _create_intersect(
         cls, *selects: _SelectStatementForCompoundArgument
-    ) -> CompoundSelect:
+    ) -> CompoundSelect[Unpack[_Ts]]:
         return CompoundSelect(_CompoundSelectKeyword.INTERSECT, *selects)
 
     @classmethod
     def _create_intersect_all(
         cls, *selects: _SelectStatementForCompoundArgument
-    ) -> CompoundSelect:
+    ) -> CompoundSelect[Unpack[_Ts]]:
         return CompoundSelect(_CompoundSelectKeyword.INTERSECT_ALL, *selects)
 
     def _scalar_type(self) -> TypeEngine[Any]:
@@ -4525,7 +4527,9 @@ class CompoundSelect(HasCompileState, GenerativeSelect, ExecutableReturnsRows):
                 return True
         return False
 
-    def set_label_style(self, style: SelectLabelStyle) -> CompoundSelect:
+    def set_label_style(
+        self, style: SelectLabelStyle
+    ) -> CompoundSelect[Unpack[_Ts]]:
         if self._label_style is not style:
             self = self._generate()
             select_0 = self.selects[0].set_label_style(style)
@@ -4533,7 +4537,7 @@ class CompoundSelect(HasCompileState, GenerativeSelect, ExecutableReturnsRows):
 
         return self
 
-    def _ensure_disambiguated_names(self) -> CompoundSelect:
+    def _ensure_disambiguated_names(self) -> CompoundSelect[Unpack[_Ts]]:
         new_select = self.selects[0]._ensure_disambiguated_names()
         if new_select is not self.selects[0]:
             self = self._generate()
@@ -6573,7 +6577,7 @@ class Select(
 
     def union(
         self, *other: _SelectStatementForCompoundArgument
-    ) -> CompoundSelect:
+    ) -> CompoundSelect[Unpack[_Ts]]:
         r"""Return a SQL ``UNION`` of this select() construct against
         the given selectables provided as positional arguments.
 
@@ -6592,7 +6596,7 @@ class Select(
 
     def union_all(
         self, *other: _SelectStatementForCompoundArgument
-    ) -> CompoundSelect:
+    ) -> CompoundSelect[Unpack[_Ts]]:
         r"""Return a SQL ``UNION ALL`` of this select() construct against
         the given selectables provided as positional arguments.
 
@@ -6611,7 +6615,7 @@ class Select(
 
     def except_(
         self, *other: _SelectStatementForCompoundArgument
-    ) -> CompoundSelect:
+    ) -> CompoundSelect[Unpack[_Ts]]:
         r"""Return a SQL ``EXCEPT`` of this select() construct against
         the given selectable provided as positional arguments.
 
@@ -6627,7 +6631,7 @@ class Select(
 
     def except_all(
         self, *other: _SelectStatementForCompoundArgument
-    ) -> CompoundSelect:
+    ) -> CompoundSelect[Unpack[_Ts]]:
         r"""Return a SQL ``EXCEPT ALL`` of this select() construct against
         the given selectables provided as positional arguments.
 
@@ -6643,7 +6647,7 @@ class Select(
 
     def intersect(
         self, *other: _SelectStatementForCompoundArgument
-    ) -> CompoundSelect:
+    ) -> CompoundSelect[Unpack[_Ts]]:
         r"""Return a SQL ``INTERSECT`` of this select() construct against
         the given selectables provided as positional arguments.
 
@@ -6662,7 +6666,7 @@ class Select(
 
     def intersect_all(
         self, *other: _SelectStatementForCompoundArgument
-    ) -> CompoundSelect:
+    ) -> CompoundSelect[Unpack[_Ts]]:
         r"""Return a SQL ``INTERSECT ALL`` of this select() construct
         against the given selectables provided as positional arguments.
 

--- a/test/typing/plain_files/sql/common_sql_element.py
+++ b/test/typing/plain_files/sql/common_sql_element.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from sqlalchemy import asc
 from sqlalchemy import Column
 from sqlalchemy import column
+from sqlalchemy import ColumnElement
 from sqlalchemy import desc
 from sqlalchemy import Integer
 from sqlalchemy import literal
@@ -19,6 +20,8 @@ from sqlalchemy import select
 from sqlalchemy import SQLColumnExpression
 from sqlalchemy import String
 from sqlalchemy import Table
+from sqlalchemy import union
+from sqlalchemy import union_all
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
@@ -176,3 +179,33 @@ mydict = {
     literal("5"): "q",
     column("q"): "q",
 }
+
+# union, union_all (issue #11922):
+
+str_col = ColumnElement[str]()
+int_col = ColumnElement[int]()
+
+first_stmt = select(str_col, int_col)
+second_stmt = select(str_col, int_col)
+
+union_query = union(first_stmt, second_stmt)
+
+# EXPECTED_TYPE: CompoundSelect[str, int]
+reveal_type(union_query)
+
+# EXPECTED_TYPE: Result[str, int]
+reveal_type(Session().execute(union_query))
+
+union_all_query = union_all(first_stmt, second_stmt)
+
+# EXPECTED_TYPE: CompoundSelect[str, int]
+reveal_type(union_all_query)
+
+# EXPECTED_TYPE: Result[str, int]
+reveal_type(Session().execute(union_all_query))
+
+# EXPECTED_TYPE: CompoundSelect[str, int]
+reveal_type(first_stmt.union(second_stmt))
+
+# EXPECTED_TYPE: CompoundSelect[str, int]
+reveal_type(first_stmt.union_all(second_stmt))


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Resolve https://github.com/sqlalchemy/sqlalchemy/issues/11922

- Change `CompoundSelect` to generic
- Overide `union` and `union_all`
- Change `Select.union` and `Select.union` return `CompoundSelect[Unpack[_Ts]]`

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
