### PR TITLE
refactor(testing-and-utils): Remove unused code and fix style issues

### DIFF
--- a/lib/sqlalchemy/testing/plugin/pytestplugin.py
+++ b/lib/sqlalchemy/testing/plugin/pytestplugin.py
@@ -270,7 +270,6 @@ def pytest_collection_modifyitems(session, config, items):
         for test_class in test_classes:
             # transfer legacy __backend__ and __sparse_backend__ symbols
             # to be markers
-            add_markers = set()
             if getattr(test_class.cls, "__backend__", False) or getattr(
                 test_class.cls, "__only_on__", False
             ):

--- a/lib/sqlalchemy/testing/suite/test_dialect.py
+++ b/lib/sqlalchemy/testing/suite/test_dialect.py
@@ -537,7 +537,7 @@ class DifficultParametersTest(fixtures.TestBase):
             t.c[name].in_(["some name", "some other_name"])
         )
 
-        row = connection.execute(stmt).first()
+        connection.execute(stmt).first()
 
     @testing.fixture
     def multirow_fixture(self, metadata, connection):
@@ -621,7 +621,7 @@ class ReturningGuardsTest(fixtures.TablesTest):
                         f"current server capabilities does not support "
                         f".*RETURNING when executemany is used",
                     ):
-                        result = connection.execute(
+                        connection.execute(
                             stmt,
                             [
                                 {id_param_name: 1, "data": "d1"},

--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -460,7 +460,7 @@ class QuotedNameArgumentTest(fixtures.TablesTest):
             is_true(isinstance(res, dict))
         else:
             with expect_raises(NotImplementedError):
-                res = insp.get_table_options(name)
+                insp.get_table_options(name)
 
     @quote_fixtures
     @testing.requires.view_column_reflection
@@ -2048,7 +2048,7 @@ class ComponentReflectionTest(ComparesTables, OneConnectionTablesTest):
             is_true(isinstance(res, dict))
         else:
             with expect_raises(NotImplementedError):
-                res = insp.get_table_options("users", schema=schema)
+                insp.get_table_options("users", schema=schema)
 
     @testing.combinations((True, testing.requires.schemas), False)
     def test_multi_get_table_options(self, use_schema):
@@ -2064,7 +2064,7 @@ class ComponentReflectionTest(ComparesTables, OneConnectionTablesTest):
             eq_(res, exp)
         else:
             with expect_raises(NotImplementedError):
-                res = insp.get_multi_table_options()
+                insp.get_multi_table_options()
 
     @testing.fixture
     def get_multi_exp(self, connection):

--- a/lib/sqlalchemy/testing/suite/test_select.py
+++ b/lib/sqlalchemy/testing/suite/test_select.py
@@ -1780,7 +1780,7 @@ class IdentityAutoincrementTest(fixtures.TablesTest):
         )
 
     def test_autoincrement_with_identity(self, connection):
-        res = connection.execute(self.tables.tbl.insert(), {"desc": "row"})
+        connection.execute(self.tables.tbl.insert(), {"desc": "row"})
         res = connection.execute(self.tables.tbl.select()).first()
         eq_(res, (1, "row"))
 

--- a/lib/sqlalchemy/util/topological.py
+++ b/lib/sqlalchemy/util/topological.py
@@ -112,7 +112,7 @@ def find_cycles(
                     todo.remove(node)
                     break
             else:
-                node = stack.pop()
+                stack.pop()
     return output
 
 

--- a/tools/cython_imports.py
+++ b/tools/cython_imports.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import re
 
-
 from sqlalchemy.util.tool_support import code_writer_cmd
 
 sa_path = Path(__file__).parent.parent / "lib/sqlalchemy"


### PR DESCRIPTION
This PR includes several small refactorings and style fixes aimed at improving code cleanliness, primarily within the test suite and tooling.

Key changes:

*   Removed assignments to unused variables in various test files (`test_dialect.py`, `test_reflection.py`, `test_select.py`).
*   Removed an unused variable in the pytest plugin (`pytestplugin.py`).
*   Removed an unused variable in the topological sort utility (`topological.py`).
*   Fixed a minor style issue (removed an extra blank line) in the `cython_imports.py` script.