### PR TITLE
docs: Clarify that relationship() first parameter is positional

### DIFF
--- a/doc/build/orm/basic_relationships.rst
+++ b/doc/build/orm/basic_relationships.rst
@@ -1018,7 +1018,7 @@ within any of these string expressions::
 
 In an example like the above, the string passed to :class:`_orm.Mapped`
 can be disambiguated from a specific class argument by passing the class
-location string directly to :paramref:`_orm.relationship.argument` as well.
+location string directly to the first positional parameter (:paramref:`_orm.relationship.argument`) as well.
 Below illustrates a typing-only import for ``Child``, combined with a
 runtime specifier for the target class that will search for the correct
 name within the :class:`_orm.registry`::


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Minor documentation clarification to address potential confusion where `relationship.argument` notation might suggest keyword parameter usage. However, the community convention is to use this parameter positionally: `relationship(SomeClass)`.

#### Help needed
As someone new to SQLAlchemy, I've done a focused review of the `relationship()` function documentation and a quick check of similar functions (`column_property()`, `deferred()`, `aliased()`, `synonym()`), but didn't spot similar issues elsewhere.

Given your extensive familiarity with the codebase, I'd be very grateful if you could expand this PR with any other similar cases, or handle this in whatever way works best for the project. Thanks for your patience! 🙏

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
