### PR TITLE
Fix the code examples and the grammatic in `declarative_tables.rst`

### DIFF
--- a/doc/build/orm/declarative_tables.rst
+++ b/doc/build/orm/declarative_tables.rst
@@ -1720,7 +1720,7 @@ associate additional parameters with the column.   Options include:
   collection when inspecting the history of the attribute.   This may incur
   additional SQL statements::
 
-    from sqlalchemy.orm import deferred
+    from sqlalchemy.orm import column_property
 
     user_table = Table(
         "user",

--- a/doc/build/orm/declarative_tables.rst
+++ b/doc/build/orm/declarative_tables.rst
@@ -709,7 +709,7 @@ SQLAlchemy supports mapping union types inside the ``type_annotation_map`` to
 allow mapping database types that can support multiple Python types, such as
 :class:`_types.JSON` or :class:`_postgresql.JSONB`::
 
-    from typing import Union
+    from typing import Union, Optional
     from sqlalchemy import JSON
     from sqlalchemy.dialects import postgresql
     from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column

--- a/doc/build/orm/declarative_tables.rst
+++ b/doc/build/orm/declarative_tables.rst
@@ -1958,7 +1958,7 @@ that selectable.   This is so that when an ORM object is loaded or persisted,
 it can be placed in the :term:`identity map` with an appropriate
 :term:`identity key`.
 
-In those cases where the a reflected table to be mapped does not include
+In those cases where a reflected table to be mapped does not include
 a primary key constraint, as well as in the general case for
 :ref:`mapping against arbitrary selectables <orm_mapping_arbitrary_subqueries>`
 where primary key columns might not be present, the


### PR DESCRIPTION
### Description
In the `orm/declarative_tables.rst` file, I've imported a missing `Optional` class from the `typing` library in first code example of the "Union types inside the Type Map" chapter to fix the example.

UPD: Also, I've replaced the import of the `deferred` function to `column_property` of the `sqlalchemy.orm` package in  the code example of the `active_history` item of the "Applying Load, Persistence and Mapping Options for Imperative Table Columns" chapter.

UPD: Additionally, I've removed the unnecessary article fro in the second paragraph of the "Mapping to an Explicit Set of Primary Key Columns" chapter.

### Checklist

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
