### PR TITLE
Cast empty PostgreSQL ARRAY from the type specified to array()

### DIFF
--- a/doc/build/changelog/unreleased_20/12432.rst
+++ b/doc/build/changelog/unreleased_20/12432.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: usecase, postgresql
+    :tickets: 12432
+
+    When building a PostgreSQL ``ARRAY`` literal using
+    :class:`_postgresql.array` with an empty ``clauses`` argument, use the
+    ``type_`` argument to cast the resulting ``ARRAY[]`` SQL expression.
+    Pull request courtesy Denis Laxalde.

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1807,6 +1807,8 @@ class PGCompiler(compiler.SQLCompiler):
         }"""
 
     def visit_array(self, element, **kw):
+        if not element.clauses and not element.type.item_type._isnull:
+            return "ARRAY[]::%s" % element.type.compile(self.dialect)
         return "ARRAY[%s]" % self.visit_clauselist(element, **kw)
 
     def visit_slice(self, element, **kw):

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -1988,6 +1988,14 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             String,
         )
 
+    @testing.combinations(
+        ("with type_", Date, "ARRAY[]::DATE[]"),
+        ("no type_", None, "ARRAY[]"),
+        id_="iaa",
+    )
+    def test_array_literal_empty(self, type_, expected):
+        self.assert_compile(postgresql.array([], type_=type_), expected)
+
     def test_array_literal(self):
         self.assert_compile(
             func.array_dims(
@@ -4237,4 +4245,24 @@ class CacheKeyTest(fixtures.CacheKeyFixture, fixtures.TestBase):
                 ),
             ),
             compare_values=False,
+        )
+
+    def test_array(self):
+        self._run_cache_key_equal_fixture(
+            lambda: (
+                array([0]),
+                array([0], type_=Integer),
+                array([1], type_=Integer),
+            ),
+            compare_values=False,
+        )
+
+    def test_array_empty(self):
+        self._run_cache_key_fixture(
+            lambda: (
+                array([], type_=Integer),
+                array([], type_=Text),
+                array([0]),
+            ),
+            compare_values=True,
         )

--- a/test/dialect/postgresql/test_query.py
+++ b/test/dialect/postgresql/test_query.py
@@ -1640,6 +1640,10 @@ class TableValuedRoundTripTest(fixtures.TestBase):
 
         eq_(connection.execute(stmt).all(), [(4, 1), (3, 2), (2, 3), (1, 4)])
 
+    def test_array_empty_with_type(self, connection):
+        stmt = select(postgresql.array([], type_=Integer))
+        eq_(connection.execute(stmt).all(), [([],)])
+
     def test_plain_old_unnest(self, connection):
         fn = func.unnest(
             postgresql.array(["one", "two", "three", "four"])

--- a/test/sql/test_compare.py
+++ b/test/sql/test_compare.py
@@ -1661,6 +1661,7 @@ class HasCacheKeySubclass(fixtures.TestBase):
             {"_with_options", "_raw_columns", "_setup_joins"},
             {"args"},
         ),
+        "array": ({"operator", "type", "clauses"}, {"clauses", "type_"}),
         "next_value": ({"sequence"}, {"seq"}),
     }
 


### PR DESCRIPTION
When using `postgresql.array()` with an empty list as `clauses` and a `type_` argument specified, we now cast the resulting `ARRAY[]` SQL expression using that type information thus removing the need for an explicit cast on user side.

We need to add the 'type' attribute to the cache key of `postgresql.array` in order to distinguish statements produced with an empty list clause and with or without a `type_` argument.

Fixes #12432