### PR TITLE
Add type annotations to `postgresql.array`

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/array.py
+++ b/lib/sqlalchemy/dialects/postgresql/array.py
@@ -4,7 +4,6 @@
 #
 # This module is part of SQLAlchemy and is released under
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
-# mypy: ignore-errors
 
 
 from __future__ import annotations
@@ -29,6 +28,7 @@ from ...sql import operators
 
 if TYPE_CHECKING:
     from ...engine.interfaces import Dialect
+    from ...sql._typing import _ColumnExpressionArgument
     from ...sql._typing import _TypeEngineArgument
     from ...sql.elements import ColumnElement
     from ...sql.elements import Grouping
@@ -45,22 +45,30 @@ if TYPE_CHECKING:
 _T = TypeVar("_T", bound=typing_Any)
 
 
-def Any(other, arrexpr, operator=operators.eq):
+def Any(
+    other: typing_Any,
+    arrexpr: _ColumnExpressionArgument[_T],
+    operator: OperatorType = operators.eq,
+) -> ColumnElement[bool]:
     """A synonym for the ARRAY-level :meth:`.ARRAY.Comparator.any` method.
     See that method for details.
 
     """
 
-    return arrexpr.any(other, operator)
+    return arrexpr.any(other, operator)  # type: ignore[no-any-return, union-attr]  # noqa: E501
 
 
-def All(other, arrexpr, operator=operators.eq):
+def All(
+    other: typing_Any,
+    arrexpr: _ColumnExpressionArgument[_T],
+    operator: OperatorType = operators.eq,
+) -> ColumnElement[bool]:
     """A synonym for the ARRAY-level :meth:`.ARRAY.Comparator.all` method.
     See that method for details.
 
     """
 
-    return arrexpr.all(other, operator)
+    return arrexpr.all(other, operator)  # type: ignore[no-any-return, union-attr]  # noqa: E501
 
 
 class array(expression.ExpressionClauseList[_T]):

--- a/lib/sqlalchemy/dialects/postgresql/array.py
+++ b/lib/sqlalchemy/dialects/postgresql/array.py
@@ -10,7 +10,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Any as typing_Any
 from typing import Optional
 from typing import TypeVar
 
@@ -24,7 +24,7 @@ from ...sql import operators
 from ...sql._typing import _TypeEngineArgument
 
 
-_T = TypeVar("_T", bound=Any)
+_T = TypeVar("_T", bound=typing_Any)
 
 
 def Any(other, arrexpr, operator=operators.eq):
@@ -237,7 +237,7 @@ class ARRAY(sqltypes.ARRAY):
 
     def __init__(
         self,
-        item_type: _TypeEngineArgument[Any],
+        item_type: _TypeEngineArgument[typing_Any],
         as_tuple: bool = False,
         dimensions: Optional[int] = None,
         zero_indexes: bool = False,

--- a/lib/sqlalchemy/dialects/postgresql/array.py
+++ b/lib/sqlalchemy/dialects/postgresql/array.py
@@ -142,12 +142,10 @@ class array(expression.ExpressionClauseList[_T]):
     ):
         super().__init__(operators.comma_op, *clauses, **kw)
 
-        self._type_tuple = [arg.type for arg in self.clauses]
-
         main_type = (
             type_
             if type_ is not None
-            else self._type_tuple[0] if self._type_tuple else sqltypes.NULLTYPE
+            else self.clauses[0].type if self.clauses else sqltypes.NULLTYPE
         )
 
         if isinstance(main_type, ARRAY):

--- a/lib/sqlalchemy/dialects/postgresql/json.py
+++ b/lib/sqlalchemy/dialects/postgresql/json.py
@@ -337,7 +337,7 @@ class JSONB(JSON):
             .. versionadded:: 2.0
             """
             if not isinstance(array, _pg_array):
-                array = _pg_array(array)  # type: ignore[no-untyped-call]
+                array = _pg_array(array)
             right_side = cast(array, ARRAY(sqltypes.TEXT))
             return self.operate(DELETE_PATH, right_side, result_type=JSONB)
 

--- a/test/typing/plain_files/dialects/postgresql/pg_stuff.py
+++ b/test/typing/plain_files/dialects/postgresql/pg_stuff.py
@@ -99,3 +99,21 @@ range_col_stmt = select(Column(INT4RANGE()), Column(INT8MULTIRANGE()))
 
 # EXPECTED_TYPE: Select[Range[int], Sequence[Range[int]]]
 reveal_type(range_col_stmt)
+
+array_from_ints = array(range(2))
+
+# EXPECTED_TYPE: array[int]
+reveal_type(array_from_ints)
+
+array_of_strings = array([], type_=Text)
+
+# EXPECTED_TYPE: array[str]
+reveal_type(array_of_strings)
+
+array_of_ints = array([0], type_=Integer)
+
+# EXPECTED_TYPE: array[int]
+reveal_type(array_of_ints)
+
+# EXPECTED_MYPY: Cannot infer type argument 1 of "array"
+array([0], type_=Text)


### PR DESCRIPTION
Improved static typing for `postgresql.array()` by making the type parameter (the type of array's elements) inferred from the `clauses` and `type_` arguments while also ensuring they are consistent.

Also completed type annotations of `postgresql.ARRAY` following commit 0bf7e02afbec557eb3a5607db407f27deb7aac77 and added type annotations for functions `postgresql.Any()` and `postgresql.All()`.
 
Finally, fixed shadowing `typing.Any` by the `Any()` function through aliasing as `typing_Any` and removed unused `_type_tuple` attribute of `postgresql.array`.

Related to #6810