### PR TITLE
chore: Fix typo of psycopg2 in comment

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -266,7 +266,7 @@ will remain consistent with the state of the transaction::
     from sqlalchemy import event
 
     postgresql_engine = create_engine(
-        "postgresql+pyscopg2://scott:tiger@hostname/dbname",
+        "postgresql+psycopg2://scott:tiger@hostname/dbname",
         # disable default reset-on-return scheme
         pool_reset_on_return=None,
     )


### PR DESCRIPTION
This is the first example in the documentation of a particular connector, which mgith result in copy+pastes, resulting in an error

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Minor typo in documentation for DB connectors

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Maintainers, have a very nice day!**
