### PR TITLE
Fix incorrect UUID version counter example in documentation

### DIFF
--- a/doc/build/orm/versioning.rst
+++ b/doc/build/orm/versioning.rst
@@ -233,14 +233,14 @@ at our choosing::
         __mapper_args__ = {"version_id_col": version_uuid, "version_id_generator": False}
 
 
-    u1 = User(name="u1", version_uuid=uuid.uuid4())
+    u1 = User(name="u1", version_uuid=uuid.uuid4().hex)
 
     session.add(u1)
 
     session.commit()
 
     u1.name = "u2"
-    u1.version_uuid = uuid.uuid4()
+    u1.version_uuid = uuid.uuid4().hex
 
     session.commit()
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

The example for programmatic version counters shows assigning a raw UUID object to a String column, which causes database errors with most backends. This PR updates the example to use `uuid.uuid4().hex` instead of just `uuid.uuid4()` to convert the UUID object to a string, matching how the `version_id_generator` example works earlier in the same document.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
