### PR TITLE
Prevent reuse of a finalized _ConnectionFairy by SingletonThreadPool

### DIFF
--- a/lib/sqlalchemy/pool/impl.py
+++ b/lib/sqlalchemy/pool/impl.py
@@ -433,7 +433,7 @@ class SingletonThreadPool(Pool):
         except AttributeError:
             pass
         else:
-            if rec is not None:
+            if rec is not None and rec.dbapi_connection and rec._connection_record:
                 return rec._checkout_existing()
 
         return _ConnectionFairy._checkout(self, self._fairy)


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Prevent reuse of a finalized `_ConnectionFairy` in SingletonThreadPool by checking that neither `_ConnectionFairy.dbapi_connection` nor `_ConnectionFairy._connection_record` are nulled.

Fixes https://github.com/sqlalchemy/sqlalchemy/issues/12719

Note: I'm not sure how to make a good test for this, I'd be grateful for a pointer in the right direction

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
