### PR TITLE
Implement GROUPS frame spec for window functions (discussion #12444)

### DIFF
--- a/doc/build/changelog/unreleased_20/12444.rst
+++ b/doc/build/changelog/unreleased_20/12444.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: sql
+    :tickets: 12444
+    
+    Implemented support for the GROUPS frame specification in window 
+    functions by adding "groups" option to :class:`.Over` and 
+    :meth:`.FunctionElement.over`. Pull request courtesy Kaan Dikmen.

--- a/lib/sqlalchemy/sql/_elements_constructors.py
+++ b/lib/sqlalchemy/sql/_elements_constructors.py
@@ -1500,6 +1500,7 @@ def over(
     order_by: Optional[_ByArgument] = None,
     range_: Optional[typing_Tuple[Optional[int], Optional[int]]] = None,
     rows: Optional[typing_Tuple[Optional[int], Optional[int]]] = None,
+    groups: Optional[typing_Tuple[Optional[int], Optional[int]]] = None,
 ) -> Over[_T]:
     r"""Produce an :class:`.Over` object against a function.
 
@@ -1562,10 +1563,12 @@ def over(
     :param range\_: optional range clause for the window.  This is a
      tuple value which can contain integer values or ``None``,
      and will render a RANGE BETWEEN PRECEDING / FOLLOWING clause.
-
     :param rows: optional rows clause for the window.  This is a tuple
      value which can contain integer values or None, and will render
      a ROWS BETWEEN PRECEDING / FOLLOWING clause.
+    :param groups: optional groups clause for the window.  This is a
+     tuple value which can contain integer values or ``None``,
+     and will render a GROUPS BETWEEN PRECEDING / FOLLOWING clause.
 
     This function is also available from the :data:`~.expression.func`
     construct itself via the :meth:`.FunctionElement.over` method.
@@ -1579,7 +1582,7 @@ def over(
         :func:`_expression.within_group`
 
     """  # noqa: E501
-    return Over(element, partition_by, order_by, range_, rows)
+    return Over(element, partition_by, order_by, range_, rows, groups)
 
 
 @_document_text_coercion("text", ":func:`.text`", ":paramref:`.text.text`")

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -2880,6 +2880,8 @@ class SQLCompiler(Compiled):
             range_ = f"RANGE BETWEEN {self.process(over.range_, **kwargs)}"
         elif over.rows is not None:
             range_ = f"ROWS BETWEEN {self.process(over.rows, **kwargs)}"
+        elif over.groups is not None:
+            range_ = f"GROUPS BETWEEN {self.process(over.groups, **kwargs)}"
         else:
             range_ = None
 

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -4246,37 +4246,23 @@ class Over(ColumnElement[_T]):
                 _literal_as_text_role=roles.ByOfRole,
             )
 
-        self.range_, self.rows, self.groups = None, None, None
-        if range_:
-            self.range_ = _FrameClause(range_)
-            if rows:
-                raise exc.ArgumentError(
-                    "'range_' and 'rows' are mutually exclusive"
-                )
-            if groups:
-                raise exc.ArgumentError(
-                    "'range_' and 'groups' are mutually exclusive"
-                )
-        if rows:
-            self.rows = _FrameClause(rows)
-            if range_:
-                raise exc.ArgumentError(
-                    "'rows' and 'range_' are mutually exclusive"
-                )
-            if groups:
-                raise exc.ArgumentError(
-                    "'rows' and 'groups' are mutually exclusive"
-                )
-        if groups:
-            self.groups = _FrameClause(groups)
-            if range_:
-                raise exc.ArgumentError(
-                    "'groups' and 'range_' are mutually exclusive"
-                )
-            if rows:
-                raise exc.ArgumentError(
-                    "'groups' and 'rows' are mutually exclusive"
-                )
+        # validate frame spec and assign clause
+        _frame_spec_map = {"range_": range_, "rows": rows, "groups": groups}
+        if sum([v is not None for v in _frame_spec_map.values()]) > 1:
+            _clauses = [
+                f"'{k}'"
+                for i, k in enumerate(_frame_spec_map.keys())
+                if list(_frame_spec_map.values())[i]
+            ]
+            _clauses_str = ' and '.join(_clauses)
+            raise exc.ArgumentError(
+                f"too many frame spec clauses provided: {_clauses_str}"
+            )
+        else:
+            self.range_, self.rows, self.groups = [
+                (_FrameClause(v) if v else None)
+                for v in _frame_spec_map.values()
+            ]
 
     if not TYPE_CHECKING:
 

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -4246,7 +4246,7 @@ class Over(ColumnElement[_T]):
                 _literal_as_text_role=roles.ByOfRole,
             )
 
-        if (range_ and (rows or groups)) or (rows and (range_ or groups)):
+        if sum(bool(item) for item in (range_, rows, groups)) > 1:
             raise exc.ArgumentError(
                 "only one of 'rows', 'range_', or 'groups' may be provided"
             )

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -4246,23 +4246,14 @@ class Over(ColumnElement[_T]):
                 _literal_as_text_role=roles.ByOfRole,
             )
 
-        # validate frame spec and assign clause
-        _frame_spec_map = {"range_": range_, "rows": rows, "groups": groups}
-        if sum([v is not None for v in _frame_spec_map.values()]) > 1:
-            _clauses = [
-                f"'{k}'"
-                for i, k in enumerate(_frame_spec_map.keys())
-                if list(_frame_spec_map.values())[i]
-            ]
-            _clauses_str = ' and '.join(_clauses)
+        if (range_ and (rows or groups)) or (rows and (range_ or groups)):
             raise exc.ArgumentError(
-                f"too many frame spec clauses provided: {_clauses_str}"
+                "only one of 'rows', 'range_', or 'groups' may be provided"
             )
         else:
-            self.range_, self.rows, self.groups = [
-                (_FrameClause(v) if v else None)
-                for v in _frame_spec_map.values()
-            ]
+            self.range_ = _FrameClause(range_) if range_ else None
+            self.rows = _FrameClause(rows) if rows else None
+            self.groups = _FrameClause(groups) if groups else None
 
     if not TYPE_CHECKING:
 

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -4212,6 +4212,7 @@ class Over(ColumnElement[_T]):
         ("partition_by", InternalTraversal.dp_clauseelement),
         ("range_", InternalTraversal.dp_clauseelement),
         ("rows", InternalTraversal.dp_clauseelement),
+        ("groups", InternalTraversal.dp_clauseelement),
     ]
 
     order_by: Optional[ClauseList] = None
@@ -4223,6 +4224,7 @@ class Over(ColumnElement[_T]):
 
     range_: Optional[_FrameClause]
     rows: Optional[_FrameClause]
+    groups: Optional[_FrameClause]
 
     def __init__(
         self,
@@ -4231,6 +4233,7 @@ class Over(ColumnElement[_T]):
         order_by: Optional[_ByArgument] = None,
         range_: Optional[typing_Tuple[Optional[int], Optional[int]]] = None,
         rows: Optional[typing_Tuple[Optional[int], Optional[int]]] = None,
+        groups: Optional[typing_Tuple[Optional[int], Optional[int]]] = None,
     ):
         self.element = element
         if order_by is not None:
@@ -4243,19 +4246,37 @@ class Over(ColumnElement[_T]):
                 _literal_as_text_role=roles.ByOfRole,
             )
 
+        self.range_, self.rows, self.groups = None, None, None
         if range_:
             self.range_ = _FrameClause(range_)
             if rows:
                 raise exc.ArgumentError(
                     "'range_' and 'rows' are mutually exclusive"
                 )
-            else:
-                self.rows = None
-        elif rows:
+            if groups:
+                raise exc.ArgumentError(
+                    "'range_' and 'groups' are mutually exclusive"
+                )
+        if rows:
             self.rows = _FrameClause(rows)
-            self.range_ = None
-        else:
-            self.rows = self.range_ = None
+            if range_:
+                raise exc.ArgumentError(
+                    "'rows' and 'range_' are mutually exclusive"
+                )
+            if groups:
+                raise exc.ArgumentError(
+                    "'rows' and 'groups' are mutually exclusive"
+                )
+        if groups:
+            self.groups = _FrameClause(groups)
+            if range_:
+                raise exc.ArgumentError(
+                    "'groups' and 'range_' are mutually exclusive"
+                )
+            if rows:
+                raise exc.ArgumentError(
+                    "'groups' and 'rows' are mutually exclusive"
+                )
 
     if not TYPE_CHECKING:
 
@@ -4409,6 +4430,7 @@ class WithinGroup(ColumnElement[_T]):
         order_by: Optional[_ByArgument] = None,
         rows: Optional[typing_Tuple[Optional[int], Optional[int]]] = None,
         range_: Optional[typing_Tuple[Optional[int], Optional[int]]] = None,
+        groups: Optional[typing_Tuple[Optional[int], Optional[int]]] = None,
     ) -> Over[_T]:
         """Produce an OVER clause against this :class:`.WithinGroup`
         construct.
@@ -4423,6 +4445,7 @@ class WithinGroup(ColumnElement[_T]):
             order_by=order_by,
             range_=range_,
             rows=rows,
+            groups=groups,
         )
 
     @overload
@@ -4540,6 +4563,7 @@ class FunctionFilter(Generative, ColumnElement[_T]):
         ] = None,
         range_: Optional[typing_Tuple[Optional[int], Optional[int]]] = None,
         rows: Optional[typing_Tuple[Optional[int], Optional[int]]] = None,
+        groups: Optional[typing_Tuple[Optional[int], Optional[int]]] = None,
     ) -> Over[_T]:
         """Produce an OVER clause against this filtered function.
 
@@ -4565,6 +4589,7 @@ class FunctionFilter(Generative, ColumnElement[_T]):
             order_by=order_by,
             range_=range_,
             rows=rows,
+            groups=groups,
         )
 
     def within_group(

--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -435,6 +435,7 @@ class FunctionElement(Executable, ColumnElement[_T], FromClause, Generative):
         order_by: Optional[_ByArgument] = None,
         rows: Optional[Tuple[Optional[int], Optional[int]]] = None,
         range_: Optional[Tuple[Optional[int], Optional[int]]] = None,
+        groups: Optional[Tuple[Optional[int], Optional[int]]] = None,
     ) -> Over[_T]:
         """Produce an OVER clause against this function.
 
@@ -466,6 +467,7 @@ class FunctionElement(Executable, ColumnElement[_T], FromClause, Generative):
             order_by=order_by,
             rows=rows,
             range_=range_,
+            groups=groups,
         )
 
     def within_group(

--- a/test/ext/test_serializer.py
+++ b/test/ext/test_serializer.py
@@ -301,6 +301,16 @@ class SerializeTest(AssertsCompiledSQL, fixtures.MappedTest):
             "max(users.name) OVER (ROWS BETWEEN CURRENT "
             "ROW AND UNBOUNDED FOLLOWING)",
         ),
+        (
+            lambda: func.max(users.c.name).over(groups=(None, 0)),
+            "max(users.name) OVER (GROUPS BETWEEN UNBOUNDED "
+            "PRECEDING AND CURRENT ROW)",
+        ),
+        (
+            lambda: func.max(users.c.name).over(groups=(0, None)),
+            "max(users.name) OVER (GROUPS BETWEEN CURRENT "
+            "ROW AND UNBOUNDED FOLLOWING)",
+        ),
     )
     def test_over(self, over_fn, sql):
         o = over_fn()

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -3260,8 +3260,7 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
 
         assert_raises_message(
             exc.ArgumentError,
-            "too many frame spec clauses provided: "
-            "'range_' and 'rows'",
+            "only one of 'rows', 'range_', or 'groups' may be provided",
             func.row_number().over,
             range_=(-5, 8),
             rows=(-2, 5),
@@ -3269,8 +3268,7 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
 
         assert_raises_message(
             exc.ArgumentError,
-            "too many frame spec clauses provided: "
-            "'range_' and 'groups'",
+            "only one of 'rows', 'range_', or 'groups' may be provided",
             func.row_number().over,
             range_=(-5, 8),
             groups=(None, None),
@@ -3278,8 +3276,7 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
 
         assert_raises_message(
             exc.ArgumentError,
-            "too many frame spec clauses provided: "
-            "'rows' and 'groups'",
+            "only one of 'rows', 'range_', or 'groups' may be provided",
             func.row_number().over,
             rows=(-2, 5),
             groups=(None, None),
@@ -3287,8 +3284,7 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
 
         assert_raises_message(
             exc.ArgumentError,
-            "too many frame spec clauses provided: "
-            "'range_' and 'rows' and 'groups'",
+            "only one of 'rows', 'range_', or 'groups' may be provided",
             func.row_number().over,
             range_=(-5, 8),
             rows=(-2, 5),

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -3260,10 +3260,39 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
 
         assert_raises_message(
             exc.ArgumentError,
-            "'range_' and 'rows' are mutually exclusive",
+            "too many frame spec clauses provided: "
+            "'range_' and 'rows'",
             func.row_number().over,
             range_=(-5, 8),
             rows=(-2, 5),
+        )
+
+        assert_raises_message(
+            exc.ArgumentError,
+            "too many frame spec clauses provided: "
+            "'range_' and 'groups'",
+            func.row_number().over,
+            range_=(-5, 8),
+            groups=(None, None),
+        )
+
+        assert_raises_message(
+            exc.ArgumentError,
+            "too many frame spec clauses provided: "
+            "'rows' and 'groups'",
+            func.row_number().over,
+            rows=(-2, 5),
+            groups=(None, None),
+        )
+
+        assert_raises_message(
+            exc.ArgumentError,
+            "too many frame spec clauses provided: "
+            "'range_' and 'rows' and 'groups'",
+            func.row_number().over,
+            range_=(-5, 8),
+            rows=(-2, 5),
+            groups=(None, None),
         )
 
     def test_over_within_group(self):

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -3208,6 +3208,41 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
             checkparams={"param_1": 10, "param_2": 1},
         )
 
+        self.assert_compile(
+            select(func.row_number().over(order_by=expr, groups=(None, 0))),
+            "SELECT row_number() OVER "
+            "(ORDER BY mytable.myid GROUPS BETWEEN "
+            "UNBOUNDED PRECEDING AND CURRENT ROW)"
+            " AS anon_1 FROM mytable",
+        )
+
+        self.assert_compile(
+            select(func.row_number().over(order_by=expr, groups=(-5, 10))),
+            "SELECT row_number() OVER "
+            "(ORDER BY mytable.myid GROUPS BETWEEN "
+            ":param_1 PRECEDING AND :param_2 FOLLOWING)"
+            " AS anon_1 FROM mytable",
+            checkparams={"param_1": 5, "param_2": 10},
+        )
+
+        self.assert_compile(
+            select(func.row_number().over(order_by=expr, groups=(1, 10))),
+            "SELECT row_number() OVER "
+            "(ORDER BY mytable.myid GROUPS BETWEEN "
+            ":param_1 FOLLOWING AND :param_2 FOLLOWING)"
+            " AS anon_1 FROM mytable",
+            checkparams={"param_1": 1, "param_2": 10},
+        )
+
+        self.assert_compile(
+            select(func.row_number().over(order_by=expr, groups=(-10, -1))),
+            "SELECT row_number() OVER "
+            "(ORDER BY mytable.myid GROUPS BETWEEN "
+            ":param_1 PRECEDING AND :param_2 PRECEDING)"
+            " AS anon_1 FROM mytable",
+            checkparams={"param_1": 10, "param_2": 1},
+        )
+
     def test_over_invalid_framespecs(self):
         assert_raises_message(
             exc.ArgumentError,


### PR DESCRIPTION
### Description
I have implemented support for the GROUPS frame specification in SQLAlchemy’s window functions. Currently, SQLAlchemy supports only RANGE and ROWS as frame-spec clauses, but both PostgreSQL and SQLite have supported GROUPS for a good number of years.

Fixes: #12444 

```python

table = table("mytable", column("myid", Integer), column("name", String))
stmt = select(func.row_number().over(order_by=table.c.myid, groups=(0, None))

# stmt should compile to: SELECT row_number() OVER (ORDER BY mytable.myid GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)

```

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
- [ ] A short code fix
- [x] A new feature implementation

**Have a nice day!**
