### PR TITLE
chore: Fix typo in autoflush SAWarning

### DIFF
--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -3048,7 +3048,7 @@ class Session(_SessionClassMethods, EventTarget):
         "This warning originated from the Session 'autoflush' process, "
         "which was invoked automatically in response to a user-initiated "
         "operation. Consider using ``no_autoflush`` context manager if this "
-        "warning happended while initializing objects.",
+        "warning happened while initializing objects.",
         sa_exc.SAWarning,
     )
     def _autoflush(self) -> None:

--- a/test/orm/test_utils.py
+++ b/test/orm/test_utils.py
@@ -141,7 +141,7 @@ class ContextualWarningsTest(fixtures.TestBase):
                 "(This warning originated from the Session 'autoflush' "
                 "process, which was invoked automatically in response to a "
                 "user-initiated operation. Consider using ``no_autoflush`` "
-                "context manager if this warning happended while "
+                "context manager if this warning happened while "
                 "initializing objects.)"
             ),
         ):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Fixes a typo in SAWarning emitted from automatic autoflush.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
