### PR TITLE
Add ability to specify numeric start num when compile stmt

### DIFF
--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -1386,7 +1386,7 @@ class SQLCompiler(Compiled):
          these values may be disabled which means SQL expressions may
          be rendered inline, RETURNING may not be rendered, etc.
 
-         :param numeric_start_num: the starting number for numeric
+        :param numeric_start_num: the starting number for numeric
          bind parameters, if the dialect uses a numeric paramstyle.
 
         :param kwargs: additional keyword arguments to be consumed by the

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -1365,6 +1365,7 @@ class SQLCompiler(Compiled):
         column_keys: Optional[Sequence[str]] = None,
         for_executemany: bool = False,
         linting: Linting = NO_LINTING,
+        numeric_start_num: Optional[int] = None,
         _supporting_against: Optional[SQLCompiler] = None,
         **kwargs: Any,
     ):
@@ -1384,6 +1385,9 @@ class SQLCompiler(Compiled):
          Depending on the backend and driver in use, support for retrieving
          these values may be disabled which means SQL expressions may
          be rendered inline, RETURNING may not be rendered, etc.
+
+         :param numeric_start_num: the starting number for numeric
+         bind parameters, if the dialect uses a numeric paramstyle.
 
         :param kwargs: additional keyword arguments to be consumed by the
          superclass.
@@ -1489,7 +1493,7 @@ class SQLCompiler(Compiled):
         if self.state is CompilerState.STRING_APPLIED:
             if self.positional:
                 if self._numeric_binds:
-                    self._process_numeric()
+                    self._process_numeric(numeric_start_num)
                 else:
                     self._process_positional()
 
@@ -1690,11 +1694,11 @@ class SQLCompiler(Compiled):
                 insert_crud_params=insert_crud_params,
             )
 
-    def _process_numeric(self):
+    def _process_numeric(self, start_num: Optional[int] = None):
         assert self._numeric_binds
         assert self.state is CompilerState.STRING_APPLIED
 
-        num = 1
+        num = start_num if start_num is not None else 1
         param_pos: Dict[str, str] = {}
         order: Iterable[str]
         if self._insertmanyvalues and self._values_bindparam is not None:

--- a/lib/sqlalchemy/testing/assertions.py
+++ b/lib/sqlalchemy/testing/assertions.py
@@ -529,6 +529,7 @@ class AssertsCompiledSQL:
         from_linting=False,
         check_param_order=True,
         use_literal_execute_for_simple_int=False,
+        numeric_start_num=None,
     ):
         if use_default_dialect:
             dialect = default.DefaultDialect()
@@ -584,6 +585,9 @@ class AssertsCompiledSQL:
 
         if from_linting or getattr(self, "assert_from_linting", False):
             kw["linting"] = sql.FROM_LINTING
+
+        if numeric_start_num is not None:
+            kw["numeric_start_num"] = numeric_start_num
 
         from sqlalchemy import orm
 

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -823,6 +823,23 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
             dialect=default.DefaultDialect(paramstyle="pyformat"),
         )
 
+    def test_numeric_start_num(self):
+        stmt = text("select :foo, :bar, :bat from sometable")
+
+        self.assert_compile(
+            stmt,
+            "select :2, :3, :4 from sometable",
+            dialect=default.DefaultDialect(paramstyle="numeric"),
+            numeric_start_num=2,
+        )
+
+        self.assert_compile(
+            stmt,
+            "select $2, $3, $4 from sometable",
+            dialect=default.DefaultDialect(paramstyle="numeric_dollar"),
+            numeric_start_num=2,
+        )
+
     def test_anon_param_name_on_keys(self):
         self.assert_compile(
             keyed.insert(),


### PR DESCRIPTION
### Description

Discussion #12755

Here is brief summary.

We are working on a feature where we need to compile part of a raw SQL statement. Basically, we want to create a WHERE clause based on input data dynamically.

There is a small issue that SQLAlchemy always compiles query and starts counting the number of parameters from 1, and there is no way to adjust this value. You can post-process the query with a regex expression where we replace all numeric params, but it's rather a workaround.

I propose to add the ability to configure numeric_start_num.

I imagine code to look smth like this:

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
