### PR TITLE
fix(typing): allow DeclarativeBase subclasses in with_for_update(of=...)

### DIFF
--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -113,6 +113,7 @@ and_ = BooleanClauseList.and_
 
 
 if TYPE_CHECKING:
+    from sqlalchemy.orm import DeclarativeBase
     from ._typing import _ColumnExpressionArgument
     from ._typing import _ColumnExpressionOrStrLabelArgument
     from ._typing import _FromClauseArgument
@@ -175,9 +176,10 @@ _ForUpdateOfArgument = Union[
     Union[
         "_ColumnExpressionArgument[Any]",
         "_FromClauseArgument",
+        Type[DeclarativeBase],
     ],
     # or sequence of single column elements
-    Sequence["_ColumnExpressionArgument[Any]"],
+     Sequence[Union["_ColumnExpressionArgument[Any]", Type[DeclarativeBase]]],
 ]
 
 


### PR DESCRIPTION
This commit updates the `_ForUpdateOfArgument` type alias used in the `with_for_update(of=...)` method to explicitly allow `Type[DeclarativeBase]` subclasses.

In SQLAlchemy 2.x, `DeclarativeBase` is the recommended way to define ORM models. While runtime behavior already accepts these classes as valid arguments for the `of` parameter, static type checkers like mypy and pyright currently report type errors when `DeclarativeBase` subclasses are passed.

This patch resolves issue #12730 by expanding `_ForUpdateOfArgument` to include `Type[DeclarativeBase]` (and sequences containing them), aligning type hints with actual valid runtime behavior.

Fixes #12730.

