### PR TITLE
orm.exc.NoResultFound => exc.NoResultFound

### DIFF
--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -1513,8 +1513,8 @@ class Result(_WithKeys, ResultInternal[Row[Unpack[_Ts]]]):
     def one(self) -> Row[Unpack[_Ts]]:
         """Return exactly one row or raise an exception.
 
-        Raises :class:`.NoResultFound` if the result returns no
-        rows, or :class:`.MultipleResultsFound` if multiple rows
+        Raises :class:`_exc.NoResultFound` if the result returns no
+        rows, or :class:`_exc.MultipleResultsFound` if multiple rows
         would be returned.
 
         .. note::  This method returns one **row**, e.g. tuple, by default.

--- a/lib/sqlalchemy/ext/asyncio/scoping.py
+++ b/lib/sqlalchemy/ext/asyncio/scoping.py
@@ -1223,8 +1223,7 @@ class async_scoped_session(Generic[_AS]):
             Proxied for the :class:`_asyncio.AsyncSession` class on
             behalf of the :class:`_asyncio.scoping.async_scoped_session` class.
 
-        Raises ``sqlalchemy.exc.NoResultFound`` if the query selects
-        no rows.
+        Raises :class:`_exc.NoResultFound` if the query selects no rows.
 
         ..versionadded: 2.0.22
 

--- a/lib/sqlalchemy/ext/asyncio/scoping.py
+++ b/lib/sqlalchemy/ext/asyncio/scoping.py
@@ -1223,7 +1223,7 @@ class async_scoped_session(Generic[_AS]):
             Proxied for the :class:`_asyncio.AsyncSession` class on
             behalf of the :class:`_asyncio.scoping.async_scoped_session` class.
 
-        Raises ``sqlalchemy.orm.exc.NoResultFound`` if the query selects
+        Raises ``sqlalchemy.exc.NoResultFound`` if the query selects
         no rows.
 
         ..versionadded: 2.0.22

--- a/lib/sqlalchemy/ext/asyncio/session.py
+++ b/lib/sqlalchemy/ext/asyncio/session.py
@@ -631,8 +631,7 @@ class AsyncSession(ReversibleProxy[Session]):
         """Return an instance based on the given primary key identifier,
         or raise an exception if not found.
 
-        Raises ``sqlalchemy.exc.NoResultFound`` if the query selects
-        no rows.
+        Raises :class:`_exc.NoResultFound` if the query selects no rows.
 
         ..versionadded: 2.0.22
 

--- a/lib/sqlalchemy/ext/asyncio/session.py
+++ b/lib/sqlalchemy/ext/asyncio/session.py
@@ -631,7 +631,7 @@ class AsyncSession(ReversibleProxy[Session]):
         """Return an instance based on the given primary key identifier,
         or raise an exception if not found.
 
-        Raises ``sqlalchemy.orm.exc.NoResultFound`` if the query selects
+        Raises ``sqlalchemy.exc.NoResultFound`` if the query selects
         no rows.
 
         ..versionadded: 2.0.22

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -2836,11 +2836,10 @@ class Query(
     def one(self) -> _T:
         """Return exactly one result or raise an exception.
 
-        Raises ``sqlalchemy.exc.NoResultFound`` if the query selects
-        no rows.  Raises ``sqlalchemy.orm.exc.MultipleResultsFound``
-        if multiple object identities are returned, or if multiple
-        rows are returned for a query that returns only scalar values
-        as opposed to full identity-mapped entities.
+        Raises :class:`_exc.NoResultFound` if the query selects no rows.
+        Raises :class:`_exc.MultipleResultsFound` if multiple object identities
+        are returned, or if multiple rows are returned for a query that returns
+        only scalar values as opposed to full identity-mapped entities.
 
         Calling :meth:`.one` results in an execution of the underlying query.
 
@@ -2860,7 +2859,7 @@ class Query(
     def scalar(self) -> Any:
         """Return the first element of the first result or None
         if no rows present.  If multiple rows are returned,
-        raises MultipleResultsFound.
+        raises :class:`_exc.MultipleResultsFound`.
 
           >>> session.query(Item).scalar()
           <Item>

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -2836,7 +2836,7 @@ class Query(
     def one(self) -> _T:
         """Return exactly one result or raise an exception.
 
-        Raises ``sqlalchemy.orm.exc.NoResultFound`` if the query selects
+        Raises ``sqlalchemy.exc.NoResultFound`` if the query selects
         no rows.  Raises ``sqlalchemy.orm.exc.MultipleResultsFound``
         if multiple object identities are returned, or if multiple
         rows are returned for a query that returns only scalar values

--- a/lib/sqlalchemy/orm/scoping.py
+++ b/lib/sqlalchemy/orm/scoping.py
@@ -1116,8 +1116,7 @@ class scoped_session(Generic[_S]):
             Proxied for the :class:`_orm.Session` class on
             behalf of the :class:`_orm.scoping.scoped_session` class.
 
-        Raises ``sqlalchemy.exc.NoResultFound`` if the query
-        selects no rows.
+        Raises :class:`_exc.NoResultFound` if the query selects no rows.
 
         For a detailed documentation of the arguments see the
         method :meth:`.Session.get`.

--- a/lib/sqlalchemy/orm/scoping.py
+++ b/lib/sqlalchemy/orm/scoping.py
@@ -1116,7 +1116,7 @@ class scoped_session(Generic[_S]):
             Proxied for the :class:`_orm.Session` class on
             behalf of the :class:`_orm.scoping.scoped_session` class.
 
-        Raises ``sqlalchemy.orm.exc.NoResultFound`` if the query
+        Raises ``sqlalchemy.exc.NoResultFound`` if the query
         selects no rows.
 
         For a detailed documentation of the arguments see the

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -3735,8 +3735,7 @@ class Session(_SessionClassMethods, EventTarget):
         """Return exactly one instance based on the given primary key
         identifier, or raise an exception if not found.
 
-        Raises ``sqlalchemy.exc.NoResultFound`` if the query
-        selects no rows.
+        Raises :class:`_exc.NoResultFound` if the query selects no rows.
 
         For a detailed documentation of the arguments see the
         method :meth:`.Session.get`.

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -3735,7 +3735,7 @@ class Session(_SessionClassMethods, EventTarget):
         """Return exactly one instance based on the given primary key
         identifier, or raise an exception if not found.
 
-        Raises ``sqlalchemy.orm.exc.NoResultFound`` if the query
+        Raises ``sqlalchemy.exc.NoResultFound`` if the query
         selects no rows.
 
         For a detailed documentation of the arguments see the


### PR DESCRIPTION
### Description

Replace `orm.exc.NoResultFound` with `exc.NoResultFound` in docstrings.

### Checklist
This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
