### PR TITLE
Use lower case on update in server_defaults #12488

### DIFF
--- a/doc/build/changelog/unreleased_20/12488.rst
+++ b/doc/build/changelog/unreleased_20/12488.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: bug, mysql
+    :tickets: 12488
+
+    Fixed issue where using lowercase `on update` in server defaults would incorrectly
+    apply parenthesis and thus causing an error in the generated DDL.

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1941,7 +1941,7 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
                 if (
                     self.dialect._support_default_function
                     and not re.match(r"^\s*[\'\"\(]", default)
-                    and "ON UPDATE" not in default
+                    and "ON UPDATE".casefold() not in default.casefold()
                     and re.match(r".*\W.*", default)
                 ):
                     colspec.append(f"DEFAULT ({default})")

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1941,7 +1941,7 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
                 if (
                     self.dialect._support_default_function
                     and not re.match(r"^\s*[\'\"\(]", default)
-                    and "ON UPDATE".casefold() not in default.casefold()
+                    and not re.search(r"ON +UPDATE", default, re.I)
                     and re.match(r".*\W.*", default)
                 ):
                     colspec.append(f"DEFAULT ({default})")

--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -2905,6 +2905,16 @@ class ComponentReflectionTestExtra(ComparesIndexes, fixtures.TestBase):
         ),
         (DateTime, func.now(), r"current_timestamp|now|getdate"),
         (
+            DateTime,
+            sa.text("now() ON UPDATE now()"),
+            r"current_timestamp|now|getdate",
+        ),
+        (
+            DateTime,
+            sa.text("now() on update now()"),
+            r"current_timestamp|now|getdate",
+        ),
+        (
             Integer,
             sa.literal_column("3") + sa.literal_column("5"),
             r"3\+5",

--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -2905,16 +2905,6 @@ class ComponentReflectionTestExtra(ComparesIndexes, fixtures.TestBase):
         ),
         (DateTime, func.now(), r"current_timestamp|now|getdate"),
         (
-            DateTime,
-            sa.text("now() ON UPDATE now()"),
-            r"current_timestamp|now|getdate",
-        ),
-        (
-            DateTime,
-            sa.text("now() on update now()"),
-            r"current_timestamp|now|getdate",
-        ),
-        (
             Integer,
             sa.literal_column("3") + sa.literal_column("5"),
             r"3\+5",

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -442,6 +442,11 @@ class CompileTest(ReservedWordFixture, fixtures.TestBase, AssertsCompiledSQL):
                 "description", String(255), server_default=func.lower("hi")
             ),
             Column("data", JSON, server_default=func.json_object()),
+            Column(
+                "updated",
+                DateTime,
+                server_default=text("now() on update now()"),
+            ),
         )
 
         eq_(dialect._support_default_function, has_brackets)
@@ -453,7 +458,8 @@ class CompileTest(ReservedWordFixture, fixtures.TestBase, AssertsCompiledSQL):
                 "time DATETIME DEFAULT CURRENT_TIMESTAMP, "
                 "name VARCHAR(255) DEFAULT 'some str', "
                 "description VARCHAR(255) DEFAULT (lower('hi')), "
-                "data JSON DEFAULT (json_object()))",
+                "data JSON DEFAULT (json_object()), "
+                "updated DATETIME DEFAULT now() on update now())",
                 dialect=dialect,
             )
         else:
@@ -463,7 +469,8 @@ class CompileTest(ReservedWordFixture, fixtures.TestBase, AssertsCompiledSQL):
                 "time DATETIME DEFAULT CURRENT_TIMESTAMP, "
                 "name VARCHAR(255) DEFAULT 'some str', "
                 "description VARCHAR(255) DEFAULT lower('hi'), "
-                "data JSON DEFAULT json_object())",
+                "data JSON DEFAULT json_object(), "
+                "updated DATETIME DEFAULT now() on update now())",
                 dialect=dialect,
             )
 

--- a/test/dialect/mysql/test_query.py
+++ b/test/dialect/mysql/test_query.py
@@ -85,6 +85,11 @@ class ServerDefaultCreateTest(fixtures.TestBase):
             text("now() on update now()"),
             testing.requires.mysql_expression_defaults,
         ),
+        (
+            DateTime,
+            text("now() ON   UPDATE now()"),
+            testing.requires.mysql_expression_defaults,
+        ),
         argnames="datatype, default",
     )
     def test_create_server_defaults(

--- a/test/dialect/mysql/test_query.py
+++ b/test/dialect/mysql/test_query.py
@@ -75,6 +75,16 @@ class ServerDefaultCreateTest(fixtures.TestBase):
             literal_column("3") + literal_column("5"),
             testing.requires.mysql_expression_defaults,
         ),
+        (
+            DateTime,
+            text("now() ON UPDATE now()"),
+            testing.requires.mysql_expression_defaults,
+        ),
+        (
+            DateTime,
+            text("now() on update now()"),
+            testing.requires.mysql_expression_defaults,
+        ),
         argnames="datatype, default",
     )
     def test_create_server_defaults(


### PR DESCRIPTION
This fixes a bug where using lowercase for `on update` in the server_defaults would generate incorrect DDL.

### Description
Fixes #12488 

### Checklist
This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

