### PR TITLE
Add missing imports to code example for `values()`

### DIFF
--- a/lib/sqlalchemy/sql/_selectable_constructors.py
+++ b/lib/sqlalchemy/sql/_selectable_constructors.py
@@ -701,6 +701,8 @@ def values(
 
         from sqlalchemy import column
         from sqlalchemy import values
+        from sqlalchemy import Integer
+        from sqlalchemy import String
 
         value_expr = values(
             column("id", Integer),


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

The code snippet provided as the example for `values()` in the [docs](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.values) is currently missing imports for `Integer` and `String`, so it doesn't work. This PR adds those imports so the code snippet works.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
