### PR TITLE
refactor: clean up unused variables in engine module

### DIFF
--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -2437,7 +2437,7 @@ class Connection(ConnectionEventsTarget, inspection.Inspectable["Inspector"]):
                     break
 
             if sqlalchemy_exception and is_disconnect != ctx.is_disconnect:
-                sqlalchemy_exception.connection_invalidated = is_disconnect = (
+                sqlalchemy_exception.connection_invalidated = (
                     ctx.is_disconnect
                 )
 

--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -2437,9 +2437,7 @@ class Connection(ConnectionEventsTarget, inspection.Inspectable["Inspector"]):
                     break
 
             if sqlalchemy_exception and is_disconnect != ctx.is_disconnect:
-                sqlalchemy_exception.connection_invalidated = (
-                    ctx.is_disconnect
-                )
+                sqlalchemy_exception.connection_invalidated = ctx.is_disconnect
 
         if newraise:
             raise newraise.with_traceback(exc_info[2]) from e

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -744,8 +744,6 @@ class DefaultDialect(Dialect):
                 raise
 
     def do_ping(self, dbapi_connection: DBAPIConnection) -> bool:
-        cursor = None
-
         cursor = dbapi_connection.cursor()
         try:
             cursor.execute(self._dialect_specific_select_one)
@@ -1849,7 +1847,7 @@ class DefaultExecutionContext(ExecutionContext):
 
         if self.is_crud or self.is_text:
             result = self._setup_dml_or_text_result()
-            yp = sr = False
+            yp = False
         else:
             yp = exec_opt.get("yield_per", None)
             sr = self._is_server_side or exec_opt.get("stream_results", False)

--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -811,7 +811,6 @@ class ResultInternal(InPlaceGenerative, Generic[_R]):
                     "was required"
                 )
         else:
-            next_row = _NO_ROW
             # if we checked for second row then that would have
             # closed us :)
             self._soft_close(hard=True)


### PR DESCRIPTION
Removed unused variables to improve code clarity and maintainability. This change simplifies logic in `base.py`, `default.py`, and `result.py`. No functionality was altered.
