### PR TITLE
Fix missing data type in Article.writer_id mapping example

### DIFF
--- a/doc/build/orm/join_conditions.rst
+++ b/doc/build/orm/join_conditions.rst
@@ -387,7 +387,7 @@ for both; then to make ``Article`` refer to ``Writer`` as well,
 
         article_id = mapped_column(Integer)
         magazine_id = mapped_column(ForeignKey("magazine.id"))
-        writer_id = mapped_column()
+        writer_id = mapped_column(Integer)
 
         magazine = relationship("Magazine")
         writer = relationship("Writer")


### PR DESCRIPTION
The code example in the "Overlapping Foreign Keys" section contains a bug that causes a runtime error when using modern SQLAlchemy versions.

```
writer_id = mapped_column()  # Missing data type
```

