### PR TITLE
10909 postgresql dialect table options

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1206,14 +1206,14 @@ dialect in conjunction with the :class:`_schema.Table` construct:
 
     Table("some_table", metadata, ..., postgresql_with={"fillfactor": 100})
 
-    Set various storage options on the table
+ Set various storage options on the table
 
 * ``WITH OIDS``::
 
     Table("some_table", metadata, ..., postgresql_with_oids=True)
 
-    Automatically add object identifiers to table rows. Legacy feature, removed
-    in postgresql 12.
+Automatically add object identifiers to table rows. Removed
+in postgresql 12.
 
 * ``WITHOUT OIDS``::
 

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1202,9 +1202,18 @@ dialect in conjunction with the :class:`_schema.Table` construct:
 
   .. versionadded:: 2.0.26
 
+* ``WITH``:
+
+    Table("some_table", metadata, ..., postgresql_with={"fillfactor": 100})
+
+    Set various storage options on the table
+
 * ``WITH OIDS``::
 
     Table("some_table", metadata, ..., postgresql_with_oids=True)
+
+    Automatically add object identifiers to table rows. Legacy feature, removed
+    in postgresql 12.
 
 * ``WITHOUT OIDS``::
 
@@ -2583,6 +2592,12 @@ class PGDDLCompiler(compiler.DDLCompiler):
         if pg_opts["using"]:
             table_opts.append("\n USING %s" % pg_opts["using"])
 
+        if pg_opts["with"]:
+            storage_params = (
+                "%s = %s" % (k, v) for (k, v) in pg_opts["with"].items()
+            )
+            table_opts.append(" WITH (%s)" % ", ".join(storage_params))
+
         if pg_opts["with_oids"] is True:
             table_opts.append("\n WITH OIDS")
         elif pg_opts["with_oids"] is False:
@@ -3198,6 +3213,7 @@ class PGDialect(default.DefaultDialect):
                 "tablespace": None,
                 "partition_by": None,
                 "with_oids": None,
+                "with": None,
                 "on_commit": None,
                 "inherits": None,
                 "using": None,

--- a/lib/sqlalchemy/dialects/postgresql/pg_catalog.py
+++ b/lib/sqlalchemy/dialects/postgresql/pg_catalog.py
@@ -310,3 +310,22 @@ pg_collation = Table(
     Column("collicurules", Text, info={"server_version": (16,)}),
     Column("collversion", Text, info={"server_version": (10,)}),
 )
+
+pg_inherits = Table(
+    "pg_inherits",
+    pg_catalog_meta,
+    Column("inhrelid", OID),
+    Column("inhparent", OID),
+    Column("inhseqno", Integer),
+    Column("inhdetachpending", Boolean),
+)
+
+pg_tablespace = Table(
+    "pg_tablespace",
+    pg_catalog_meta,
+    Column("oid", OID),
+    Column("spcname", NAME),
+    Column("spcowner", OID),
+    Column("spcacl", ARRAY(Text)),
+    Column("spcoptions", ARRAY(Text)),
+)

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -582,6 +582,43 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             "CREATE TABLE anothertable (id INTEGER) WITHOUT OIDS",
         )
 
+    def test_create_table_with_storage_parameters(self):
+        m = MetaData()
+
+        tbl = Table("atable1", m, postgresql_with={"fillfactor": 100})
+
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE atable1 () " "WITH (fillfactor = 100)",
+        )
+
+        tbl2 = Table(
+            "atable2",
+            m,
+            postgresql_with={"toast.autovacuum_insert_scale_factor": 1.25},
+        )
+
+        self.assert_compile(
+            schema.CreateTable(tbl2),
+            "CREATE TABLE atable2 () "
+            "WITH (toast.autovacuum_insert_scale_factor = 1.25)",
+        )
+
+        tbl3 = Table(
+            "atable3",
+            m,
+            postgresql_with={
+                "user_catalog_table": False,
+                "parallel_workers": 15,
+            },
+        )
+
+        self.assert_compile(
+            schema.CreateTable(tbl3),
+            "CREATE TABLE atable3 () "
+            "WITH (user_catalog_table = False, parallel_workers = 15)",
+        )
+
     def test_create_table_with_oncommit_option(self):
         m = MetaData()
         tbl = Table(

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -2924,3 +2924,116 @@ class TestReflectDifficultColTypes(fixtures.TablesTest):
         is_true(len(rows) > 0)
         for row in rows:
             self.check_int_list(row, "conkey")
+
+
+class TestTableOptionsReflection(fixtures.TestBase):
+    __only_on__ = "postgresql"
+    __backend__ = True
+
+    def test_table_inherits(self, metadata, connection):
+        def assert_inherits_from(table_name, expect_base_tables):
+            table_options = inspect(connection).get_table_options(table_name)
+            eq_(table_options["postgresql_inherits"], expect_base_tables)
+
+        def assert_column_names(table_name, expect_columns):
+            columns = inspect(connection).get_columns(table_name)
+            print("columns", columns)
+            eq_([c["name"] for c in columns], expect_columns)
+
+        Table("base", metadata, Column("id", INTEGER, primary_key=True))
+        Table("name_mixin", metadata, Column("name", String(16)))
+        Table("single_inherits", metadata, postgresql_inherits="base")
+        Table(
+            "single_inherits_tuple_arg",
+            metadata,
+            postgresql_inherits=("base",),
+        )
+        Table(
+            "inherits_mixin",
+            metadata,
+            postgresql_inherits=("base", "name_mixin"),
+        )
+
+        metadata.create_all(connection)
+
+        assert_inherits_from("base", ())
+        assert_inherits_from("name_mixin", ())
+
+        assert_inherits_from("single_inherits", ("base",))
+        assert_column_names("single_inherits", ["id"])
+
+        assert_inherits_from("single_inherits_tuple_arg", ("base",))
+
+        assert_inherits_from("inherits_mixin", ("base", "name_mixin"))
+        assert_column_names("inherits_mixin", ["id", "name"])
+
+    def test_table_storage_params(self, metadata, connection):
+        def assert_has_storage_param(table_name, option_key, option_value):
+            table_options = inspect(connection).get_table_options(table_name)
+            storage_params = table_options["postgresql_with"]
+            assert isinstance(storage_params, dict)
+            eq_(storage_params[option_key], option_value)
+
+        Table("table_no_storage_params", metadata)
+        Table(
+            "table_with_fillfactor",
+            metadata,
+            postgresql_with={"fillfactor": 10},
+        )
+        Table(
+            "table_with_parallel_workers",
+            metadata,
+            postgresql_with={"parallel_workers": 15},
+        )
+
+        metadata.create_all(connection)
+
+        no_params_options = inspect(connection).get_table_options(
+            "table_no_storage_params"
+        )
+        assert "postgresql_with" in no_params_options
+
+        assert_has_storage_param("table_with_fillfactor", "fillfactor", "10")
+        assert_has_storage_param(
+            "table_with_parallel_workers", "parallel_workers", "15"
+        )
+
+    # @testing.skip_if("postgresql >= 12.0", "with_oids not supported")
+    # def test_table_with_oids(self, metadata, connection):
+    #     Table("table_with_oids", metadata, postgresql_with_oids=True)
+    #     Table("table_without_oids", metadata, postgresql_with_oids=False)
+    #     metadata.create_all(connection)
+
+    #     table_options = inspect(connection).get_table_options("table_with_oids")
+    #     eq_(table_options["postgresql_with_oids"], True)
+
+    #     table_options = inspect(connection).get_table_options("table_without_oids")
+    #     eq_(table_options["postgresql_with_oids"], False)
+
+    def test_table_using(self, metadata, connection):
+        Table("table_using_heap", metadata, postgresql_using="heap")
+        Table("heap_is_default", metadata)
+        metadata.create_all(connection)
+
+        table_options = inspect(connection).get_table_options(
+            "table_using_heap"
+        )
+        print("table_options", table_options)
+        eq_(table_options["postgresql_using"], "heap")
+
+        table_options = inspect(connection).get_table_options(
+            "heap_is_default"
+        )
+        eq_(table_options["postgresql_using"], "heap")
+
+        # TODO: Test custom access method.
+
+        # self.define_table(metadata, "table_using_btree", postgresql_using="btree")
+        # table_options = inspect(connection).get_table_options("table_using_btree")
+        # eq_(table_options["using"], "btree")
+
+    # def test_table_option_tablespace(self, metadata, connection):
+    #     self.define_simple_table(metadata, "table_sample_tablespace", postgresql_tablespace="sample_tablespace")
+
+    #     table_options = inspect(connection).get_table_options("table_sample_tablespace")
+    #     eq_(table_options["tablespace"], "sample_tablespace")


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Implements `PGDialect.get_table_options`, `PGDialect.get_multi_table_options` and attempts to properly reflect the following dialect specific options passed to the `Table` constructor

- postgresql_inherits
- postgresql_with
- postgresql_with_oids (in supported versions)
- postgresql_using
- postgresql_tablespace

No attempt was made to reflect `postgresql_partition_by`, as the option is passed as a text string and would be difficult to replicate effectively (also, it's kind of useless without also reflecting `postgresql_partition_of`, but I'd make an attempt at implementing declarative partitioning for postgres if there was interest.

Also adds support for passing [table storage parameters](https://www.postgresql.org/docs/current/sql-createtable.html) to `PGDDLCompiler.post_create_table` to the compiler.

Fixes issue #10909 

<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
