### PR TITLE
Support schema-qualified collation in types for PostgreSQL

### DIFF
--- a/doc/build/changelog/unreleased_20/9693.rst
+++ b/doc/build/changelog/unreleased_20/9693.rst
@@ -1,0 +1,5 @@
+.. change::
+    :tags: usecase, postgresql
+    :tickets: 9693
+
+    Added support for schema-qualified collation names in types for PostgreSQL.

--- a/lib/sqlalchemy/dialects/postgresql/named_types.py
+++ b/lib/sqlalchemy/dialects/postgresql/named_types.py
@@ -443,6 +443,7 @@ class DOMAIN(NamedType, sqltypes.SchemaType):
         data_type: _TypeEngineArgument[Any],
         *,
         collation: Optional[str] = None,
+        collation_schema: Optional[str] = None,
         default: Union[elements.TextClause, str, None] = None,
         constraint_name: Optional[str] = None,
         not_null: Optional[bool] = None,
@@ -460,6 +461,9 @@ class DOMAIN(NamedType, sqltypes.SchemaType):
           If no collation is specified, the underlying data type's default
           collation is used. The underlying type must be collatable if
           ``collation`` is specified.
+        :param collation_schema: The optional name of the schema in which
+          specified ``collation`` is defined. If not specified, the current
+          schema is assumed.
         :param default: The DEFAULT clause specifies a default value for
           columns of the domain data type. The default should be a string
           or a :func:`_expression.text` value.
@@ -489,6 +493,11 @@ class DOMAIN(NamedType, sqltypes.SchemaType):
         self.data_type = type_api.to_instance(data_type)
         self.default = default
         self.collation = collation
+        if collation_schema is not None and collation is None:
+            raise TypeError(
+                "The collation argument is required for using collation_schema"
+            )
+        self.collation_schema = collation_schema
         self.constraint_name = constraint_name
         self.not_null = bool(not_null)
         if check is not None:

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -7444,33 +7444,46 @@ class GenericTypeCompiler(TypeCompiler):
         return "NCLOB"
 
     def _render_string_type(
-        self, name: str, length: Optional[int], collation: Optional[str]
+        self,
+        name: str,
+        length: Optional[int],
+        collation: Optional[str],
+        collation_schema: Optional[str],
     ) -> str:
         text = name
         if length:
             text += f"({length})"
         if collation:
-            text += f' COLLATE "{collation}"'
+            if collation_schema is not None:
+                text += f' COLLATE "{collation_schema}"."{collation}"'
+            else:
+                text += f' COLLATE "{collation}"'
         return text
 
     def visit_CHAR(self, type_: sqltypes.CHAR, **kw: Any) -> str:
-        return self._render_string_type("CHAR", type_.length, type_.collation)
+        return self._render_string_type(
+            "CHAR", type_.length, type_.collation, type_.collation_schema
+        )
 
     def visit_NCHAR(self, type_: sqltypes.NCHAR, **kw: Any) -> str:
-        return self._render_string_type("NCHAR", type_.length, type_.collation)
+        return self._render_string_type(
+            "NCHAR", type_.length, type_.collation, type_.collation_schema
+        )
 
     def visit_VARCHAR(self, type_: sqltypes.String, **kw: Any) -> str:
         return self._render_string_type(
-            "VARCHAR", type_.length, type_.collation
+            "VARCHAR", type_.length, type_.collation, type_.collation_schema
         )
 
     def visit_NVARCHAR(self, type_: sqltypes.NVARCHAR, **kw: Any) -> str:
         return self._render_string_type(
-            "NVARCHAR", type_.length, type_.collation
+            "NVARCHAR", type_.length, type_.collation, type_.collation_schema
         )
 
     def visit_TEXT(self, type_: sqltypes.Text, **kw: Any) -> str:
-        return self._render_string_type("TEXT", type_.length, type_.collation)
+        return self._render_string_type(
+            "TEXT", type_.length, type_.collation, type_.collation_schema
+        )
 
     def visit_UUID(self, type_: sqltypes.Uuid[Any], **kw: Any) -> str:
         return "UUID"
@@ -7489,7 +7502,9 @@ class GenericTypeCompiler(TypeCompiler):
 
     def visit_uuid(self, type_: sqltypes.Uuid[Any], **kw: Any) -> str:
         if not type_.native_uuid or not self.dialect.supports_native_uuid:
-            return self._render_string_type("CHAR", length=32, collation=None)
+            return self._render_string_type(
+                "CHAR", length=32, collation=None, collation_schema=None
+            )
         else:
             return self.visit_UUID(type_, **kw)
 

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -196,6 +196,7 @@ class String(Concatenable, TypeEngine[str]):
         self,
         length: Optional[int] = None,
         collation: Optional[str] = None,
+        collation_schema: Optional[str] = None,
     ):
         """
         Create a string-holding type.
@@ -219,17 +220,25 @@ class String(Concatenable, TypeEngine[str]):
             >>> print(select(cast("some string", String(collation="utf8"))))
             {printsql}SELECT CAST(:param_1 AS VARCHAR COLLATE utf8) AS anon_1
 
-          .. note::
+        :param collation_schema: Optional, the name of the schema in which the
+          collation is defined.
 
-            In most cases, the :class:`.Unicode` or :class:`.UnicodeText`
-            datatypes should be used for a :class:`_schema.Column` that expects
-            to store non-ascii data. These datatypes will ensure that the
-            correct types are used on the database.
+        .. note::
+
+          In most cases, the :class:`.Unicode` or :class:`.UnicodeText`
+          datatypes should be used for a :class:`_schema.Column` that expects
+          to store non-ascii data. These datatypes will ensure that the
+          correct types are used on the database.
 
         """
 
         self.length = length
         self.collation = collation
+        if collation_schema is not None and collation is None:
+            raise TypeError(
+                "The collation argument is required for using collation_schema"
+            )
+        self.collation_schema = collation_schema
 
     def _with_collation(self, collation):
         new_type = self.copy()
@@ -3789,6 +3798,7 @@ class Uuid(Emulated, TypeEngine[_UUID_RETURN]):
 
     length: Optional[int] = None
     collation: Optional[str] = None
+    collation_schema: Optional[str] = None
 
     @overload
     def __init__(

--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -2491,13 +2491,13 @@ class ComponentReflectionTest(ComparesTables, OneConnectionTablesTest):
         eq_({c["name"]: c["comment"]}, {"emoji": "🐍🧙🝝🧙‍♂️🧙‍♀️"})
 
     @testing.requires.column_collation_reflection
-    @testing.requires.order_by_collation
     def test_column_collation_reflection(self, connection, metadata):
-        collation = testing.requires.get_order_by_collation(config)
+        connection.exec_driver_sql("CREATE SCHEMA s")
+        connection.exec_driver_sql("CREATE COLLATION s.c (LOCALE = 'C.utf8')")
         Table(
             "t",
             metadata,
-            Column("collated", sa.String(collation=collation)),
+            Column("collated", sa.String(collation="c", collation_schema="s")),
             Column("not_collated", sa.String()),
         )
         metadata.create_all(connection)
@@ -2505,12 +2505,21 @@ class ComponentReflectionTest(ComparesTables, OneConnectionTablesTest):
         m2 = MetaData()
         t2 = Table("t", m2, autoload_with=connection)
 
-        eq_(t2.c.collated.type.collation, collation)
+        eq_(
+            (
+                t2.c.collated.type.collation,
+                t2.c.collated.type.collation_schema,
+            ),
+            ("c", "s"),
+        )
         is_none(t2.c.not_collated.type.collation)
 
         insp = inspect(connection)
         collated, not_collated = insp.get_columns("t")
-        eq_(collated["type"].collation, collation)
+        eq_(
+            (collated["type"].collation, collated["type"].collation_schema),
+            ("c", "s"),
+        )
         is_none(not_collated["type"].collation)
 
 

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -389,14 +389,17 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
                 DOMAIN(
                     "foo",
                     Text,
-                    collation="utf8",
+                    collation="my-coll",
+                    collation_schema="CollS",
                     default="foobar",
                     constraint_name="no_bar",
                     not_null=True,
                     check="VALUE != 'bar'",
                 )
             ),
-            "CREATE DOMAIN foo AS TEXT COLLATE utf8 DEFAULT 'foobar' "
+            "CREATE DOMAIN foo AS TEXT "
+            'COLLATE "CollS"."my-coll" '
+            "DEFAULT 'foobar' "
             "CONSTRAINT no_bar NOT NULL CHECK (VALUE != 'bar')",
         )
 

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -521,6 +521,26 @@ class DomainReflectionTest(fixtures.TestBase, AssertsExecutionResults):
         connection.exec_driver_sql('DROP DOMAIN "SomeSchema"."Quoted.Domain"')
 
     @testing.fixture
+    def some_collation(self, connection, some_schema):
+        connection.exec_driver_sql(
+            'CREATE COLLATION IF NOT EXISTS "SomeSchema"."SomeCollation"'
+            " (LOCALE = 'C.utf8')"
+        )
+        yield
+        connection.exec_driver_sql(
+            'DROP COLLATION IF EXISTS "SomeSchema"."SomeCollation"'
+        )
+
+    @testing.fixture
+    def schema_collation_domain(self, connection, some_schema, some_collation):
+        connection.exec_driver_sql(
+            "CREATE DOMAIN domain_with_collation AS TEXT"
+            ' COLLATE "SomeSchema"."SomeCollation"'
+        )
+        yield
+        connection.exec_driver_sql("DROP DOMAIN domain_with_collation")
+
+    @testing.fixture
     def int_domain(self, connection):
         connection.exec_driver_sql(
             "CREATE DOMAIN my_int AS int CONSTRAINT b_my_int_one CHECK "
@@ -710,6 +730,7 @@ class DomainReflectionTest(fixtures.TestBase, AssertsExecutionResults):
         enum_domain,
         nullable_domains,
         int_domain,
+        schema_collation_domain,
         testdomain,
         testdomain_schema,
     ):
@@ -724,6 +745,7 @@ class DomainReflectionTest(fixtures.TestBase, AssertsExecutionResults):
                     "default": None,
                     "constraints": [],
                     "collation": None,
+                    "collation_schema": None,
                 },
                 {
                     "visible": True,
@@ -734,6 +756,7 @@ class DomainReflectionTest(fixtures.TestBase, AssertsExecutionResults):
                     "default": None,
                     "constraints": [],
                     "collation": None,
+                    "collation_schema": None,
                 },
                 {
                     "visible": True,
@@ -744,6 +767,18 @@ class DomainReflectionTest(fixtures.TestBase, AssertsExecutionResults):
                     "default": None,
                     "constraints": [],
                     "collation": None,
+                    "collation_schema": None,
+                },
+                {
+                    "visible": True,
+                    "name": "domain_with_collation",
+                    "schema": "public",
+                    "nullable": True,
+                    "type": "text",
+                    "default": None,
+                    "constraints": [],
+                    "collation": "SomeCollation",
+                    "collation_schema": "SomeSchema",
                 },
                 {
                     "visible": True,
@@ -754,6 +789,7 @@ class DomainReflectionTest(fixtures.TestBase, AssertsExecutionResults):
                     "default": None,
                     "constraints": [],
                     "collation": None,
+                    "collation_schema": None,
                 },
                 {
                     "visible": True,
@@ -769,6 +805,7 @@ class DomainReflectionTest(fixtures.TestBase, AssertsExecutionResults):
                         {"check": "VALUE <> 22", "name": "my_int_check"},
                     ],
                     "collation": None,
+                    "collation_schema": None,
                 },
                 {
                     "visible": True,
@@ -779,6 +816,7 @@ class DomainReflectionTest(fixtures.TestBase, AssertsExecutionResults):
                     "default": None,
                     "constraints": [],
                     "collation": "default",
+                    "collation_schema": "pg_catalog",
                 },
                 {
                     "visible": True,
@@ -796,6 +834,7 @@ class DomainReflectionTest(fixtures.TestBase, AssertsExecutionResults):
                         }
                     ],
                     "collation": "C",
+                    "collation_schema": "pg_catalog",
                 },
                 {
                     "visible": True,
@@ -806,6 +845,7 @@ class DomainReflectionTest(fixtures.TestBase, AssertsExecutionResults):
                     "default": "42",
                     "constraints": [],
                     "collation": None,
+                    "collation_schema": None,
                 },
             ],
             "test_schema": [
@@ -818,6 +858,7 @@ class DomainReflectionTest(fixtures.TestBase, AssertsExecutionResults):
                     "default": "0",
                     "constraints": [],
                     "collation": None,
+                    "collation_schema": None,
                 }
             ],
             "SomeSchema": [
@@ -830,6 +871,7 @@ class DomainReflectionTest(fixtures.TestBase, AssertsExecutionResults):
                     "default": "0",
                     "constraints": [],
                     "collation": None,
+                    "collation_schema": None,
                 }
             ],
         }
@@ -2719,10 +2761,13 @@ class CustomTypeReflectionTest(fixtures.TestBase):
             self.domains = domains
 
     class CustomType:
-        def __init__(self, arg1=None, arg2=None, collation=None):
+        def __init__(
+            self, arg1=None, arg2=None, collation=None, collation_schema=None
+        ):
             self.arg1 = arg1
             self.arg2 = arg2
             self.collation = collation
+            self.collation_schema = collation_schema
 
     ischema_names = None
 
@@ -2748,7 +2793,11 @@ class CustomTypeReflectionTest(fixtures.TestBase):
                 "format_type": sch,
                 "default": None,
                 "not_null": False,
-                "collation": "cc" if sch == "my_custom_type()" else None,
+                "collation": (
+                    {"name": "cc", "schema": "ccnsp"}
+                    if sch == "my_custom_type()"
+                    else None
+                ),
                 "comment": None,
                 "generated": "",
                 "identity_options": None,
@@ -2765,8 +2814,10 @@ class CustomTypeReflectionTest(fixtures.TestBase):
             eq_(column_info["type"].arg2, args[1])
             if sch == "my_custom_type()":
                 eq_(column_info["type"].collation, "cc")
+                eq_(column_info["type"].collation_schema, "ccnsp")
             else:
                 eq_(column_info["type"].collation, None)
+                eq_(column_info["type"].collation_schema, None)
 
     def test_clslevel(self):
         postgresql.PGDialect.ischema_names["my_custom_type"] = self.CustomType

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -673,6 +673,7 @@ class NamedTypeTest(
                             }
                         ],
                         "collation": "default",
+                        "collation_schema": "pg_catalog",
                     }
                 ],
             )
@@ -1485,17 +1486,36 @@ class DomainTest(
     __backend__ = True
     __only_on__ = "postgresql > 8.3"
 
+    def test_domain_collation_collation_schema(self):
+        with expect_raises_message(
+            TypeError,
+            "The collation argument is required for using collation_schema",
+        ):
+            DOMAIN("my", Text(), collation_schema="s")
+
     @testing.requires.postgresql_working_nullable_domains
     def test_domain_type_reflection(self, metadata, connection):
         positive_int = DOMAIN(
             "positive_int", Integer(), check="value > 0", not_null=True
         )
         my_str = DOMAIN("my_string", Text(), collation="C", default="~~")
+        connection.exec_driver_sql("CREATE SCHEMA IF NOT EXISTS collation_s")
+        connection.exec_driver_sql(
+            "CREATE COLLATION IF NOT EXISTS collation_s.my_collation"
+            " (LOCALE = 'C', PROVIDER = 'builtin')"
+        )
+        schema_collated_str = DOMAIN(
+            "schema_collated_string",
+            Text(),
+            collation="my_collation",
+            collation_schema="collation_s",
+        )
         Table(
             "table",
             metadata,
             Column("value", positive_int),
             Column("str", my_str),
+            Column("coll_str", schema_collated_str),
         )
 
         metadata.create_all(connection)
@@ -1520,9 +1540,22 @@ class DomainTest(
         is_(st.check, None)
         is_true("~~" in st.default)
         eq_(st.collation, "C")
+        eq_(st.collation_schema, "pg_catalog")
         is_(st.constraint_name, None)
         is_false(st.not_null)
         is_false(st.create_type)
+
+        cst = t2.c.coll_str.type
+        is_true(isinstance(cst, DOMAIN))
+        is_true(isinstance(cst.data_type, Text))
+        eq_(cst.name, "schema_collated_string")
+        is_(cst.check, None)
+        is_(cst.default, None)
+        eq_(cst.collation, "my_collation")
+        eq_(cst.collation_schema, "collation_s")
+        is_(cst.constraint_name, None)
+        is_false(cst.not_null)
+        is_false(cst.create_type)
 
     def test_domain_create_table(self, metadata, connection):
         metadata = self.metadata

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -3999,6 +3999,19 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             String(50, collation="FOO"), 'VARCHAR(50) COLLATE "FOO"'
         )
 
+    def test_string_collation_schema_no_collation(self):
+        with expect_raises_message(
+            TypeError,
+            "The collation argument is required for using collation_schema",
+        ):
+            String(collation_schema="test")
+
+    def test_string_collation_schema(self):
+        self.assert_compile(
+            String(collation="my-collation", collation_schema="test-schema"),
+            'VARCHAR COLLATE "test-schema"."my-collation"',
+        )
+
     def test_char_plain(self):
         self.assert_compile(CHAR(), "CHAR")
 
@@ -4010,6 +4023,12 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             CHAR(50, collation="FOO"), 'CHAR(50) COLLATE "FOO"'
         )
 
+    def test_char_collation_schema(self):
+        self.assert_compile(
+            CHAR(50, collation="FOO", collation_schema="S"),
+            'CHAR(50) COLLATE "S"."FOO"',
+        )
+
     def test_text_plain(self):
         self.assert_compile(Text(), "TEXT")
 
@@ -4018,6 +4037,12 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def test_text_collation(self):
         self.assert_compile(Text(collation="FOO"), 'TEXT COLLATE "FOO"')
+
+    def test_text_collation_schema(self):
+        self.assert_compile(
+            Text(collation="FOO", collation_schema="S"),
+            'TEXT COLLATE "S"."FOO"',
+        )
 
     def test_default_compile_pg_inet(self):
         self.assert_compile(


### PR DESCRIPTION
We add a `collation_schema` in types supporting `collation`, along with
`postgresql.DOMAIN`, allowing to create respective elements with a
schema-qualified collation name.

Reflection is also handled for both types and domains.

Fix #9693.