### PR TITLE
Enhance AddConstraint/DropConstraint documentation

### DIFF
--- a/lib/sqlalchemy/sql/ddl.py
+++ b/lib/sqlalchemy/sql/ddl.py
@@ -747,7 +747,16 @@ class DropIndex(_DropBase):
 
 
 class AddConstraint(_CreateBase):
-    """Represent an ALTER TABLE ADD CONSTRAINT statement."""
+    """Represent an ALTER TABLE ADD CONSTRAINT statement.
+
+    Note that if a constraint has been used as part of a :class:`_schema.Table`
+    definition or specified using ``__table_args__`` for a :ref:`Declarative
+    Table configuration <orm_declarative_table_configuration>`, instantiating
+    this class for that constraint will prevent the constraint from being
+    emitted as part of a CREATE TABLE statement (e.g. via
+    :meth:`_schema.MetaData.create_all()`).
+
+    """
 
     __visit_name__ = "add_constraint"
 
@@ -759,7 +768,16 @@ class AddConstraint(_CreateBase):
 
 
 class DropConstraint(_DropBase):
-    """Represent an ALTER TABLE DROP CONSTRAINT statement."""
+    """Represent an ALTER TABLE DROP CONSTRAINT statement.
+
+    Note that if a constraint has been used as part of a :class:`_schema.Table`
+    definition or specified using ``__table_args__`` for a :ref:`Declarative
+    Table configuration <orm_declarative_table_configuration>`, instantiating
+    this class for that constraint will prevent the constraint from being
+    emitted as part of a CREATE TABLE statement (e.g. via
+    :meth:`_schema.MetaData.create_all()`).
+
+    """
 
     __visit_name__ = "drop_constraint"
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
The fact that instantiating an `AddConstrant` or `DropConstraint` instance prevents a constraint that has been included in a table definition from being emitted in a CREATE TABLE statement was undocumented.  Remedy by expanding the docstrings for those classes.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.