### PR TITLE
Fix SQLite error for table with "WITHOUT ROWID" & "STRICT"

### DIFF
--- a/doc/build/changelog/unreleased_20/12368.rst
+++ b/doc/build/changelog/unreleased_20/12368.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: bug, sqlite
+    :tickets: 12368
+
+    Fixed a bug that caused incorrect DDL when setting
+    :paramref:`.Table.sqlite_with_rowid` to ``False`` in combination with
+    :paramref:`.Table.sqlite_strict` to ``True``.

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -1758,12 +1758,18 @@ class SQLiteDDLCompiler(compiler.DDLCompiler):
         return text
 
     def post_create_table(self, table):
-        text = ""
-        if table.dialect_options["sqlite"]["with_rowid"] is False:
-            text += "\n WITHOUT ROWID"
-        if table.dialect_options["sqlite"]["strict"] is True:
-            text += "\n STRICT"
-        return text
+        table_options = []
+
+        if not table.dialect_options["sqlite"]["with_rowid"]:
+            table_options.append("WITHOUT ROWID")
+
+        if table.dialect_options["sqlite"]["strict"]:
+            table_options.append("STRICT")
+
+        if table_options:
+            return "\n " + ",\n ".join(table_options)
+        else:
+            return ""
 
 
 class SQLiteTypeCompiler(compiler.GenericTypeCompiler):

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -1153,6 +1153,14 @@ class SQLTest(fixtures.TestBase, AssertsCompiledSQL):
             "CREATE TABLE atable (id INTEGER) STRICT",
         )
 
+    def test_create_table_without_rowid_strict(self):
+        m = MetaData()
+        table = Table("atable", m, Column("id", Integer), sqlite_with_rowid=False, sqlite_strict=True)
+        self.assert_compile(
+            schema.CreateTable(table),
+            "CREATE TABLE atable (id INTEGER) WITHOUT ROWID, STRICT",
+        )
+
 
 class OnConflictDDLTest(fixtures.TestBase, AssertsCompiledSQL):
     __dialect__ = sqlite.dialect()

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -1155,7 +1155,13 @@ class SQLTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def test_create_table_without_rowid_strict(self):
         m = MetaData()
-        table = Table("atable", m, Column("id", Integer), sqlite_with_rowid=False, sqlite_strict=True)
+        table = Table(
+            "atable",
+            m,
+            Column("id", Integer),
+            sqlite_with_rowid=False,
+            sqlite_strict=True,
+        )
         self.assert_compile(
             schema.CreateTable(table),
             "CREATE TABLE atable (id INTEGER) WITHOUT ROWID, STRICT",


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Adds a comma between WITHOUT ROWID and STRICT if both options are used when creating a table.
Refer to #12368.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
