### PR TITLE
docs: Fix substr function starting index in hybrid_property example

### DIFF
--- a/doc/build/orm/mapped_attributes.rst
+++ b/doc/build/orm/mapped_attributes.rst
@@ -234,7 +234,7 @@ logic::
             """Produce a SQL expression that represents the value
             of the _email column, minus the last twelve characters."""
 
-            return func.substr(cls._email, 0, func.length(cls._email) - 12)
+            return func.substr(cls._email, 1, func.length(cls._email) - 12)
 
 Above, accessing the ``email`` property of an instance of ``EmailAddress``
 will return the value of the ``_email`` attribute, removing or adding the
@@ -249,7 +249,7 @@ attribute, a SQL function is rendered which produces the same effect:
     {execsql}SELECT address.email AS address_email, address.id AS address_id
     FROM address
     WHERE substr(address.email, ?, length(address.email) - ?) = ?
-    (0, 12, 'address')
+    (1, 12, 'address')
     {stop}
 
 Read more about Hybrids at :ref:`hybrids_toplevel`.


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Modify the starting index in the example from 0 to 1 to align with SQL standard string function conventions.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
