### PR TITLE
Add support for reflection of collation in types on PostgreSQL

### DIFF
--- a/doc/build/changelog/unreleased_20/6511.rst
+++ b/doc/build/changelog/unreleased_20/6511.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: usecase, postgresql
+    :tickets: 6511
+
+    Added support for reflection of collation in types for PostgreSQL.
+    Pull request courtesy Denis Laxalde.

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3861,7 +3861,7 @@ class PGDialect(default.DefaultDialect):
             )
         )
 
-        collations = self._load_collation_dict(connection)
+        collations = self._load_collation_dict(connection, **kw)
 
         columns = self._get_columns_info(
             rows, domains, enums, collations, schema
@@ -5288,7 +5288,7 @@ class PGDialect(default.DefaultDialect):
 
     @reflection.cache
     def _load_collation_dict(
-        self, connection
+        self, connection, **kw
     ) -> dict[int, Tuple[str, Optional[list[int]]]]:
         rows = connection.execute(self._pg_collation_query)
         return {oid: (name, types) for oid, name, types in rows}

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -4034,19 +4034,18 @@ class PGDialect(default.DefaultDialect):
             table_cols = columns[(schema, row_dict["table_name"])]
 
             try:
-                collation_name, default_collation_for_types = collations[
+                collation, default_collation_for_types = collations[
                     row_dict["collation"]
                 ]
             except KeyError:
                 collation = None
             else:
                 # Only export the collation if distinct from type's default.
-                collation = (
-                    collation_name
-                    if default_collation_for_types is not None
-                    and row_dict["type"] not in default_collation_for_types
-                    else None
-                )
+                if (
+                    default_collation_for_types is not None
+                    and row_dict["type"] in default_collation_for_types
+                ):
+                    collation = None
 
             coltype = self._reflect_type(
                 row_dict["format_type"],

--- a/lib/sqlalchemy/testing/requirements.py
+++ b/lib/sqlalchemy/testing/requirements.py
@@ -683,6 +683,11 @@ class SuiteRequirements(Requirements):
         return exclusions.closed()
 
     @property
+    def column_collation_reflection(self):
+        """Indicates if the database support column collation reflection"""
+        return exclusions.open()
+
+    @property
     def view_column_reflection(self):
         """target database must support retrieval of the columns in a view,
         similarly to how a table is inspected.

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -2732,6 +2732,7 @@ class CustomTypeReflectionTest(fixtures.TestBase):
                 "default": None,
                 "not_null": False,
                 "comment": None,
+                "collation": None,
                 "generated": "",
                 "identity_options": None,
             }
@@ -2774,6 +2775,7 @@ class CustomTypeReflectionTest(fixtures.TestBase):
                 "default": None,
                 "not_null": False,
                 "comment": None,
+                "collation": None,
                 "generated": "",
                 "identity_options": None,
             }

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -2731,13 +2731,14 @@ class CustomTypeReflectionTest(fixtures.TestBase):
                 "format_type": sch,
                 "default": None,
                 "not_null": False,
+                "type": 123,
+                "collation": 456,
                 "comment": None,
-                "collation": None,
                 "generated": "",
                 "identity_options": None,
             }
             column_info = dialect._get_columns_info(
-                [row_dict], {}, {}, "public"
+                [row_dict], {}, {}, {456: ("mycoll", [123])}, "public"
             )
             assert ("public", "tblname") in column_info
             column_info = column_info[("public", "tblname")]
@@ -2774,13 +2775,14 @@ class CustomTypeReflectionTest(fixtures.TestBase):
                 "format_type": None,
                 "default": None,
                 "not_null": False,
+                "type": 987,
+                "collation": 0,
                 "comment": None,
-                "collation": None,
                 "generated": "",
                 "identity_options": None,
             }
             column_info = dialect._get_columns_info(
-                [row_dict], {}, {}, "public"
+                [row_dict], {}, {}, {654: ("somecollation", [])}, "public"
             )
             assert ("public", "tblname") in column_info
             column_info = column_info[("public", "tblname")]

--- a/test/engine/test_reflection.py
+++ b/test/engine/test_reflection.py
@@ -36,6 +36,7 @@ from sqlalchemy.testing import in_
 from sqlalchemy.testing import is_
 from sqlalchemy.testing import is_false
 from sqlalchemy.testing import is_instance_of
+from sqlalchemy.testing import is_none
 from sqlalchemy.testing import is_not
 from sqlalchemy.testing import is_true
 from sqlalchemy.testing import mock
@@ -1335,6 +1336,28 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
         t3 = Table("sometable", m2, extend_existing=True)
         eq_(t3.comment, "t1 comment")
         eq_(t3.c.id.comment, "c1 comment")
+
+    @testing.requires.column_collation_reflection
+    def test_column_collation_reflection(self, connection, metadata):
+        m1 = metadata
+        Table(
+            "t",
+            m1,
+            Column("collated", sa.String(collation="C")),
+            Column("not_collated", sa.String()),
+        )
+        m1.create_all(connection)
+
+        m2 = MetaData()
+        t2 = Table("t", m2, autoload_with=connection)
+
+        eq_(t2.c.collated.type.collation, "C")
+        is_none(t2.c.not_collated.type.collation)
+
+        insp = inspect(connection)
+        collated, not_collated = insp.get_columns("t")
+        eq_(collated["type"].collation, "C")
+        is_none(not_collated["type"].collation)
 
     @testing.requires.check_constraint_reflection
     def test_check_constraint_reflection(self, connection, metadata):

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -176,6 +176,10 @@ class DefaultRequirements(SuiteRequirements):
         return only_on(["postgresql"])
 
     @property
+    def column_collation_reflection(self):
+        return only_on(["postgresql"])
+
+    @property
     def unbounded_varchar(self):
         """Target database must support VARCHAR with no length"""
 


### PR DESCRIPTION
The 'collation' returned is `None` if it matches the default collation for the type. On the other hand, if the column collation matches the one of the database but is explicitly set at column creation, the value is reflected.

Related to #6511.