### PR TITLE
refactor (sql): simplify and optimize internal SQL handling

### DIFF
--- a/lib/sqlalchemy/sql/cache_key.py
+++ b/lib/sqlalchemy/sql/cache_key.py
@@ -516,7 +516,7 @@ class CacheKey(NamedTuple):
                             e2,
                         )
             else:
-                pickup_index = stack.pop(-1)
+                stack.pop(-1)
                 break
 
     def _diff(self, other: CacheKey) -> str:

--- a/lib/sqlalchemy/sql/cache_key.py
+++ b/lib/sqlalchemy/sql/cache_key.py
@@ -494,7 +494,6 @@ class CacheKey(NamedTuple):
         k2 = other.key
 
         stack: List[int] = []
-        pickup_index = 0
         while True:
             s1, s2 = k1, k2
             for idx in stack:
@@ -502,8 +501,6 @@ class CacheKey(NamedTuple):
                 s2 = s2[idx]
 
             for idx, (e1, e2) in enumerate(zip_longest(s1, s2)):
-                if idx < pickup_index:
-                    continue
                 if e1 != e2:
                     if isinstance(e1, tuple) and isinstance(e2, tuple):
                         stack.append(idx)

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -4266,7 +4266,7 @@ class SQLCompiler(Compiled):
                 inner = "(%s)" % (inner,)
             return inner
         else:
-            enclosing_alias = kwargs["enclosing_alias"] = alias
+            kwargs["enclosing_alias"] = alias
 
         if asfrom or ashint:
             if isinstance(alias.name, elements._truncated_label):

--- a/lib/sqlalchemy/sql/crud.py
+++ b/lib/sqlalchemy/sql/crud.py
@@ -236,7 +236,7 @@ def _get_crud_params(
         stmt_parameter_tuples = list(spd.items())
         spd_str_key = {_column_as_key(key) for key in spd}
     else:
-        stmt_parameter_tuples = spd = spd_str_key = None
+        stmt_parameter_tuples = spd_str_key = None
 
     # if we have statement parameters - set defaults in the
     # compiled params

--- a/lib/sqlalchemy/sql/lambdas.py
+++ b/lib/sqlalchemy/sql/lambdas.py
@@ -256,10 +256,7 @@ class LambdaElement(elements.ClauseElement):
 
                 self.closure_cache_key = cache_key
 
-                try:
-                    rec = lambda_cache[tracker_key + cache_key]
-                except KeyError:
-                    rec = None
+                rec = lambda_cache.get(tracker_key + cache_key)
             else:
                 cache_key = _cache_key.NO_CACHE
                 rec = None
@@ -1173,7 +1170,7 @@ class AnalyzedFunction:
                         closure_pywrappers.append(bind)
                 else:
                     value = fn.__globals__[name]
-                    new_globals[name] = bind = PyWrapper(fn, name, value)
+                    new_globals[name] = PyWrapper(fn, name, value)
 
             # rewrite the original fn.   things that look like they will
             # become bound parameters are wrapped in a PyWrapper.


### PR DESCRIPTION
Replaced redundant variable assignments with direct operations. Used `dict.get()` for safer dictionary lookups to streamline logic. Improves code readability and reduces unnecessary lines.
