### PR TITLE
Support column list for foreign key ON DELETE SET actions on PostgreSQL

### DIFF
--- a/doc/build/changelog/unreleased_20/11595.rst
+++ b/doc/build/changelog/unreleased_20/11595.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: feature, postgresql
+    :tickets: 11595, 11946
+
+    Added support for specifying a list of columns for ``SET NULL`` and
+    ``SET DEFAULT`` actions of ``ON DELETE`` clause of foreign key definition on
+    PostgreSQL.

--- a/doc/build/core/constraints.rst
+++ b/doc/build/core/constraints.rst
@@ -311,6 +311,11 @@ arguments. The value is any string which will be output after the appropriate
 Note that these clauses require ``InnoDB`` tables when used with MySQL.
 They may also not be supported on other databases.
 
+On PostgreSQL, the ``SET NULL`` and ``SET DEFAULT`` actions of ``ON DELETE``
+clause also accept a list of columns to cascade on; e.g., ``ON DELETE SET NULL
+(note_id)``. Otherwise, all columns in the foreign key constraint are normally
+considered.
+
 .. seealso::
 
     For background on integration of ``ON DELETE CASCADE`` with

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -7100,14 +7100,21 @@ class DDLCompiler(Compiled):
     def define_constraint_cascades(self, constraint):
         text = ""
         if constraint.ondelete is not None:
-            text += " ON DELETE %s" % self.preparer.validate_sql_phrase(
-                constraint.ondelete, FK_ON_DELETE
-            )
+            text += self.define_constraint_ondelete_cascade(constraint)
+
         if constraint.onupdate is not None:
-            text += " ON UPDATE %s" % self.preparer.validate_sql_phrase(
-                constraint.onupdate, FK_ON_UPDATE
-            )
+            text += self.define_constraint_onupdate_cascade(constraint)
         return text
+
+    def define_constraint_ondelete_cascade(self, constraint):
+        return " ON DELETE %s" % self.preparer.validate_sql_phrase(
+            constraint.ondelete, FK_ON_DELETE
+        )
+
+    def define_constraint_onupdate_cascade(self, constraint):
+        return " ON UPDATE %s" % self.preparer.validate_sql_phrase(
+            constraint.onupdate, FK_ON_UPDATE
+        )
 
     def define_constraint_deferrability(self, constraint):
         text = ""

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -7,6 +7,7 @@ from sqlalchemy import BigInteger
 from sqlalchemy import Column
 from sqlalchemy import exc
 from sqlalchemy import ForeignKey
+from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy import Identity
 from sqlalchemy import Index
 from sqlalchemy import inspect
@@ -20,6 +21,7 @@ from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy import testing
 from sqlalchemy import Text
+from sqlalchemy import text
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.dialects.postgresql import base as postgresql
@@ -907,6 +909,51 @@ class ReflectionTest(
         meta2 = MetaData()
         subject = Table("subject", meta2, autoload_with=connection)
         eq_(subject.primary_key.columns.keys(), ["p2", "p1"])
+
+    def test_reflected_foreign_key_ondelete_column_list(
+        self, metadata, connection
+    ):
+        meta1 = metadata
+        pktable = Table(
+            "pktable",
+            meta1,
+            Column("tid", Integer, primary_key=True),
+            Column("id", Integer, primary_key=True),
+        )
+        Table(
+            "fktable",
+            meta1,
+            Column("tid", Integer),
+            Column("id", Integer),
+            Column("fk_id_del_set_null", Integer),
+            Column("fk_id_del_set_default", Integer, server_default=text("0")),
+            ForeignKeyConstraint(
+                columns=["tid", "fk_id_del_set_null"],
+                refcolumns=[pktable.c.tid, pktable.c.id],
+                ondelete="SET NULL (fk_id_del_set_null)",
+            ),
+            ForeignKeyConstraint(
+                columns=["tid", "fk_id_del_set_default"],
+                refcolumns=[pktable.c.tid, pktable.c.id],
+                ondelete="SET DEFAULT(fk_id_del_set_default)",
+            ),
+        )
+
+        meta1.create_all(connection)
+        meta2 = MetaData()
+        fktable = Table("fktable", meta2, autoload_with=connection)
+        fkey_set_null = next(
+            c
+            for c in fktable.foreign_key_constraints
+            if c.name == "fktable_tid_fk_id_del_set_null_fkey"
+        )
+        eq_(fkey_set_null.ondelete, "SET NULL (fk_id_del_set_null)")
+        fkey_set_default = next(
+            c
+            for c in fktable.foreign_key_constraints
+            if c.name == "fktable_tid_fk_id_del_set_default_fkey"
+        )
+        eq_(fkey_set_default.ondelete, "SET DEFAULT (fk_id_del_set_default)")
 
     def test_pg_weirdchar_reflection(self, metadata, connection):
         meta1 = metadata


### PR DESCRIPTION
Added support for specifying a list of columns for ON DELETE SET (NULL|DEFAULT) actions of foreign key definition on PostgreSQL. This is handled on both compiler and reflection sides.

Test cases (tables definition) are taken from PostgreSQL test suite.

Fixes: #11595
Fixes: #11946