### PR TITLE
Create new `str` subclass implementing postgresql bitstring for PG drivers

### DIFF
--- a/doc/build/changelog/migration_21.rst
+++ b/doc/build/changelog/migration_21.rst
@@ -384,3 +384,25 @@ would appear in a valid ODBC connection string (i.e., the same as would be
 required if using the connection string directly with ``pyodbc.connect()``).
 
 :ticket:`11250`
+
+.. _change_12594
+
+Addition of ``BitString`` subclass for handling postgresql ``BIT`` columns
+--------------------------------------------------------------------------
+
+Values of :class:`_dialects.postgresl.BIT` columns in the postgresql dialect are
+now objects of a new :class:`str` subclass,
+:class:`_dialects.postgresql.BitString`. Previously, the value of :class:`BIT`
+columns was driver dependent, with most drivers using :class:`str` instances
+except asyncpg, which used :class:`asyncpg.BitString`.
+
+For implementations using the `psycopg`, `psycopg2` or `pg8000` drivers, the new type is
+mostly compatible with :class:`str` with some additional methods for manipulating bits and
+implementations of the bitwise operators. However, equality and ordering
+value will now fail. This can be rectified by wrapping or unwrapping one side
+of the comparison so that both sides are similarly typed.
+
+For implementations using the `asyncpg` driver, the new type is incompatible with
+the existing :class:`asyncpg.BitString` type.
+
+:ticket:`10556`

--- a/doc/build/changelog/unreleased_21/10556.rst
+++ b/doc/build/changelog/unreleased_21/10556.rst
@@ -1,0 +1,11 @@
+.. change::
+    :tags: feature, postgresql
+    :tickets: 10556
+
+Adds the :class:`dialects.postgresql.BitString` representing PostgreSQL bitstrings
+in python. This type, which is a subtype of the :class:`str` builtin includes
+functionality for converting to/from :class:`int` and :class:`bytes`, in
+addition to implementing utility methods and operators for dealing with bits.
+
+In PostgreSQL drivers, the :class:`postgresql.BIT` type now binds to instances of
+this new utility class.

--- a/doc/build/dialects/postgresql.rst
+++ b/doc/build/dialects/postgresql.rst
@@ -374,6 +374,21 @@ don't yet fully support, conversion of rows to Python ``ipaddress`` datatypes
 
 .. versionadded:: 2.0.18 - added the ``native_inet_types`` parameter.
 
+PostgreSQL BIT type
+-------------------
+
+The PostgreSQL dialect provides a :class:`_postgresql.BitString` type which
+represents an ordered sequence of boolean switches. This is exposed in python as a
+subclass of :class:`str` which exposes appropriate bitwise methods and operators.
+
+* :class:`_postgrsql.BIT` - Typing support for PostgreSQL bitstrings.
+
+* :class:`_postgresql.BitString` - Python implementation of postgresql bitstrings
+
+.. versionadded:: 2.1
+
+PostgreSQL supports
+
 PostgreSQL Data Types
 ---------------------
 

--- a/lib/sqlalchemy/dialects/postgresql/__init__.py
+++ b/lib/sqlalchemy/dialects/postgresql/__init__.py
@@ -33,6 +33,7 @@ from .base import SMALLINT
 from .base import TEXT
 from .base import UUID
 from .base import VARCHAR
+from .bitstring import BitString
 from .dml import Insert
 from .dml import insert
 from .ext import aggregate_order_by
@@ -154,6 +155,7 @@ __all__ = (
     "JSONPATH",
     "Any",
     "All",
+    "BitString",
     "DropEnumType",
     "DropDomainType",
     "CreateDomainType",

--- a/lib/sqlalchemy/dialects/postgresql/asyncpg.py
+++ b/lib/sqlalchemy/dialects/postgresql/asyncpg.py
@@ -247,11 +247,9 @@ class AsyncpgBit(BIT):
         asyncpg_BitString = dialect.dbapi.asyncpg.BitString
 
         def to_bind(value):
-            print(f"processing bound value '{value}'")
             if isinstance(value, str):
                 value = BitString(value)
                 r = asyncpg_BitString.from_int(int(value), len(value))
-                print(f"returning {r}")
                 return r
             return value
 
@@ -260,7 +258,6 @@ class AsyncpgBit(BIT):
     def result_processor(self, dialect, coltype):
         def to_result(value):
             if value is not None:
-                print(f"result {value} length {len(value)}")
                 value = BitString.from_int(value.to_int(), length=len(value))
             return value
 

--- a/lib/sqlalchemy/dialects/postgresql/asyncpg.py
+++ b/lib/sqlalchemy/dialects/postgresql/asyncpg.py
@@ -247,11 +247,11 @@ class AsyncpgBit(BIT):
         asyncpg_BitString = dialect.dbapi.asyncpg.BitString
 
         def to_bind(value):
-            print(f'processing bound value \'{value}\'')
+            print(f"processing bound value '{value}'")
             if isinstance(value, str):
                 value = BitString(value)
                 r = asyncpg_BitString.from_int(int(value), len(value))
-                print(f'returning {r}')
+                print(f"returning {r}")
                 return r
             return value
 
@@ -260,11 +260,8 @@ class AsyncpgBit(BIT):
     def result_processor(self, dialect, coltype):
         def to_result(value):
             if value is not None:
-                print(f'result {value} length {len(value)}')
-                value = BitString.from_int(
-                    value.to_int(),
-                    length=len(value)
-                )
+                print(f"result {value} length {len(value)}")
+                value = BitString.from_int(value.to_int(), length=len(value))
             return value
 
         return to_result

--- a/lib/sqlalchemy/dialects/postgresql/asyncpg.py
+++ b/lib/sqlalchemy/dialects/postgresql/asyncpg.py
@@ -207,6 +207,7 @@ from .base import PGExecutionContext
 from .base import PGIdentifierPreparer
 from .base import REGCLASS
 from .base import REGCONFIG
+from .bitstring import BitString
 from .types import BIT
 from .types import BYTEA
 from .types import CITEXT
@@ -241,6 +242,32 @@ class AsyncpgTime(sqltypes.Time):
 
 class AsyncpgBit(BIT):
     render_bind_cast = True
+
+    def bind_processor(self, dialect):
+        asyncpg_BitString = dialect.dbapi.asyncpg.BitString
+
+        def to_bind(value):
+            print(f'processing bound value \'{value}\'')
+            if isinstance(value, str):
+                value = BitString(value)
+                r = asyncpg_BitString.from_int(int(value), len(value))
+                print(f'returning {r}')
+                return r
+            return value
+
+        return to_bind
+
+    def result_processor(self, dialect, coltype):
+        def to_result(value):
+            if value is not None:
+                print(f'result {value} length {len(value)}')
+                value = BitString.from_int(
+                    value.to_int(),
+                    length=len(value)
+                )
+            return value
+
+        return to_result
 
 
 class AsyncpgByteA(BYTEA):

--- a/lib/sqlalchemy/dialects/postgresql/bitstring.py
+++ b/lib/sqlalchemy/dialects/postgresql/bitstring.py
@@ -1,0 +1,367 @@
+# dialects/postgresql/types.py
+# Copyright (C) 2013-2025 the SQLAlchemy authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of SQLAlchemy and is released under
+# the MIT License: https://www.opensource.org/licenses/mit-license.php
+from __future__ import annotations
+
+import functools
+import math
+from typing import SupportsIndex, cast
+from typing import Literal
+
+
+@functools.total_ordering
+class BitString(str):
+    """Represent a PostgreSQL bit string.
+
+    e.g.
+        b = BitString('101')
+    """
+
+    def __new__(cls, _value: str, _check=True):
+        if not isinstance(_value, BitString) and (
+            _check and _value and any(c not in "01" for c in _value)
+        ):
+            print(f'value: {_value}')
+            raise ValueError("BitString must only contain '0' and '1' chars")
+        return super().__new__(cls, _value)
+
+    @classmethod
+    def from_int(cls, value: int, length: int):
+        """
+        Returns a BitString consisting of the bits in the little-endian
+        representation of the given python int ``value``. A ``ValueError``
+        is raised if ``value`` is not a non-negative integer.
+
+        If the provided ``value`` can not be represented in a bit string
+        of at most ``length``, a ``ValueError`` will be raised. The bitstring
+        will be padded on the left by ``'0'`` to bits to produce a
+        """
+        if value < 0:
+            raise ValueError("value must be a postive integer")
+
+        if length >= 0:
+            if length > 0:
+                template_str = f'{{0:0{length}b}}' if length > 0 else ''
+                r = template_str.format(value)
+            else:
+                # f'{0:00b}'.format(0) == '0'
+                r = ''
+
+            if len(r) > length:
+                raise ValueError(
+                    f"Cannot encode {value} as a BitString of length {length}"
+                )
+        else:
+            r = '{0:b}'.format(value)
+
+        return cls(r)
+
+    @classmethod
+    def from_bytes(cls, value: bytes, length: int = -1):
+        """
+        Returns a ``BitString`` consisting of the bits in the given ``value``
+        bytes.
+
+        If ``length`` is provided, then the length of the provided string
+        will be exactly ``length``, with ``'0'`` bits inserted at the left of
+        the string in order to produce a value of the required length.
+        If, the bits obtained by omitting the leading `0` bits of ``value``
+        cannot be represented in a string of this length, then a ``ValueError``
+        will be raised.
+        """
+        str_v: str = "".join(f"{c:08b}" for c in value)
+        if length >= 0:
+            str_v = str_v.lstrip('0')
+
+            if len(str_v) >= length:
+                raise ValueError(
+                    f"Cannot encode {value} as a BitString of length {length}"
+                )
+            str_v = str_v.zfill(length)
+
+        return cls(str_v)
+
+    def get_bit(self, index) -> Literal["0", "1"]:
+        """
+        Returns the value of the flag at the given index
+
+        e.g. BitString('0101').get_flag(4) == 1
+        """
+        return cast(Literal["0", "1"], super().__getitem__(index))
+
+    @property
+    def bit_length(self):
+        return len(self)
+
+    @property
+    def octet_length(self):
+        return math.ceil(len(self) / 8)
+
+    def has_bit(self, index) -> bool:
+        return self.get_bit(index) == "1"
+
+    def set_bit(
+        self, index: int, value: bool | int | Literal["0", "1"]
+    ) -> BitString:
+        """
+        Set the bit at index to the given value.
+
+        If value is an int, then it is considered to be '1' iff nonzero.
+        """
+        if index < 0 or index >= len(self):
+            raise IndexError("BitString index out of range")
+
+        if isinstance(value, (bool, int)):
+            value = "1" if value else "0"
+
+        if self.get_bit(index) == value:
+            return self
+
+        return BitString(
+            "".join([self[:index], value, self[index + 1:]]), False
+        )
+
+    # These methods probably should return str and not override the fillchar
+    # def ljust(self, width, fillchar=None) -> BitString:
+    #     """
+    #     Returns the BitString left justified in a string of length width.
+    #     Padding is done using the provided fillchar (default is '0').
+
+    #     If the width is shorter than the length, then the original BitString
+    #     is returned.
+    #     """
+    #     if width < len(self):
+    #         return self
+
+    #     fillchar = fillchar or "0"
+    #     if str(fillchar) not in "01":
+    #         raise ValueError("fillchar must be either '0' or '1'")
+
+    #     return BitString(super().ljust(width, fillchar or "0"))
+
+    # def rjust(self, width, fillchar=None) -> BitString:
+    #     if width < len(self):
+    #         return self
+
+    #     fillchar = fillchar or "0"
+    #     if str(fillchar) not in "01":
+    #         raise ValueError("fillchar must be either '0' or '1'")
+
+    #     return BitString(super().rjust(width, fillchar))
+
+    def lstrip(self, char=None) -> BitString:
+        """
+        Returns a copy of the BitString with leading characters removed.
+
+        If omitted or None, 'chars' defaults '0'
+
+        e.g.
+        BitString('00010101000').lstrip() === BitString('00010101')
+        BitString('11110101111').lstrip('1') === BitString('1111010')
+        """
+        if char is None:
+            char = "0"
+        return BitString(super().lstrip(char), False)
+
+    def rstrip(self, char=None) -> BitString:
+        """
+        Returns a copy of the BitString with trailing characters removed.
+
+        If omitted or None, 'chars' trailing '0'
+
+        e.g.
+        BitString('00010101000').rstrip() === BitString('10101000')
+        BitString('11110101111').rstrip('1') === BitString('10101111')
+        """
+        if char is None:
+            char = "0"
+        return BitString(super().rstrip(char), False)
+
+    def strip(self, char=None) -> BitString:
+        """
+        Returns a copy of the BitString with both leading and trailing
+        characters removed.
+        If ommitted or None, char defaults to '0'
+
+        e.g.
+        BitString('00010101000').rstrip() === BitString('10101')
+        BitString('11110101111').rstrip('1') === BitString('1010')
+        """
+        if char is None:
+            char = "0"
+        return BitString(super().strip(char))
+
+    def partition(self, sep: str = "0") -> tuple[BitString, str, BitString]:
+        """
+        Split the string after the first appearance of sep
+        (which defaults to '0') and return a 3-tuple containing
+        the portion of the string before the separator.
+
+        """
+        prefix, _, suffix = super().partition(sep)
+        return (BitString(prefix, False), sep, BitString(suffix, False))
+
+    def removeprefix(self, prefix: str, /) -> BitString:
+        return BitString(super().removeprefix(prefix), False)
+
+    def removesuffix(self, suffix: str, /) -> BitString:
+        return BitString(super().removesuffix(suffix), False)
+
+    def replace(self, old, new, count: SupportsIndex = -1) -> BitString:
+        new = BitString(new)
+        return BitString(super().replace(old, new, count=count), False)
+
+    def split(  # type: ignore
+            self,
+            sep=None,
+            maxsplit: SupportsIndex = -1,
+    ) -> list[BitString]:
+        return [BitString(word) for word in super().split(sep, maxsplit)]
+
+    def zfill(self, width) -> BitString:
+        return BitString(super().zfill(width), False)
+
+    def __repr__(self):
+        return f'BitString("{self.__str__()}")'
+
+    def __int__(self):
+        return int(self, 2) if self else 0
+
+    def __bytes__(self):
+        s = str(self)
+        bs = []
+        while s:
+            bs.append(int(s[-8:], 2))
+            s = s[:-8]
+        return bytes(bs)
+
+    def __lt__(self, o):
+        if isinstance(o, BitString):
+            return super().__lt__(o)
+        return NotImplemented
+
+    def __eq__(self, o):
+        return isinstance(o, BitString) and super().__eq__(o)
+
+    def __hash__(self):
+        return hash(BitString) ^ super().__hash__()
+
+    def __getitem__(self, key):
+        return BitString(super().__getitem__(key), False)
+
+    def __add__(self, o):
+        """Return self + o"""
+        if not isinstance(o, str):
+            raise TypeError((
+                "Can only concatenate str "
+                "(not '{0}') to BitString"
+            ).format(type(o)))
+        return BitString(''.join([self, o]))
+
+    def __radd__(self, o):
+        if not isinstance(o, str):
+            raise TypeError((
+                "Can only concatenate str (not '{0}') to BitString"
+            ).format(type(o)))
+        return BitString(''.join([o, self]))
+
+    def __lshift__(self, amount: int):
+        """
+        Shifts each the bitstring to the left by the given amount.
+        String length is preserved.
+
+        i.e. BitString('000101') << 1 == BitString('001010')
+        """
+        return BitString(
+            "".join([self, *("0" for _ in range(amount))])[-len(self):], False
+        )
+
+    def __rshift__(self, amount: int):
+        """
+        Shifts each bit in the bitstring to the right by the given amount.
+        String length is preserved.
+
+        e.g. BitString('101') >> 1 == BitString('010')
+        """
+        return BitString(self[:-amount], False).zfill(width=len(self))
+
+    def __invert__(self):
+        """
+        Inverts (~) each bit in the bitstring
+
+        e.g. ~BitString('01010') == BitString('10101')
+        """
+        return BitString("".join("1" if x == "0" else "0" for x in self))
+
+    def __and__(self, o):
+        """
+        Performs a bitwise and (``&``) with the given operand.
+        A ``ValueError`` is raised if the operand is not the same length.
+
+        e.g. BitString('011') & BitString('011') == BitString('010')
+        """
+
+        if not isinstance(o, str):
+            return NotImplemented
+        o = BitString(o)
+        if len(self) != len(o):
+            raise ValueError("Operands must be the same length")
+
+        return BitString(
+            "".join(
+                "1" if (x == "1" and y == "1") else "0"
+                for x, y in zip(self, o)
+            ),
+            False,
+        )
+
+    def __or__(self, o):
+        """
+        Performs a bitwise or (``|``) with the given operand.
+        A ``ValueError`` is raised if the operand is not the same length.
+
+        e.g. BitString('011') | BitString('010') == BitString('011')
+        """
+        if not isinstance(o, str):
+            return NotImplemented
+
+        if len(self) != len(o):
+            raise ValueError("Operands must be the same length")
+
+        o = BitString(o)
+        return BitString(
+            "".join(
+                "1" if (x == "1" or y == "1") else "0"
+                for (x, y) in zip(self, o)
+            ),
+            False,
+        )
+
+    def __xor__(self, o):
+        """
+        Performs a bitwise xor (``^``) with the given operand.
+        A ``ValueError`` is raised if the operand is not the same length.
+
+        e.g. BitString('011') ^ BitString('010') == BitString('001')
+        """
+
+        if not isinstance(o, BitString):
+            return NotImplemented
+
+        if len(self) != len(o):
+            raise ValueError("Operands must be the same length")
+
+        return BitString(
+            "".join(
+                (
+                    "1"
+                    if ((x == "1" and y == "0") or (x == "0" and y == "1"))
+                    else "0"
+                )
+                for (x, y) in zip(self, o)
+            ),
+            False,
+        )

--- a/lib/sqlalchemy/dialects/postgresql/bitstring.py
+++ b/lib/sqlalchemy/dialects/postgresql/bitstring.py
@@ -1,4 +1,4 @@
-# dialects/postgresql/types.py
+# dialects/postgresql/bitstring.py
 # Copyright (C) 2013-2025 the SQLAlchemy authors and contributors
 # <see AUTHORS file>
 #
@@ -7,9 +7,12 @@
 from __future__ import annotations
 
 import functools
+import itertools
 import math
-from typing import SupportsIndex, cast
+from typing import Any
+from typing import cast
 from typing import Literal
+from typing import SupportsIndex
 
 
 @functools.total_ordering
@@ -20,16 +23,15 @@ class BitString(str):
         b = BitString('101')
     """
 
-    def __new__(cls, _value: str, _check=True):
+    def __new__(cls, _value: str, _check: bool = True) -> BitString:
         if not isinstance(_value, BitString) and (
             _check and _value and any(c not in "01" for c in _value)
         ):
-            print(f'value: {_value}')
             raise ValueError("BitString must only contain '0' and '1' chars")
         return super().__new__(cls, _value)
 
     @classmethod
-    def from_int(cls, value: int, length: int):
+    def from_int(cls, value: int, length: int) -> BitString:
         """
         Returns a BitString consisting of the bits in the little-endian
         representation of the given python int ``value``. A ``ValueError``
@@ -40,27 +42,22 @@ class BitString(str):
         will be padded on the left by ``'0'`` to bits to produce a
         """
         if value < 0:
-            raise ValueError("value must be a postive integer")
+            raise ValueError("value must be non-negative")
+        if length < 0:
+            raise ValueError("length must be non-negative")
 
-        if length >= 0:
-            if length > 0:
-                template_str = f'{{0:0{length}b}}' if length > 0 else ''
-                r = template_str.format(value)
-            else:
-                # f'{0:00b}'.format(0) == '0'
-                r = ''
+        template_str = f"{{0:0{length}b}}" if length > 0 else ""
+        r = template_str.format(value)
 
-            if len(r) > length:
-                raise ValueError(
-                    f"Cannot encode {value} as a BitString of length {length}"
-                )
-        else:
-            r = '{0:b}'.format(value)
+        if (length == 0 and value > 0) or len(r) > length:
+            raise ValueError(
+                f"Cannot encode {value} as a BitString of length {length}"
+            )
 
         return cls(r)
 
     @classmethod
-    def from_bytes(cls, value: bytes, length: int = -1):
+    def from_bytes(cls, value: bytes, length: int = -1) -> BitString:
         """
         Returns a ``BitString`` consisting of the bits in the given ``value``
         bytes.
@@ -72,19 +69,20 @@ class BitString(str):
         cannot be represented in a string of this length, then a ``ValueError``
         will be raised.
         """
-        str_v: str = "".join(f"{c:08b}" for c in value)
+        str_v: str = "".join(f"{int(c):08b}" for c in value)
         if length >= 0:
-            str_v = str_v.lstrip('0')
+            str_v = str_v.lstrip("0")
 
-            if len(str_v) >= length:
+            if len(str_v) > length:
                 raise ValueError(
-                    f"Cannot encode {value} as a BitString of length {length}"
+                    f"Cannot encode {value!r} as a BitString of "
+                    f"length {length}"
                 )
             str_v = str_v.zfill(length)
 
         return cls(str_v)
 
-    def get_bit(self, index) -> Literal["0", "1"]:
+    def get_bit(self, index: int) -> Literal["0", "1"]:
         """
         Returns the value of the flag at the given index
 
@@ -93,14 +91,14 @@ class BitString(str):
         return cast(Literal["0", "1"], super().__getitem__(index))
 
     @property
-    def bit_length(self):
+    def bit_length(self) -> int:
         return len(self)
 
     @property
-    def octet_length(self):
+    def octet_length(self) -> int:
         return math.ceil(len(self) / 8)
 
-    def has_bit(self, index) -> bool:
+    def has_bit(self, index: int) -> bool:
         return self.get_bit(index) == "1"
 
     def set_bit(
@@ -121,88 +119,50 @@ class BitString(str):
             return self
 
         return BitString(
-            "".join([self[:index], value, self[index + 1:]]), False
+            "".join([self[:index], value, self[index + 1 :]]), False
         )
 
-    # These methods probably should return str and not override the fillchar
-    # def ljust(self, width, fillchar=None) -> BitString:
-    #     """
-    #     Returns the BitString left justified in a string of length width.
-    #     Padding is done using the provided fillchar (default is '0').
-
-    #     If the width is shorter than the length, then the original BitString
-    #     is returned.
-    #     """
-    #     if width < len(self):
-    #         return self
-
-    #     fillchar = fillchar or "0"
-    #     if str(fillchar) not in "01":
-    #         raise ValueError("fillchar must be either '0' or '1'")
-
-    #     return BitString(super().ljust(width, fillchar or "0"))
-
-    # def rjust(self, width, fillchar=None) -> BitString:
-    #     if width < len(self):
-    #         return self
-
-    #     fillchar = fillchar or "0"
-    #     if str(fillchar) not in "01":
-    #         raise ValueError("fillchar must be either '0' or '1'")
-
-    #     return BitString(super().rjust(width, fillchar))
-
-    def lstrip(self, char=None) -> BitString:
+    def lstrip(self, char: str | None = None) -> BitString:
         """
         Returns a copy of the BitString with leading characters removed.
 
         If omitted or None, 'chars' defaults '0'
 
         e.g.
-        BitString('00010101000').lstrip() === BitString('00010101')
-        BitString('11110101111').lstrip('1') === BitString('1111010')
+            BitString('00010101000').lstrip() === BitString('00010101')
+            BitString('11110101111').lstrip('1') === BitString('1111010')
         """
         if char is None:
             char = "0"
         return BitString(super().lstrip(char), False)
 
-    def rstrip(self, char=None) -> BitString:
+    def rstrip(self, char: str | None = "0") -> BitString:
         """
         Returns a copy of the BitString with trailing characters removed.
 
-        If omitted or None, 'chars' trailing '0'
+        If omitted or None, 'char' defaults to "0"
 
         e.g.
-        BitString('00010101000').rstrip() === BitString('10101000')
-        BitString('11110101111').rstrip('1') === BitString('10101111')
+            BitString('00010101000').rstrip() === BitString('10101000')
+            BitString('11110101111').rstrip('1') === BitString('10101111')
         """
         if char is None:
             char = "0"
         return BitString(super().rstrip(char), False)
 
-    def strip(self, char=None) -> BitString:
+    def strip(self, char: str | None = "0") -> BitString:
         """
         Returns a copy of the BitString with both leading and trailing
         characters removed.
-        If ommitted or None, char defaults to '0'
+        If ommitted or None, char defaults to "0"
 
         e.g.
-        BitString('00010101000').rstrip() === BitString('10101')
-        BitString('11110101111').rstrip('1') === BitString('1010')
+            BitString('00010101000').rstrip() === BitString('10101')
+            BitString('11110101111').rstrip('1') === BitString('1010')
         """
         if char is None:
             char = "0"
         return BitString(super().strip(char))
-
-    def partition(self, sep: str = "0") -> tuple[BitString, str, BitString]:
-        """
-        Split the string after the first appearance of sep
-        (which defaults to '0') and return a 3-tuple containing
-        the portion of the string before the separator.
-
-        """
-        prefix, _, suffix = super().partition(sep)
-        return (BitString(prefix, False), sep, BitString(suffix, False))
 
     def removeprefix(self, prefix: str, /) -> BitString:
         return BitString(super().removeprefix(prefix), False)
@@ -210,65 +170,85 @@ class BitString(str):
     def removesuffix(self, suffix: str, /) -> BitString:
         return BitString(super().removesuffix(suffix), False)
 
-    def replace(self, old, new, count: SupportsIndex = -1) -> BitString:
+    def replace(
+        self,
+        old: str,
+        new: str,
+        count: SupportsIndex = -1,
+    ) -> BitString:
         new = BitString(new)
         return BitString(super().replace(old, new, count=count), False)
 
-    def split(  # type: ignore
-            self,
-            sep=None,
-            maxsplit: SupportsIndex = -1,
-    ) -> list[BitString]:
+    def split(
+        self,
+        sep: str | None = None,
+        maxsplit: SupportsIndex = -1,
+    ) -> list[str]:
         return [BitString(word) for word in super().split(sep, maxsplit)]
 
-    def zfill(self, width) -> BitString:
+    def zfill(self, width: SupportsIndex) -> BitString:
         return BitString(super().zfill(width), False)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'BitString("{self.__str__()}")'
 
-    def __int__(self):
+    def __int__(self) -> int:
         return int(self, 2) if self else 0
 
-    def __bytes__(self):
+    def to_bytes(self, length: int = -1) -> bytes:
         s = str(self)
-        bs = []
+        bs: list[int] = []
         while s:
-            bs.append(int(s[-8:], 2))
+            bs.insert(0, int(s[-8:], 2))
             s = s[:-8]
+        if length >= 0:
+            bs = list(itertools.dropwhile(lambda c: c == 0, bs))
+            if len(bs) > length:
+                raise ValueError(
+                    f"Cannot fit a BitString of length {len(self)} into a "
+                    f"bytes instance of length {length}"
+                )
+            # "zfill" the result with 0 bytes
+            bs = [0] * (length - len(bs)) + bs
         return bytes(bs)
 
-    def __lt__(self, o):
+    def __bytes__(self) -> bytes:
+        return self.to_bytes()
+
+    def __lt__(self, o: object) -> bool:
         if isinstance(o, BitString):
             return super().__lt__(o)
         return NotImplemented
 
-    def __eq__(self, o):
+    def __eq__(self, o: object) -> bool:
         return isinstance(o, BitString) and super().__eq__(o)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(BitString) ^ super().__hash__()
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: SupportsIndex | slice[Any, Any, Any]) -> str:
         return BitString(super().__getitem__(key), False)
 
-    def __add__(self, o):
+    def __add__(self, o: str) -> BitString:
         """Return self + o"""
         if not isinstance(o, str):
-            raise TypeError((
-                "Can only concatenate str "
-                "(not '{0}') to BitString"
-            ).format(type(o)))
-        return BitString(''.join([self, o]))
+            raise TypeError(
+                ("Can only concatenate str (not '{0}') to BitString").format(
+                    type(o)
+                )
+            )
+        return BitString("".join([self, o]))
 
-    def __radd__(self, o):
+    def __radd__(self, o: str) -> BitString:
         if not isinstance(o, str):
-            raise TypeError((
-                "Can only concatenate str (not '{0}') to BitString"
-            ).format(type(o)))
-        return BitString(''.join([o, self]))
+            raise TypeError(
+                (f"Can only concatenate str (not '{0}') to BitString").format(
+                    type(o)
+                )
+            )
+        return BitString("".join([o, self]))
 
-    def __lshift__(self, amount: int):
+    def __lshift__(self, amount: int) -> BitString:
         """
         Shifts each the bitstring to the left by the given amount.
         String length is preserved.
@@ -276,10 +256,10 @@ class BitString(str):
         i.e. BitString('000101') << 1 == BitString('001010')
         """
         return BitString(
-            "".join([self, *("0" for _ in range(amount))])[-len(self):], False
+            "".join([self, *("0" for _ in range(amount))])[-len(self) :], False
         )
 
-    def __rshift__(self, amount: int):
+    def __rshift__(self, amount: int) -> BitString:
         """
         Shifts each bit in the bitstring to the right by the given amount.
         String length is preserved.
@@ -288,7 +268,7 @@ class BitString(str):
         """
         return BitString(self[:-amount], False).zfill(width=len(self))
 
-    def __invert__(self):
+    def __invert__(self) -> BitString:
         """
         Inverts (~) each bit in the bitstring
 
@@ -296,7 +276,7 @@ class BitString(str):
         """
         return BitString("".join("1" if x == "0" else "0" for x in self))
 
-    def __and__(self, o):
+    def __and__(self, o: str) -> BitString:
         """
         Performs a bitwise and (``&``) with the given operand.
         A ``ValueError`` is raised if the operand is not the same length.
@@ -318,7 +298,7 @@ class BitString(str):
             False,
         )
 
-    def __or__(self, o):
+    def __or__(self, o: str) -> BitString:
         """
         Performs a bitwise or (``|``) with the given operand.
         A ``ValueError`` is raised if the operand is not the same length.
@@ -340,7 +320,7 @@ class BitString(str):
             False,
         )
 
-    def __xor__(self, o):
+    def __xor__(self, o: str) -> BitString:
         """
         Performs a bitwise xor (``^``) with the given operand.
         A ``ValueError`` is raised if the operand is not the same length.

--- a/lib/sqlalchemy/dialects/postgresql/bitstring.py
+++ b/lib/sqlalchemy/dialects/postgresql/bitstring.py
@@ -177,7 +177,7 @@ class BitString(str):
         count: SupportsIndex = -1,
     ) -> BitString:
         new = BitString(new)
-        return BitString(super().replace(old, new, count=count), False)
+        return BitString(super().replace(old, new, count), False)
 
     def split(
         self,

--- a/test/dialect/postgresql/test_bitstring.py
+++ b/test/dialect/postgresql/test_bitstring.py
@@ -1,0 +1,105 @@
+from sqlalchemy.testing import fixtures
+
+from sqlalchemy.dialects.postgresql import BitString
+from sqlalchemy.testing.assertions import eq_
+from sqlalchemy.testing.assertions import is_false
+from sqlalchemy.testing.assertions import is_true
+from sqlalchemy.testing.assertions import assert_raises
+
+
+class BitStringTests(fixtures.TestBase):
+
+    def test_ctor(self):
+        x = BitString("1110111")
+        eq_(str(x), "1110111")
+        eq_(int(x), 119)
+
+        eq_(BitString("111"), BitString("111"))
+        is_false(BitString("111") == "111")
+
+        eq_(hash(BitString("011")), hash(BitString("011")))
+        is_false(hash(BitString("011")) == hash("011"))
+
+        eq_(BitString("011")[1], BitString("1"))
+
+    def test_int_conversion(self):
+        assert_raises(ValueError, lambda: BitString.from_int(127, length=6))
+
+        eq_(BitString.from_int(127, length=8), BitString("01111111"))
+        eq_(int(BitString.from_int(127, length=8)), 127)
+
+        eq_(BitString.from_int(119, length=10), BitString("0001110111"))
+        eq_(int(BitString.from_int(119, length=10)), 119)
+
+    def test_bytes_conversion(self):
+        eq_(BitString.from_bytes(b"\x01"), BitString("0000001"))
+        eq_(BitString.from_bytes(b"\x01", 4), BitString("00000001"))
+
+        eq_(BitString.from_bytes(b"\xaf\x04"), BitString("101011110010"))
+        eq_(
+            BitString.from_bytes(b"\xaf\x04", 12),
+            BitString("0000101011110010"),
+        )
+        assert_raises(
+            ValueError, lambda: BitString.from_bytes(b"\xaf\x04", 4), 1
+        )
+
+    def test_get_set_bit(self):
+        eq_(BitString("1010").get_bit(2), "1")
+        eq_(BitString("0101").get_bit(2), "0")
+        assert_raises(IndexError, lambda: BitString("0").get_bit(1))
+
+        eq_(BitString("0101").set_bit(3, "0"), BitString("0100"))
+        eq_(BitString("0101").set_bit(3, "1"), BitString("0101"))
+        assert_raises(IndexError, lambda: BitString("1111").set_bit(5, "1"))
+
+    def test_string_methods(self):
+
+        # Which of these methods should be overridden to produce BitStrings?
+        eq_(BitString("111").center(8), "  111   ")
+
+        eq_(BitString("0101").ljust(8), "0101    ")
+        eq_(BitString("0110").rjust(8), "    0110")
+
+        eq_(BitString("01100").lstrip(), BitString("1100"))
+        eq_(BitString("01100").rstrip(), BitString("011"))
+        eq_(BitString("01100").strip(), BitString("11"))
+
+        eq_(BitString("11100").removeprefix("111"), BitString("00"))
+        eq_(BitString("11100").removeprefix("0"), BitString("11100"))
+
+        eq_(BitString("11100").removesuffix("10"), BitString("11100"))
+        eq_(BitString("11100").removesuffix("00"), BitString("111"))
+
+        eq_(
+            BitString("010101011").replace("0101", "11", 1),
+            BitString("1101011"),
+        )
+        eq_(
+            BitString("01101101").split("1", 2),
+            [BitString("0"), BitString(""), BitString("01101")],
+        )
+
+        eq_(BitString("0110").split("11"), [BitString("0"), BitString("0")])
+        eq_(BitString("111").zfill(8), BitString("00000111"))
+
+    def test_str_ops(self):
+        is_true("1" in BitString("001"))
+        is_true("0" in BitString("110"))
+        is_false("1" in BitString("000"))
+
+        is_true("001" in BitString("01001"))
+        is_true(BitString("001") in BitString("01001"))
+        is_false(BitString("000") in BitString("01001"))
+
+        eq_(BitString("010") + "001", BitString("010001"))
+        eq_("001" + BitString("010"), BitString("001010"))
+
+    def test_bitwise_ops(self):
+        eq_(~BitString("0101"), BitString("1010"))
+        eq_(BitString("010") & BitString("011"), BitString("010"))
+        eq_(BitString("010") | BitString("011"), BitString("011"))
+        eq_(BitString("010") ^ BitString("011"), BitString("001"))
+
+        eq_(BitString("001100") << 2, BitString("110000"))
+        eq_(BitString("001100") >> 2, BitString("000011"))


### PR DESCRIPTION
- Added custom `BitString` implementation which inherits from `str` and overrides methods and operators appropriately and implements the bitwise operations in a manner consistent with postgresql. Also exposes class and instance methods ensuring instances can be converted to/from `int` and `bytes` sensibly.

- Added default implementations of `bind_processor` and `result_processor` to `postgresql.BIT` type to convert `BitString` to/from string for PG drivers.

- Override `bind_processor` and `result_processor` in AsyncpgBit in order to convert `BitString` to/from `asynpg.BitString` in `asyncpg` driver.

- Added support for bitwise comparators to postgresql `BIT` instances

Fixes: #10556 

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
