### PR TITLE
Ensure PostgreSQL network address types are not cast as VARCHAR

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/types.py
+++ b/lib/sqlalchemy/dialects/postgresql/types.py
@@ -55,12 +55,22 @@ class BYTEA(sqltypes.LargeBinary):
 class INET(sqltypes.TypeEngine[str]):
     __visit_name__ = "INET"
 
+    def coerce_compared_value(
+        self, op: Optional[OperatorType], value: Any
+    ) -> TypeEngine[Any]:
+        return self
+
 
 PGInet = INET
 
 
 class CIDR(sqltypes.TypeEngine[str]):
     __visit_name__ = "CIDR"
+
+    def coerce_compared_value(
+        self, op: Optional[OperatorType], value: Any
+    ) -> TypeEngine[Any]:
+        return self
 
 
 PGCidr = CIDR
@@ -69,12 +79,22 @@ PGCidr = CIDR
 class MACADDR(sqltypes.TypeEngine[str]):
     __visit_name__ = "MACADDR"
 
+    def coerce_compared_value(
+        self, op: Optional[OperatorType], value: Any
+    ) -> TypeEngine[Any]:
+        return self
+
 
 PGMacAddr = MACADDR
 
 
 class MACADDR8(sqltypes.TypeEngine[str]):
     __visit_name__ = "MACADDR8"
+
+    def coerce_compared_value(
+        self, op: Optional[OperatorType], value: Any
+    ) -> TypeEngine[Any]:
+        return self
 
 
 PGMacAddr8 = MACADDR8

--- a/lib/sqlalchemy/dialects/postgresql/types.py
+++ b/lib/sqlalchemy/dialects/postgresql/types.py
@@ -52,49 +52,39 @@ class BYTEA(sqltypes.LargeBinary):
     __visit_name__ = "BYTEA"
 
 
-class INET(sqltypes.TypeEngine[str]):
-    __visit_name__ = "INET"
+class _NetworkAddressTypeMixin:
 
     def coerce_compared_value(
         self, op: Optional[OperatorType], value: Any
     ) -> TypeEngine[Any]:
+        if TYPE_CHECKING:
+            assert isinstance(self, TypeEngine)
         return self
+
+
+class INET(_NetworkAddressTypeMixin, sqltypes.TypeEngine[str]):
+    __visit_name__ = "INET"
 
 
 PGInet = INET
 
 
-class CIDR(sqltypes.TypeEngine[str]):
+class CIDR(_NetworkAddressTypeMixin, sqltypes.TypeEngine[str]):
     __visit_name__ = "CIDR"
-
-    def coerce_compared_value(
-        self, op: Optional[OperatorType], value: Any
-    ) -> TypeEngine[Any]:
-        return self
 
 
 PGCidr = CIDR
 
 
-class MACADDR(sqltypes.TypeEngine[str]):
+class MACADDR(_NetworkAddressTypeMixin, sqltypes.TypeEngine[str]):
     __visit_name__ = "MACADDR"
-
-    def coerce_compared_value(
-        self, op: Optional[OperatorType], value: Any
-    ) -> TypeEngine[Any]:
-        return self
 
 
 PGMacAddr = MACADDR
 
 
-class MACADDR8(sqltypes.TypeEngine[str]):
+class MACADDR8(_NetworkAddressTypeMixin, sqltypes.TypeEngine[str]):
     __visit_name__ = "MACADDR8"
-
-    def coerce_compared_value(
-        self, op: Optional[OperatorType], value: Any
-    ) -> TypeEngine[Any]:
-        return self
 
 
 PGMacAddr8 = MACADDR8

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -3447,10 +3447,51 @@ class SpecialTypesCompileTest(fixtures.TestBase, AssertsCompiledSQL):
     def test_bit_compile(self, type_, expected):
         self.assert_compile(type_, expected)
 
+    @testing.combinations(
+        (psycopg.dialect(),),
+        (psycopg2.dialect(),),
+        (asyncpg.dialect(),),
+        (pg8000.dialect(),),
+        argnames="dialect",
+        id_="n",
+    )
+    def test_network_address_cast(self, metadata, dialect):
+        t = Table(
+            "addresses",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("addr", postgresql.INET),
+            Column("addr2", postgresql.MACADDR),
+            Column("addr3", postgresql.CIDR),
+            Column("addr4", postgresql.MACADDR8),
+        )
+        stmt = select(t.c.id).where(
+            t.c.addr == "127.0.0.1",
+            t.c.addr2 == "08:00:2b:01:02:03",
+            t.c.addr3 == "192.168.100.128/25",
+            t.c.addr4 == "08:00:2b:01:02:03:04:05",
+        )
+        param, param2, param3, param4 = {
+            "format": ("%s", "%s", "%s", "%s"),
+            "numeric_dollar": ("$1", "$2", "$3", "$4"),
+            "pyformat": (
+                "%(addr_1)s",
+                "%(addr2_1)s",
+                "%(addr3_1)s",
+                "%(addr4_1)s",
+            ),
+        }[dialect.paramstyle]
+        expected = (
+            "SELECT addresses.id FROM addresses "
+            f"WHERE addresses.addr = {param} "
+            f"AND addresses.addr2 = {param2} "
+            f"AND addresses.addr3 = {param3} "
+            f"AND addresses.addr4 = {param4}"
+        )
+        self.assert_compile(stmt, expected, dialect=dialect)
 
-class SpecialTypesTest(
-    AssertsCompiledSQL, fixtures.TablesTest, ComparesTables
-):
+
+class SpecialTypesTest(fixtures.TablesTest, ComparesTables):
     """test DDL and reflection of PG-specific types"""
 
     __only_on__ = ("postgresql >= 8.3.0",)
@@ -3502,40 +3543,6 @@ class SpecialTypesTest(
         assert t.c.plain_interval.type.precision is None
         assert t.c.precision_interval.type.precision == 3
         assert t.c.bitstring.type.length == 4
-
-    @testing.combinations(
-        (psycopg.dialect(),),
-        (psycopg2.dialect(),),
-        (asyncpg.dialect(),),
-        (pg8000.dialect(),),
-        argnames="dialect",
-        id_="n",
-    )
-    def test_network_address_cast(self, special_types_table, dialect):
-        stmt = select(special_types_table.c.id).where(
-            special_types_table.c.addr == "127.0.0.1",
-            special_types_table.c.addr2 == "08:00:2b:01:02:03",
-            special_types_table.c.addr3 == "192.168.100.128/25",
-            special_types_table.c.addr4 == "08:00:2b:01:02:03:04:05",
-        )
-        param, param2, param3, param4 = {
-            "format": ("%s", "%s", "%s", "%s"),
-            "numeric_dollar": ("$1", "$2", "$3", "$4"),
-            "pyformat": (
-                "%(addr_1)s",
-                "%(addr2_1)s",
-                "%(addr3_1)s",
-                "%(addr4_1)s",
-            ),
-        }[dialect.paramstyle]
-        expected = (
-            "SELECT sometable.id FROM sometable "
-            f"WHERE sometable.addr = {param} "
-            f"AND sometable.addr2 = {param2} "
-            f"AND sometable.addr3 = {param3} "
-            f"AND sometable.addr4 = {param4}"
-        )
-        self.assert_compile(stmt, expected, dialect=dialect)
 
     @testing.combinations(
         (postgresql.INET, "127.0.0.1"),


### PR DESCRIPTION
This is a similar change as for CITEXT in commit
d7ee73ff81ed69df43756240670bd98f3b1c3302.

Fix https://github.com/sqlalchemy/sqlalchemy/issues/12060