### PR TITLE
Fix CTE column key resolution for unlabeled expressions in RETURNING clause

### DIFF
--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -1690,7 +1690,11 @@ class ColumnElement(
             name = self._anon_name_label
             if key is None:
                 # fallback to anonymous label only as last resort
-                key = self._proxy_key if self._proxy_key else self._anon_key_label
+                key = (
+                    self._proxy_key
+                    if self._proxy_key
+                    else str(self._anon_key_label)
+                )
         else:
             key = name
 

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -1689,7 +1689,8 @@ class ColumnElement(
         if name is None:
             name = self._anon_name_label
             if key is None:
-                key = self._proxy_key
+                # fallback to anonymous label only as last resort
+                key = self._proxy_key if self._proxy_key else self._anon_key_label
         else:
             key = name
 

--- a/test/sql/test_returning.py
+++ b/test/sql/test_returning.py
@@ -237,10 +237,11 @@ class ReturnCombinationTests(fixtures.TestBase, AssertsCompiledSQL):
     def test_returning_cte_labeled_expression(self, table_fixture):
         t = table_fixture
 
-        stmt = delete(t).returning(
-            t.c.id,
-            (t.c.id * -1).label("negative_id")
-        ).cte()
+        stmt = (
+            delete(t)
+            .returning(t.c.id, (t.c.id * -1).label("negative_id"))
+            .cte()
+        )
 
         eq_(list(stmt.c.keys()), ["id", "negative_id"])
         eq_(stmt.c.negative_id.name, "negative_id")
@@ -248,13 +249,13 @@ class ReturnCombinationTests(fixtures.TestBase, AssertsCompiledSQL):
     def test_returning_cte_multiple_unlabeled_expressions(self, table_fixture):
         t = table_fixture
 
-        stmt = delete(t).returning(
-            t.c.id,
-            t.c.id * -1,
-            t.c.id + 10,
-            t.c.id - 10,
-            -1 * t.c.id
-        ).cte()
+        stmt = (
+            delete(t)
+            .returning(
+                t.c.id, t.c.id * -1, t.c.id + 10, t.c.id - 10, -1 * t.c.id
+            )
+            .cte()
+        )
 
         assert len(stmt.c) == 5
         assert stmt.c.id is not None

--- a/test/sql/test_returning.py
+++ b/test/sql/test_returning.py
@@ -234,6 +234,31 @@ class ReturnCombinationTests(fixtures.TestBase, AssertsCompiledSQL):
             "RETURNING t.x, t.y, t.z) SELECT c.z FROM c",
         )
 
+    def test_returning_cte_labeled_expression(self, table_fixture):
+        t = table_fixture
+
+        stmt = delete(t).returning(
+            t.c.id,
+            (t.c.id * -1).label("negative_id")
+        ).cte()
+
+        eq_(list(stmt.c.keys()), ["id", "negative_id"])
+        eq_(stmt.c.negative_id.name, "negative_id")
+
+    def test_returning_cte_multiple_unlabeled_expressions(self, table_fixture):
+        t = table_fixture
+
+        stmt = delete(t).returning(
+            t.c.id,
+            t.c.id * -1,
+            t.c.id + 10,
+            t.c.id - 10,
+            -1 * t.c.id
+        ).cte()
+
+        assert stmt.c.id is not None
+        assert all(col is not None for col in stmt.c)
+
 
 class InsertReturningTest(fixtures.TablesTest, AssertsExecutionResults):
     __requires__ = ("insert_returning",)

--- a/test/sql/test_returning.py
+++ b/test/sql/test_returning.py
@@ -256,6 +256,7 @@ class ReturnCombinationTests(fixtures.TestBase, AssertsCompiledSQL):
             -1 * t.c.id
         ).cte()
 
+        assert len(stmt.c) == 5
         assert stmt.c.id is not None
         assert all(col is not None for col in stmt.c)
 


### PR DESCRIPTION
Fix CTE column key resolution for unlabeled expressions in RETURNING clause

### Description

This PR fixes an issue #12271 where unlabeled expressions in RETURNING clauses lose their column keys when used in CTEs.

Fixes: #12271 

#### Problem

When creating a CTE from DELETE statements with RETURNING clauses containing unlabeled expressions the `_make_proxy` method got AssertionError because key was being None.

```python
# This fails - because in unlabeled expression key was being None
stmt = delete(t).returning(
    t.c.id,
    t.c.id * -1  # Unlabeled expression
).cte()
assert stmt.c.id.name == "id"  # AssertionError: key was None
```

#### Solution

Modified `_make_proxy` to ensure key is never None by falling back to `self._anon_key_label`  

To validate this fix, the following two test cases have been added:
* test_returning_cte_labeled_expression - Ensures labeled expressions continue to work as expected  
* test_returning_cte_multiple_unlabeled_expressions - Verifies that multiple unlabeled expressions are handled correctly  

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
