### PR TITLE
Updated index.rst in dialects docs to include Amazon Aurora DSQL

### DIFF
--- a/doc/build/dialects/index.rst
+++ b/doc/build/dialects/index.rst
@@ -66,6 +66,8 @@ Currently maintained external dialect projects for SQLAlchemy include:
 +------------------------------------------------+---------------------------------------+
 | Amazon Athena                                  | pyathena_                             |
 +------------------------------------------------+---------------------------------------+
+| Amazon Aurora DSQL                             | aurora-dsql-sqlalchemy_               |
++------------------------------------------------+---------------------------------------+
 | Amazon Redshift (via psycopg2)                 | sqlalchemy-redshift_                  |
 +------------------------------------------------+---------------------------------------+
 | Apache Drill                                   | sqlalchemy-drill_                     |
@@ -182,3 +184,4 @@ Currently maintained external dialect projects for SQLAlchemy include:
 .. _sqlalchemy-tidb: https://github.com/pingcap/sqlalchemy-tidb
 .. _ydb-sqlalchemy: https://github.com/ydb-platform/ydb-sqlalchemy/
 .. _denodo-sqlalchemy: https://pypi.org/project/denodo-sqlalchemy/
+.. _aurora-dsql-sqlalchemy: https://pypi.org/project/aurora-dsql-sqlalchemy/


### PR DESCRIPTION
Added a new entry for the Amazon Aurora DSQL dialect into the External Dialects table

### Description
Added a pypi link (https://pypi.org/project/aurora-dsql-sqlalchemy/) for the Amazon Aurora DSQL dialect

### Checklist
This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
