### PR TITLE
Doc: Update connection / reconnecting_engine

### DIFF
--- a/doc/build/faq/connections.rst
+++ b/doc/build/faq/connections.rst
@@ -258,7 +258,9 @@ statement executions::
                     fn(cursor_obj, statement, context=context, *arg)
                 except engine.dialect.dbapi.Error as raw_dbapi_err:
                     connection = context.root_connection
-                    if engine.dialect.is_disconnect(raw_dbapi_err, connection, cursor_obj):
+                    if engine.dialect.is_disconnect(
+                        raw_dbapi_err, connection.connection.dbapi_connection, cursor_obj
+                    ):
                         engine.logger.error(
                             "disconnection error, attempt %d/%d",
                             retry + 1,


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
I'm not 100% certain this edit is legit. What I am certain of is that the former example did not work for me since I migrated from psycopg2 to 3 a while ago, and it's only today that I took the time to investigate.

The call to `engine.dialect.is_disconnect(raw_dbapi_err, connection, cursor_obj):` crashed with `AttributeError: 'Connection' object has no attribute 'broken'`.

I went into `sqlalchemy/dialects/postgresql/psycopg.py:519` to have a look.
https://github.com/sqlalchemy/sqlalchemy/blob/15f551f250ba689fb12fb3d01275d452d4b815fc/lib/sqlalchemy/dialects/postgresql/psycopg.py#L519

We can see the call to `connection.broken`. I looked at the documentation of psycopg3, and there is indeed a `broken` attribute on the connection object. [Reference](https://www.psycopg.org/psycopg3/docs/api/connections.html#psycopg.Connection.broken)

And this is where I get unsure. The problem *may be* that the connection object within `sqlalchemy/dialects/postgresql/psycopg.py:519` is not a psycopg one, but a `sqlalchemy.engine.base.Connection`, and that class does not seem to have a `broken` attribute. Because the pyscopg connection object has it, I figured that calling the `is_disconnect` function with it instead of `sqlalchemy.engine.base.Connection` works, hence my solution to retrieve it via `context.root_connection.connection.dbapi_connection`.

For extra context, I am using a pool. Here are my object classes.

```
(Pdb) p context.root_connection.__class__
<class 'sqlalchemy.engine.base.Connection'>
(Pdb) p context.root_connection.connection.__class__
<class 'sqlalchemy.pool.base._ConnectionFairy'>
(Pdb) p context.root_connection.connection.dbapi_connection.__class__
<class 'psycopg.Connection'>
```

And this is why this may not be a "one size fits all" solution. Maybe there are some cases where there is no `sqlalchemy.pool.base._ConnectionFairy` in between and `context.root_connection.connection` is the right connection already.

For that I defer to you. Lastly, here are my current package versions.

* sqlalchemy: 2.0.41
* psycopg: 3.2.9
* psycopg-binary: 3.2.9

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**

Note: I marked the PR as "Documentation", but I don't think it's "Good to go". Experts should review if that change is compatible across the board or if it needs to be improved. (Eg.: retrieve the connection this way if it's from a pool, or differently otherwise.)