### PR TITLE
fix: compatibility with typing_extensions 4.13 and type statement

### DIFF
--- a/lib/sqlalchemy/util/typing.py
+++ b/lib/sqlalchemy/util/typing.py
@@ -358,7 +358,7 @@ def is_generic(type_: _AnnotationScanType) -> TypeGuard[GenericProtocol[Any]]:
 def is_pep695(type_: _AnnotationScanType) -> TypeGuard[TypeAliasType]:
     if hasattr(typing, "TypeAliasType"):
         # Types should be differentiated
-        return isinstance(type_, (TypeAliasType, typing.TypeAliasType))  # type: ignore[attr-defined]
+        return isinstance(type_, (TypeAliasType, typing.TypeAliasType))
     return isinstance(type_, TypeAliasType)
 
 

--- a/lib/sqlalchemy/util/typing.py
+++ b/lib/sqlalchemy/util/typing.py
@@ -356,6 +356,9 @@ def is_generic(type_: _AnnotationScanType) -> TypeGuard[GenericProtocol[Any]]:
 
 
 def is_pep695(type_: _AnnotationScanType) -> TypeGuard[TypeAliasType]:
+    if hasattr(typing, "TypeAliasType"):
+        # Types should be differentiated
+        return isinstance(type_, (TypeAliasType, typing.TypeAliasType))  # type: ignore[attr-defined]
     return isinstance(type_, TypeAliasType)
 
 

--- a/test/base/test_typing_utils.py
+++ b/test/base/test_typing_utils.py
@@ -146,8 +146,6 @@ class TestTestingThings(fixtures.TestBase):
         # no need to test typing_extensions.Union, typing_extensions.Optional
         is_(typing.Union, typing_extensions.Union)
         is_(typing.Optional, typing_extensions.Optional)
-        if py312:
-            is_(typing.TypeAliasType, typing_extensions.TypeAliasType)
 
     def test_make_union(self):
         v = int, str


### PR DESCRIPTION
`typing_extensions` 4.13 has a backport `typing_extensions.TypeAliasType` which differs from `typing.TypeAliasType` which is created though the `type` statement.

`isinstance` which only checks for the `typing_extensions` variant will return `False` which can lead to errors.

(future) TODOs:
- [x] add tests for `typing.TypeAliasType`

Fixes: #12473