### PR TITLE
Increase minimum required greenlet version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Changelog = "https://docs.sqlalchemy.org/latest/changelog/index.html"
 Discussions = "https://github.com/sqlalchemy/sqlalchemy/discussions"
 
 [project.optional-dependencies]
-asyncio = ["greenlet!=0.4.17"]
+asyncio = ["greenlet>=3"]
 mypy = [
     "mypy >= 1.7",
     "types-greenlet >= 2"
@@ -59,7 +59,7 @@ oracle-oracledb = ["oracledb>=1.0.1"]
 postgresql = ["psycopg2>=2.7"]
 postgresql-pg8000 = ["pg8000>=1.29.3"]
 postgresql-asyncpg = [
-    "greenlet!=0.4.17",  # same as ".[asyncio]" if this syntax were supported
+    "greenlet>=3",  # same as ".[asyncio]" if this syntax were supported
     "asyncpg",
 ]
 postgresql-psycopg2binary = ["psycopg2-binary"]
@@ -68,19 +68,19 @@ postgresql-psycopg = ["psycopg>=3.0.7,!=3.1.15"]
 postgresql-psycopgbinary = ["psycopg[binary]>=3.0.7,!=3.1.15"]
 pymysql = ["pymysql"]
 aiomysql = [
-    "greenlet!=0.4.17",  # same as ".[asyncio]" if this syntax were supported
+    "greenlet>=3",  # same as ".[asyncio]" if this syntax were supported
     "aiomysql",
 ]
 aioodbc = [
-    "greenlet!=0.4.17",  # same as ".[asyncio]" if this syntax were supported
+    "greenlet>=3",  # same as ".[asyncio]" if this syntax were supported
     "aioodbc",
 ]
 asyncmy = [
-    "greenlet!=0.4.17",  # same as ".[asyncio]" if this syntax were supported
+    "greenlet>=3",  # same as ".[asyncio]" if this syntax were supported
     "asyncmy>=0.2.3,!=0.2.4,!=0.2.6",
 ]
 aiosqlite = [
-    "greenlet!=0.4.17",  # same as ".[asyncio]" if this syntax were supported
+    "greenlet>=3",  # same as ".[asyncio]" if this syntax were supported
     "aiosqlite",
 ]
 sqlcipher = ["sqlcipher3_binary"]


### PR DESCRIPTION
SQLAlchemy currently has an odd requirement around greenlet: `greenlet!=0.4.17`.
I couldn't spot why this was there from some lightweight annotation digging, but it's a really old version.

Unfortunately, this lets dependency resolvers pick *very* old version of greenlet that don't work with Python 3.
I discovered this while moving [pytest-sqlalchemy](https://github.com/toirl/pytest-sqlalchemy) to be [`uv`](https://github.com/astral-sh/uv)-based and using GitHub Actions for CI, where I've been using `uv sync --all-extras --dev --resolution lowest` to check that the minimum required versions of dependencies actually work.

Here's the failing CI run: https://github.com/toirl/pytest-sqlalchemy/actions/runs/14029663597/job/39274427927?pr=11

I've picked `greenlet 3.0.0` as the minimum version, since it's the first version that appears to have dropped Python 2 support.

This isn't a massive deal, but I think the change does help SQLAlchemy present a more correct view of its dependencies.
It should also be backported to the 1.4 branch, but I don't know what the process is for that.

