### PR TITLE
Update index.rst in dialects docs to include Denodo

### DIFF
--- a/doc/build/dialects/index.rst
+++ b/doc/build/dialects/index.rst
@@ -86,6 +86,8 @@ Currently maintained external dialect projects for SQLAlchemy include:
 +------------------------------------------------+---------------------------------------+
 | Databricks                                     | databricks_                           |
 +------------------------------------------------+---------------------------------------+
+| Denodo                                         | denodo-sqlalchemy_                    |
++------------------------------------------------+---------------------------------------+
 | EXASolution                                    | sqlalchemy_exasol_                    |
 +------------------------------------------------+---------------------------------------+
 | Elasticsearch (readonly)                       | elasticsearch-dbapi_                  |
@@ -179,3 +181,4 @@ Currently maintained external dialect projects for SQLAlchemy include:
 .. _sqlalchemy-kinetica: https://github.com/kineticadb/sqlalchemy-kinetica/
 .. _sqlalchemy-tidb: https://github.com/pingcap/sqlalchemy-tidb
 .. _ydb-sqlalchemy: https://github.com/ydb-platform/ydb-sqlalchemy/
+.. _denodo-sqlalchemy: https://pypi.org/project/denodo-sqlalchemy/


### PR DESCRIPTION
Added the Denodo official SQLAlchemy dialect `denodo-sqlalchemy` to the list of _external dialects_ in SQLAlchemy's documentation.

### Description

Just added the corresponding link to https://pypi.org/project/denodo-sqlalchemy/

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [X] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
