### PR TITLE
fix(AsyncResult): Fix scalar method error due to missing attribute

### DIFF
--- a/doc/build/changelog/unreleased_20/12338.rst
+++ b/doc/build/changelog/unreleased_20/12338.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: bug, asyncio
+    :tickets: 12338
+
+    Fixed bug where :meth:`_asyncio.AsyncResult.scalar`,
+    :meth:`_asyncio.AsyncResult.scalar_one_or_none`, and
+    :meth:`_asyncio.AsyncResult.scalar_one` would raise ``AttributeError:
+    'AsyncResult' object has no attribute '_source_supports_scalars'``.

--- a/lib/sqlalchemy/ext/asyncio/result.py
+++ b/lib/sqlalchemy/ext/asyncio/result.py
@@ -97,6 +97,7 @@ class AsyncResult(_WithKeys, AsyncCommon[Row[Unpack[_Ts]]]):
 
         self._metadata = real_result._metadata
         self._unique_filter_state = real_result._unique_filter_state
+        self._source_supports_scalars = real_result._source_supports_scalars
         self._post_creational_filter = None
 
         # BaseCursorResult pre-generates the "_row_getter".  Use that

--- a/test/ext/asyncio/test_engine_py3k.py
+++ b/test/ext/asyncio/test_engine_py3k.py
@@ -1379,6 +1379,25 @@ class AsyncResultTest(EngineFixture):
 
             await conn.run_sync(lambda _: cursor.close())
 
+    @async_test
+    @testing.combinations(
+        ("scalar_one",), ("scalar_one_or_none"), ("scalar",), argnames="case"
+    )
+    async def test_stream_scalar(self, async_engine, case):
+        users = self.tables.users
+        async with async_engine.connect() as conn:
+            result = await conn.stream(
+                select(users).limit(1).order_by(users.c.user_name)
+            )
+            if case == "scalar_one":
+                u1 = await result.scalar_one()
+            elif case == "scalar_one_or_none":
+                u1 = await result.scalar_one_or_none()
+            elif case == "scalar":
+                u1 = await result.scalar()
+
+            eq_(u1, 1)
+
 
 class TextSyncDBAPI(fixtures.TestBase):
     __requires__ = ("asyncio",)


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
inherit `real_results`'s `_source_suppport_scalars` for `AsyncResult` so calling scalar methods won't fail due to the attribute not existing

Fixes #12338 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
