### PR TITLE
Coerce aliased Select and CompoundSelect to subquery

### DIFF
--- a/lib/sqlalchemy/orm/util.py
+++ b/lib/sqlalchemy/orm/util.py
@@ -85,6 +85,7 @@ from ..sql.cache_key import MemoizedHasCacheKey
 from ..sql.elements import ColumnElement
 from ..sql.elements import KeyedColumnElement
 from ..sql.selectable import FromClause
+from ..sql.selectable import GenerativeSelect
 from ..util.langhelpers import MemoizedSlots
 from ..util.typing import de_stringify_annotation as _de_stringify_annotation
 from ..util.typing import eval_name_only as _eval_name_only
@@ -1015,6 +1016,19 @@ class AliasedInsp(
         flat: bool = False,
         adapt_on_names: bool = False,
     ) -> Union[AliasedClass[_O], FromClause]:
+        if isinstance(element, GenerativeSelect):
+            util.warn(
+                f"{type(element).__name__} can't be aliased, "
+                f"coercing to subquery instead."
+            )
+            if name:
+                return coercions.expect(
+                    roles.FromClauseRole, element.subquery(name=name)
+                )
+            else:
+                return coercions.expect(
+                    roles.AnonymizedFromClauseRole, element.subquery()
+                )
         if isinstance(element, FromClause):
             if adapt_on_names:
                 raise sa_exc.ArgumentError(

--- a/lib/sqlalchemy/orm/util.py
+++ b/lib/sqlalchemy/orm/util.py
@@ -1021,15 +1021,13 @@ class AliasedInsp(
                 f"{type(element).__name__} can't be aliased, "
                 f"coercing to subquery instead."
             )
-            if name:
-                return coercions.expect(
-                    roles.FromClauseRole, element.subquery(name=name)
-                )
-            else:
-                return coercions.expect(
-                    roles.AnonymizedFromClauseRole, element.subquery()
-                )
-        if isinstance(element, FromClause):
+            return coercions.expect(
+                roles.FromClauseRole,
+                element.subquery(name=name),
+                flat=flat,
+                allow_select=True
+            )
+        elif isinstance(element, FromClause):
             if adapt_on_names:
                 raise sa_exc.ArgumentError(
                     "adapt_on_names only applies to ORM elements"


### PR DESCRIPTION
Fixes issue #6274

### Description

When `aliased()` is used on a select statement or compound select statement, it currently throws an error. The proposed solution in #6274 was to instead return a subquery and emit a warning to the user that aliases are not supported for these types of statements.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
