### PR TITLE
[TYPING] : Latest Typed Code for Asking Query

### DIFF
--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -40,11 +40,13 @@ from typing import Callable
 from typing import cast
 from typing import ClassVar
 from typing import Dict
+from typing import Final
 from typing import FrozenSet
 from typing import Iterable
 from typing import Iterator
 from typing import List
 from typing import Mapping
+from typing import Match
 from typing import MutableMapping
 from typing import NamedTuple
 from typing import NoReturn
@@ -62,6 +64,8 @@ from typing import Union
 from . import base
 from . import coercions
 from . import crud
+from . import ddl
+from . import dml
 from . import elements
 from . import functions
 from . import operators
@@ -84,6 +88,7 @@ from .. import exc
 from .. import util
 from ..util import FastIntFlag
 from ..util.typing import Literal
+from ..util.typing import LiteralString
 from ..util.typing import Self
 from ..util.typing import TupleAny
 from ..util.typing import Unpack
@@ -95,6 +100,7 @@ if typing.TYPE_CHECKING:
     from .base import Executable
     from .cache_key import CacheKey
     from .ddl import ExecutableDDLElement
+    from .dml import _DMLTableElement
     from .dml import Delete
     from .dml import Insert
     from .dml import Update
@@ -110,6 +116,7 @@ if typing.TYPE_CHECKING:
     from .elements import False_
     from .elements import Label
     from .elements import Null
+    from .elements import SavepointClause
     from .elements import True_
     from .functions import Function
     from .schema import Column
@@ -133,7 +140,10 @@ if typing.TYPE_CHECKING:
     from .type_api import TypeEngine
     from .type_api import UserDefinedType
     from .visitors import Visitable
+    from ..engine import Connection
+    from ..engine.cursor import CursorResult
     from ..engine.cursor import CursorResultMetaData
+    from ..engine.interfaces import _CoreMultiExecuteParams
     from ..engine.interfaces import _CoreSingleExecuteParams
     from ..engine.interfaces import _DBAPIAnyExecuteParams
     from ..engine.interfaces import _DBAPIMultiExecuteParams
@@ -141,13 +151,14 @@ if typing.TYPE_CHECKING:
     from ..engine.interfaces import _ExecuteOptions
     from ..engine.interfaces import _GenericSetInputSizesType
     from ..engine.interfaces import _MutableCoreSingleExecuteParams
+    from ..engine.interfaces import CoreExecuteOptionsParameter
     from ..engine.interfaces import Dialect
     from ..engine.interfaces import SchemaTranslateMapType
 
 
 _FromHintsType = Dict["FromClause", str]
 
-RESERVED_WORDS = {
+RESERVED_WORDS: Final[Set[str]] = {
     "all",
     "analyse",
     "analyze",
@@ -244,22 +255,34 @@ RESERVED_WORDS = {
     "where",
 }
 
-LEGAL_CHARACTERS = re.compile(r"^[A-Z0-9_$]+$", re.I)
-LEGAL_CHARACTERS_PLUS_SPACE = re.compile(r"^[A-Z0-9_ $]+$", re.I)
-ILLEGAL_INITIAL_CHARACTERS = {str(x) for x in range(0, 10)}.union(["$"])
+_RegexPatternStr = Pattern[str]
+_RegexMatchStr = Match[str]
+LEGAL_CHARACTERS: Final[_RegexPatternStr] = re.compile(r"^[A-Z0-9_$]+$", re.I)
+LEGAL_CHARACTERS_PLUS_SPACE: Final[_RegexPatternStr] = re.compile(
+    r"^[A-Z0-9_ $]+$", re.I
+)
+ILLEGAL_INITIAL_CHARACTERS: Final[Set[str]] = {
+    str(x) for x in range(0, 10)
+}.union(["$"])
 
-FK_ON_DELETE = re.compile(
+FK_ON_DELETE: Final[_RegexPatternStr] = re.compile(
     r"^(?:RESTRICT|CASCADE|SET NULL|NO ACTION|SET DEFAULT)$", re.I
 )
-FK_ON_UPDATE = re.compile(
+FK_ON_UPDATE: Final[_RegexPatternStr] = re.compile(
     r"^(?:RESTRICT|CASCADE|SET NULL|NO ACTION|SET DEFAULT)$", re.I
 )
-FK_INITIALLY = re.compile(r"^(?:DEFERRED|IMMEDIATE)$", re.I)
-BIND_PARAMS = re.compile(r"(?<![:\w\$\x5c]):([\w\$]+)(?![:\w\$])", re.UNICODE)
-BIND_PARAMS_ESC = re.compile(r"\x5c(:[\w\$]*)(?![:\w\$])", re.UNICODE)
+FK_INITIALLY: Final[_RegexPatternStr] = re.compile(
+    r"^(?:DEFERRED|IMMEDIATE)$", re.I
+)
+BIND_PARAMS: Final[_RegexPatternStr] = re.compile(
+    r"(?<![:\w\$\x5c]):([\w\$]+)(?![:\w\$])", re.UNICODE
+)
+BIND_PARAMS_ESC: Final[_RegexPatternStr] = re.compile(
+    r"\x5c(:[\w\$]*)(?![:\w\$])", re.UNICODE
+)
 
-_pyformat_template = "%%(%(name)s)s"
-BIND_TEMPLATES = {
+_pyformat_template: Final[str] = "%%(%(name)s)s"
+BIND_TEMPLATES: Final[Dict[str, str]] = {
     "pyformat": _pyformat_template,
     "qmark": "?",
     "format": "%%s",
@@ -268,8 +291,8 @@ BIND_TEMPLATES = {
     "named": ":%(name)s",
 }
 
-
-OPERATORS = {
+_OperatorsMapping = Dict[operators.OperatorType, str]
+OPERATORS: Final[_OperatorsMapping] = {
     # binary
     operators.and_: " AND ",
     operators.or_: " OR ",
@@ -317,7 +340,8 @@ OPERATORS = {
     operators.bitwise_rshift_op: " >> ",
 }
 
-FUNCTIONS: Dict[Type[Function[Any]], str] = {
+_FunctionMapping = Dict[Type[Function[Any]], str]
+FUNCTIONS: Final[_FunctionMapping] = {
     functions.coalesce: "coalesce",
     functions.current_date: "CURRENT_DATE",
     functions.current_time: "CURRENT_TIME",
@@ -334,8 +358,7 @@ FUNCTIONS: Dict[Type[Function[Any]], str] = {
     functions.grouping_sets: "GROUPING SETS",
 }
 
-
-EXTRACT_MAP = {
+EXTRACT_MAP: Final[Dict[str, str]] = {
     "month": "month",
     "day": "day",
     "year": "year",
@@ -353,7 +376,8 @@ EXTRACT_MAP = {
     "timezone_minute": "timezone_minute",
 }
 
-COMPOUND_KEYWORDS = {
+_CompoundKeywordsMapping = Dict[selectable._CompoundSelectKeyword, str]
+COMPOUND_KEYWORDS: Final[_CompoundKeywordsMapping] = {
     selectable._CompoundSelectKeyword.UNION: "UNION",
     selectable._CompoundSelectKeyword.UNION_ALL: "UNION ALL",
     selectable._CompoundSelectKeyword.EXCEPT: "EXCEPT",
@@ -734,7 +758,7 @@ class FromLinter(collections.namedtuple("FromLinter", ["froms", "edges"])):
         else:
             return None, None
 
-    def warn(self, stmt_type="SELECT"):
+    def warn(self, stmt_type: str = "SELECT") -> None:
         the_rest, start_with = self.lint()
 
         # FROMS left over?  boom
@@ -780,8 +804,8 @@ class Compiled:
     state: CompilerState
     """description of the compiler's state"""
 
-    is_sql = False
-    is_ddl = False
+    is_sql: bool = False
+    is_ddl: bool = False
 
     _cached_metadata: Optional[CursorResultMetaData] = None
 
@@ -850,7 +874,7 @@ class Compiled:
         schema_translate_map: Optional[SchemaTranslateMapType] = None,
         render_schema_translate: bool = False,
         compile_kwargs: Mapping[str, Any] = util.immutabledict(),
-    ):
+    ) -> None:
         """Construct a new :class:`.Compiled` object.
 
         :param dialect: :class:`.Dialect` to compile against.
@@ -905,12 +929,15 @@ class Compiled:
         return super().__init_subclass__()
 
     @classmethod
-    def _init_compiler_cls(cls):
+    def _init_compiler_cls(cls) -> None:
         pass
 
     def _execute_on_connection(
-        self, connection, distilled_params, execution_options
-    ):
+        self,
+        connection: Connection,
+        distilled_params: _CoreMultiExecuteParams,
+        execution_options: CoreExecuteOptionsParameter
+    ) -> CursorResult[Unpack[TupleAny]]:
         if self.can_execute:
             return connection._execute_compiled(
                 self, distilled_params, execution_options
@@ -918,7 +945,9 @@ class Compiled:
         else:
             raise exc.ObjectNotExecutableError(self.statement)
 
-    def visit_unsupported_compilation(self, element, err, **kw):
+    def visit_unsupported_compilation(
+        self, element: ColumnElement[Any], err: exc.CompileError, **kw: Any
+    ) -> Any:
         raise exc.UnsupportedCompilationError(self, type(element)) from err
 
     @property
@@ -958,7 +987,7 @@ class Compiled:
         raise NotImplementedError()
 
     @property
-    def params(self):
+    def params(self) -> Optional[_MutableCoreSingleExecuteParams]:
         """Return the bind params for this compiled object."""
         return self.construct_params()
 
@@ -966,9 +995,9 @@ class Compiled:
 class TypeCompiler(util.EnsureKWArg):
     """Produces DDL specification for TypeEngine objects."""
 
-    ensure_kwarg = r"visit_\w+"
+    ensure_kwarg: str = r"visit_\w+"
 
-    def __init__(self, dialect: Dialect):
+    def __init__(self, dialect: Dialect) -> None:
         self.dialect = dialect
 
     def process(self, type_: TypeEngine[Any], **kw: Any) -> str:
@@ -980,7 +1009,7 @@ class TypeCompiler(util.EnsureKWArg):
         return type_._compiler_dispatch(self, **kw)
 
     def visit_unsupported_compilation(
-        self, element: Any, err: Exception, **kw: Any
+        self, element: Type[ClauseElement], err: exc.CompileError, **kw: Any
     ) -> NoReturn:
         raise exc.UnsupportedCompilationError(self, element) from err
 
@@ -993,22 +1022,24 @@ class _CompileLabel(
     """lightweight label object which acts as an expression.Label."""
 
     __visit_name__ = "label"
-    __slots__ = "element", "name", "_alt_names"
+    __slots__ = ("element", "name", "_alt_names")
 
-    def __init__(self, col, name, alt_names=()):
+    def __init__(
+        self, col: ColumnElement[Any], name: str, alt_names: Any = ()
+    ) -> None:
         self.element = col
         self.name = name
         self._alt_names = (col,) + alt_names
 
     @property
-    def proxy_set(self):
+    def proxy_set(self) -> FrozenSet[ColumnElement[Any]]:
         return self.element.proxy_set
 
     @property
-    def type(self):
+    def type(self) -> TypeEngine[Any]:
         return self.element.type
 
-    def self_group(self, **kw):
+    def self_group(self, **kw: Any) -> Self:
         return self
 
 
@@ -1027,24 +1058,26 @@ class ilike_case_insensitive(
     """
 
     __visit_name__ = "ilike_case_insensitive_operand"
-    __slots__ = "element", "comparator"
+    __slots__ = ("element", "comparator")
 
-    def __init__(self, element):
+    def __init__(self, element: ColumnElement[Any]) -> None:
         self.element = element
         self.comparator = element.comparator
 
     @property
-    def proxy_set(self):
+    def proxy_set(self) -> FrozenSet[ColumnElement[Any]]:
         return self.element.proxy_set
 
     @property
-    def type(self):
+    def type(self) -> TypeEngine[Any]:
         return self.element.type
 
-    def self_group(self, **kw):
+    def self_group(self, **kw: Any) -> Self:
         return self
 
-    def _with_binary_element_type(self, type_):
+    def _with_binary_element_type(
+        self, type_: TypeEngine[Any]
+    ) -> ilike_case_insensitive:
         return ilike_case_insensitive(
             self.element._with_binary_element_type(type_)
         )
@@ -1057,7 +1090,7 @@ class SQLCompiler(Compiled):
 
     """
 
-    extract_map = EXTRACT_MAP
+    extract_map: ClassVar[Dict[str, str]] = EXTRACT_MAP
 
     bindname_escape_characters: ClassVar[Mapping[str, str]] = (
         util.immutabledict(
@@ -1105,9 +1138,9 @@ class SQLCompiler(Compiled):
     _bind_translate_re: ClassVar[Pattern[str]]
     _bind_translate_chars: ClassVar[Mapping[str, str]]
 
-    is_sql = True
+    is_sql: bool = True
 
-    compound_keywords = COMPOUND_KEYWORDS
+    compound_keywords: ClassVar[_CompoundKeywordsMapping] = COMPOUND_KEYWORDS
 
     isdelete: bool = False
     isinsert: bool = False
@@ -1281,11 +1314,11 @@ class SQLCompiler(Compiled):
 
     """
 
-    has_out_parameters = False
+    has_out_parameters: bool = False
     """if True, there are bindparam() objects that have the isoutparam
     flag set."""
 
-    postfetch_lastrowid = False
+    postfetch_lastrowid: bool = False
     """if True, and this in insert, use cursor.lastrowid to populate
     result.inserted_primary_key. """
 
@@ -1341,18 +1374,20 @@ class SQLCompiler(Compiled):
 
     ctes_recursive: bool
 
-    _post_compile_pattern = re.compile(r"__\[POSTCOMPILE_(\S+?)(~~.+?~~)?\]")
-    _pyformat_pattern = re.compile(r"%\(([^)]+?)\)s")
-    _positional_pattern = re.compile(
+    _post_compile_pattern: _RegexPatternStr = re.compile(
+        r"__\[POSTCOMPILE_(\S+?)(~~.+?~~)?\]"
+    )
+    _pyformat_pattern: _RegexPatternStr = re.compile(r"%\(([^)]+?)\)s")
+    _positional_pattern: _RegexPatternStr = re.compile(
         f"{_pyformat_pattern.pattern}|{_post_compile_pattern.pattern}"
     )
 
     @classmethod
-    def _init_compiler_cls(cls):
+    def _init_compiler_cls(cls) -> None:
         cls._init_bind_translate()
 
     @classmethod
-    def _init_bind_translate(cls):
+    def _init_bind_translate(cls) -> None:
         reg = re.escape("".join(cls.bindname_escape_characters))
         cls._bind_translate_re = re.compile(f"[{reg}]")
         cls._bind_translate_chars = cls.bindname_escape_characters
@@ -1546,7 +1581,7 @@ class SQLCompiler(Compiled):
             return None
 
     @property
-    def returning(self):
+    def returning(self) -> Optional[Sequence[ColumnElement[Any]]]:
         """backwards compatibility; returns the
         effective_returning collection.
 
@@ -1576,7 +1611,7 @@ class SQLCompiler(Compiled):
             raise IndexError("Compiler does not have a stack entry") from ie
 
     @property
-    def prefetch(self):
+    def prefetch(self) -> List[Column[Any]]:
         return list(self.insert_prefetch) + list(self.update_prefetch)
 
     @util.memoized_property
@@ -1631,7 +1666,7 @@ class SQLCompiler(Compiled):
                 ordered_columns,
             )
 
-    def _process_positional(self):
+    def _process_positional(self) -> None:
         assert not self.positiontup
         assert self.state is CompilerState.STRING_APPLIED
         assert not self._numeric_binds
@@ -1690,7 +1725,7 @@ class SQLCompiler(Compiled):
                 insert_crud_params=insert_crud_params,
             )
 
-    def _process_numeric(self):
+    def _process_numeric(self) -> None:
         assert self._numeric_binds
         assert self.state is CompilerState.STRING_APPLIED
 
@@ -1792,7 +1827,7 @@ class SQLCompiler(Compiled):
             if value is not None
         }
 
-    def is_subquery(self):
+    def is_subquery(self) -> bool:
         return len(self.stack) > 1
 
     @property
@@ -1990,7 +2025,7 @@ class SQLCompiler(Compiled):
         return inputsizes
 
     @property
-    def params(self):
+    def params(self) -> Optional[MutableMapping[str, Any]]:
         """Return the bind param dictionary embedded into this
         compiled object, for those values that are present.
 
@@ -2200,7 +2235,7 @@ class SQLCompiler(Compiled):
         return expanded_state
 
     @util.preload_module("sqlalchemy.engine.cursor")
-    def _create_result_map(self):
+    def _create_result_map(self) -> Any:
         """utility method used for unit tests only."""
         cursor = util.preloaded.engine_cursor
         return cursor.CursorResultMetaData._create_description_match_map(
@@ -2217,7 +2252,9 @@ class SQLCompiler(Compiled):
 
     @util.memoized_property
     @util.preload_module("sqlalchemy.engine.result")
-    def _inserted_primary_key_from_lastrowid_getter(self):
+    def _inserted_primary_key_from_lastrowid_getter(
+        self,
+    ) -> Callable[[Any, Any], Any]:
         result = util.preloaded.engine_result
 
         param_key_getter = self._within_exec_param_key_getter
@@ -2418,15 +2455,30 @@ class SQLCompiler(Compiled):
 
         return sqltext
 
-    def visit_grouping(self, grouping, asfrom=False, **kwargs):
-        return "(" + grouping.element._compiler_dispatch(self, **kwargs) + ")"
+    def visit_grouping(
+        self, grouping: ColumnClause[Any], asfrom: bool = False, **kwargs: Any
+    ) -> LiteralString:
+        return (
+            "("
+            + str(grouping.element._compiler_dispatch(self, **kwargs))
+            + ")"
+        )
 
-    def visit_select_statement_grouping(self, grouping, **kwargs):
-        return "(" + grouping.element._compiler_dispatch(self, **kwargs) + ")"
+    def visit_select_statement_grouping(
+        self, grouping: ColumnClause[Any], **kwargs: Any
+    ) -> LiteralString:
+        return (
+            "("
+            + str(grouping.element._compiler_dispatch(self, **kwargs))
+            + ")"
+        )
 
     def visit_label_reference(
-        self, element, within_columns_clause=False, **kwargs
-    ):
+        self,
+        element: ColumnElement[Any],
+        within_columns_clause: bool = False,
+        **kwargs: Any,
+    ) -> str:
         if self.stack and self.dialect.supports_simple_order_by_label:
             try:
                 compile_state = cast(
@@ -2472,8 +2524,11 @@ class SQLCompiler(Compiled):
         )
 
     def visit_textual_label_reference(
-        self, element, within_columns_clause=False, **kwargs
-    ):
+        self,
+        element: ColumnElement[Any],
+        within_columns_clause: bool = False,
+        **kwargs: Any,
+    ) -> str:
         if not self.stack:
             # compiling the element outside of the context of a SELECT
             return self.process(element._text_clause)
@@ -2565,12 +2620,14 @@ class SQLCompiler(Compiled):
                 self, within_columns_clause=False, **kw
             )
 
-    def _fallback_column_name(self, column):
+    def _fallback_column_name(self, column: ColumnClause[Any]) -> str:
         raise exc.CompileError(
             "Cannot compile Column object until its 'name' is assigned."
         )
 
-    def visit_lambda_element(self, element, **kw):
+    def visit_lambda_element(
+        self, element: ColumnElement[Any], **kw: Any
+    ) -> str:
         sql_element = element._resolved
         return self.process(sql_element, **kw)
 
@@ -2633,16 +2690,20 @@ class SQLCompiler(Compiled):
 
             return schema_prefix + self.preparer.quote(tablename) + "." + name
 
-    def visit_collation(self, element, **kw):
+    def visit_collation(self, element: ColumnClause[Any], **kw: Any) -> str:
         return self.preparer.format_collation(element.collation)
 
-    def visit_fromclause(self, fromclause, **kwargs):
+    def visit_fromclause(
+        self, fromclause: ColumnClause[Any], **kwargs: Any
+    ) -> str:
         return fromclause.name
 
     def visit_index(self, index, **kwargs):
         return index.name
 
-    def visit_typeclause(self, typeclause, **kw):
+    def visit_typeclause(
+        self, typeclause, **kw
+    ):
         kw["type_expression"] = typeclause
         kw["identifier_preparer"] = self.preparer
         return self.dialect.type_compiler_instance.process(
@@ -2751,7 +2812,7 @@ class SQLCompiler(Compiled):
         else:
             return "0"
 
-    def _generate_delimited_list(self, elements, separator, **kw):
+    def _generate_delimited_list(self, elements: Iterable[ColumnElement[Any]], separator: str, **kw: Any) -> str:
         return separator.join(
             s
             for s in (c._compiler_dispatch(self, **kw) for c in elements)
@@ -3528,40 +3589,52 @@ class SQLCompiler(Compiled):
         binary.right = percent._rconcat(ilike_case_insensitive(binary.right))
         return self.visit_ilike_op_binary(binary, operator, **kw)
 
-    def visit_not_istartswith_op_binary(self, binary, operator, **kw):
+    def visit_not_istartswith_op_binary(
+            self, binary: BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         binary = binary._clone()
         percent = self._like_percent_literal
         binary.left = ilike_case_insensitive(binary.left)
         binary.right = percent._rconcat(ilike_case_insensitive(binary.right))
         return self.visit_not_ilike_op_binary(binary, operator, **kw)
 
-    def visit_endswith_op_binary(self, binary, operator, **kw):
+    def visit_endswith_op_binary(
+            self, binary: BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         binary = binary._clone()
         percent = self._like_percent_literal
         binary.right = percent.concat(binary.right)
         return self.visit_like_op_binary(binary, operator, **kw)
 
-    def visit_not_endswith_op_binary(self, binary, operator, **kw):
+    def visit_not_endswith_op_binary(
+            self, binary: BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         binary = binary._clone()
         percent = self._like_percent_literal
         binary.right = percent.concat(binary.right)
         return self.visit_not_like_op_binary(binary, operator, **kw)
 
-    def visit_iendswith_op_binary(self, binary, operator, **kw):
+    def visit_iendswith_op_binary(
+            self, binary: BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         binary = binary._clone()
         percent = self._like_percent_literal
         binary.left = ilike_case_insensitive(binary.left)
         binary.right = percent.concat(ilike_case_insensitive(binary.right))
         return self.visit_ilike_op_binary(binary, operator, **kw)
 
-    def visit_not_iendswith_op_binary(self, binary, operator, **kw):
+    def visit_not_iendswith_op_binary(
+            self, binary: BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         binary = binary._clone()
         percent = self._like_percent_literal
         binary.left = ilike_case_insensitive(binary.left)
         binary.right = percent.concat(ilike_case_insensitive(binary.right))
         return self.visit_not_ilike_op_binary(binary, operator, **kw)
 
-    def visit_like_op_binary(self, binary, operator, **kw):
+    def visit_like_op_binary(
+            self, binary: BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         escape = binary.modifiers.get("escape", None)
 
         return "%s LIKE %s" % (
@@ -3573,7 +3646,9 @@ class SQLCompiler(Compiled):
             else ""
         )
 
-    def visit_not_like_op_binary(self, binary, operator, **kw):
+    def visit_not_like_op_binary(
+        self, binary: BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         escape = binary.modifiers.get("escape", None)
         return "%s NOT LIKE %s" % (
             binary.left._compiler_dispatch(self, **kw),
@@ -3584,7 +3659,9 @@ class SQLCompiler(Compiled):
             else ""
         )
 
-    def visit_ilike_op_binary(self, binary, operator, **kw):
+    def visit_ilike_op_binary(
+        self, binary: BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         if operator is operators.ilike_op:
             binary = binary._clone()
             binary.left = ilike_case_insensitive(binary.left)
@@ -3593,7 +3670,9 @@ class SQLCompiler(Compiled):
 
         return self.visit_like_op_binary(binary, operator, **kw)
 
-    def visit_not_ilike_op_binary(self, binary, operator, **kw):
+    def visit_not_ilike_op_binary(
+        self, binary: BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         if operator is operators.not_ilike_op:
             binary = binary._clone()
             binary.left = ilike_case_insensitive(binary.left)
@@ -3602,13 +3681,17 @@ class SQLCompiler(Compiled):
 
         return self.visit_not_like_op_binary(binary, operator, **kw)
 
-    def visit_between_op_binary(self, binary, operator, **kw):
+    def visit_between_op_binary(
+        self, binary: BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         symmetric = binary.modifiers.get("symmetric", False)
         return self._generate_generic_binary(
             binary, " BETWEEN SYMMETRIC " if symmetric else " BETWEEN ", **kw
         )
 
-    def visit_not_between_op_binary(self, binary, operator, **kw):
+    def visit_not_between_op_binary(
+        self, binary: BinaryExpression[Any], operator: Any, **kw: Any
+    ) -> str:
         symmetric = binary.modifiers.get("symmetric", False)
         return self._generate_generic_binary(
             binary,
@@ -4139,12 +4222,12 @@ class SQLCompiler(Compiled):
                     # TODO: can we get at the .columns_plus_names collection
                     # that is already (or will be?) generated for the SELECT
                     # rather than calling twice?
-                    recur_cols = [
+                    recur_cols: List[str] = [
                         # TODO: proxy_name is not technically safe,
                         # see test_cte->
                         # test_with_recursive_no_name_currently_buggy.  not
                         # clear what should be done with such a case
-                        fallback_label_name or proxy_name
+                        fallback_label_name or proxy_name  # type: ignore
                         for (
                             _,
                             proxy_name,
@@ -4202,7 +4285,7 @@ class SQLCompiler(Compiled):
                 if self.preparer._requires_quotes(cte_name):
                     cte_name = self.preparer.quote(cte_name)
                 text += self.get_render_as_alias_suffix(cte_name)
-                return text  # type: ignore[no-any-return]
+                return text
             else:
                 return self.preparer.format_alias(cte, cte_name)
 
@@ -4403,10 +4486,10 @@ class SQLCompiler(Compiled):
                 v = "%s(%s)" % (lateral, v)
         return v
 
-    def visit_scalar_values(self, element, **kw):
+    def visit_scalar_values(self, element: ColumnElement[Any], **kw: Any) -> str:
         return f"({self._render_values(element, **kw)})"
 
-    def get_render_as_alias_suffix(self, alias_name_text):
+    def get_render_as_alias_suffix(self, alias_name_text: str) -> str:
         return " AS " + alias_name_text
 
     def _add_to_result_map(
@@ -4670,7 +4753,7 @@ class SQLCompiler(Compiled):
             sqltext += " " + hinttext
         return sqltext
 
-    def get_select_hint_text(self, byfroms):
+    def get_select_hint_text(self, byfroms: Any) -> Optional[str]:
         return None
 
     def get_from_hint_text(
@@ -4678,10 +4761,10 @@ class SQLCompiler(Compiled):
     ) -> Optional[str]:
         return None
 
-    def get_crud_hint_text(self, table, text):
+    def get_crud_hint_text(self, table: Table, text: str) -> None:
         return None
 
-    def get_statement_hint_text(self, hint_texts):
+    def get_statement_hint_text(self, hint_texts: Iterable[str]) -> str:
         return " ".join(hint_texts)
 
     _default_stack_entry: _CompilerStackEntry
@@ -4958,7 +5041,7 @@ class SQLCompiler(Compiled):
             if dialect in ("*", self.dialect.name)
         }
         hint_text = self.get_select_hint_text(byfrom)
-        return hint_text, byfrom
+        return hint_text, byfrom    # type: ignore[return-value]
 
     def _setup_select_stack(
         self, select, compile_state, entry, asfrom, lateral, compound_index
@@ -5175,7 +5258,7 @@ class SQLCompiler(Compiled):
 
         return cte_text
 
-    def get_cte_preamble(self, recursive):
+    def get_cte_preamble(self, recursive: bool) -> LiteralString:
         if recursive:
             return "WITH RECURSIVE"
         else:
@@ -5197,7 +5280,7 @@ class SQLCompiler(Compiled):
             )
         return "DISTINCT " if select._distinct else ""
 
-    def group_by_clause(self, select, **kw):
+    def group_by_clause(self, select: Select[Any], **kw: Any) -> str:
         """allow dialects to customize how GROUP BY is rendered."""
 
         group_by = self._generate_delimited_list(
@@ -5208,7 +5291,7 @@ class SQLCompiler(Compiled):
         else:
             return ""
 
-    def order_by_clause(self, select, **kw):
+    def order_by_clause(self, select: Select[Any], **kw: Any) -> str:
         """allow dialects to customize how ORDER BY is rendered."""
 
         order_by = self._generate_delimited_list(
@@ -5220,7 +5303,7 @@ class SQLCompiler(Compiled):
         else:
             return ""
 
-    def for_update_clause(self, select, **kw):
+    def for_update_clause(self, select: Select[Any], **kw: Any) -> LiteralString:
         return " FOR UPDATE"
 
     def returning_clause(
@@ -5255,7 +5338,7 @@ class SQLCompiler(Compiled):
 
         return "RETURNING " + ", ".join(columns)
 
-    def limit_clause(self, select, **kw):
+    def limit_clause(self, select: Select[Any], **kw: Any) -> str:
         text = ""
         if select._limit_clause is not None:
             text += "\n LIMIT " + self.process(select._limit_clause, **kw)
@@ -5389,7 +5472,11 @@ class SQLCompiler(Compiled):
             )
         )
 
-    def _setup_crud_hints(self, stmt, table_text):
+    def _setup_crud_hints(
+        self,
+        stmt,
+        table_text
+    ):
         dialect_hints = {
             table: hint_text
             for (table, dialect), hint_text in stmt._hints.items()
@@ -5843,7 +5930,11 @@ class SQLCompiler(Compiled):
             batchnum += 1
 
     def visit_insert(
-        self, insert_stmt, visited_bindparam=None, visiting_cte=None, **kw
+        self,
+        insert_stmt,
+        visited_bindparam = None,
+        visiting_cte = None,
+        **kw
     ):
         compile_state = insert_stmt._compile_state_factory(
             insert_stmt, self, **kw
@@ -6212,7 +6303,13 @@ class SQLCompiler(Compiled):
 
         return text
 
-    def update_tables_clause(self, update_stmt, from_table, extra_froms, **kw):
+    def update_tables_clause(
+        self,
+        update_stmt: Update,
+        from_table: dml._DMLTableElement,
+        extra_froms: List[FromClause],
+        **kw: Any
+    ) -> str:
         """Provide a hook to override the initial table clause
         in an UPDATE statement.
 
@@ -6223,8 +6320,13 @@ class SQLCompiler(Compiled):
         return from_table._compiler_dispatch(self, iscrud=True, **kw)
 
     def update_from_clause(
-        self, update_stmt, from_table, extra_froms, from_hints, **kw
-    ):
+        self,
+        update_stmt: Update,
+        from_table: dml._DMLTableElement,
+        extra_froms: List[FromClause],
+        from_hints: _FromHintsType,
+        **kw: Any
+    ) -> Optional[str]:
         """Provide a hook to override the generation of an
         UPDATE..FROM clause.
         MySQL and MSSQL override this.
@@ -6416,11 +6518,16 @@ class SQLCompiler(Compiled):
 
         self.stack.pop(-1)
 
-        return text  # type: ignore[no-any-return]
+        return text
 
     def delete_extra_from_clause(
-        self, delete_stmt, from_table, extra_froms, from_hints, **kw
-    ):
+        self,
+        delete_stmt: Delete,
+        from_table: _DMLTableElement,
+        extra_froms: List[FromClause],
+        from_hints: _FromHintsType,
+        **kw: Any
+    ) -> str:
         """Provide a hook to override the generation of an
         DELETE..FROM clause.
 
@@ -6434,12 +6541,23 @@ class SQLCompiler(Compiled):
             "criteria within DELETE"
         )
 
-    def delete_table_clause(self, delete_stmt, from_table, extra_froms, **kw):
+    def delete_table_clause(
+        self,
+        delete_stmt: Delete,
+        from_table: _DMLTableElement,
+        extra_froms: List[FromClause],
+        **kw: Any
+    ) -> str:
         return from_table._compiler_dispatch(
             self, asfrom=True, iscrud=True, **kw
         )
 
-    def visit_delete(self, delete_stmt, visiting_cte=None, **kw):
+    def visit_delete(
+        self,
+        delete_stmt: Delete,
+        visiting_cte: Optional[CTE]=None,
+        **kw: Any
+    ) -> str:
         compile_state = delete_stmt._compile_state_factory(
             delete_stmt, self, **kw
         )
@@ -6467,7 +6585,7 @@ class SQLCompiler(Compiled):
             from_linter = None
             warn_linting = False
 
-        extra_froms = compile_state._extra_froms
+        extra_froms = compile_state._extra_froms    # type: ignore[attr-defined]
 
         correlate_froms = {delete_stmt.table}.union(extra_froms)
         self.stack.append(
@@ -6503,7 +6621,7 @@ class SQLCompiler(Compiled):
             if from_linter:
                 _ = self.process(delete_stmt.table, from_linter=from_linter)
 
-        crud._get_crud_params(self, delete_stmt, compile_state, toplevel, **kw)
+        crud._get_crud_params(self, delete_stmt, compile_state, toplevel, **kw) # type: ignore[arg-type]
 
         if delete_stmt._hints:
             dialect_hints, table_text = self._setup_crud_hints(
@@ -6572,15 +6690,25 @@ class SQLCompiler(Compiled):
 
         return text
 
-    def visit_savepoint(self, savepoint_stmt, **kw):
+    def visit_savepoint(
+        self,
+        savepoint_stmt: SavepointClause,
+        **kw: Any
+    ) -> str:
         return "SAVEPOINT %s" % self.preparer.format_savepoint(savepoint_stmt)
 
-    def visit_rollback_to_savepoint(self, savepoint_stmt, **kw):
+    def visit_rollback_to_savepoint(
+        self,
+        savepoint_stmt: SavepointClause,
+        **kw: Any
+    ) -> str:
         return "ROLLBACK TO SAVEPOINT %s" % self.preparer.format_savepoint(
             savepoint_stmt
         )
 
-    def visit_release_savepoint(self, savepoint_stmt, **kw):
+    def visit_release_savepoint(
+            self, savepoint_stmt: SavepointClause, **kw: Any
+    ) -> str:
         return "RELEASE SAVEPOINT %s" % self.preparer.format_savepoint(
             savepoint_stmt
         )
@@ -6606,11 +6734,16 @@ class StrSQLCompiler(SQLCompiler):
 
     """
 
-    def _fallback_column_name(self, column):
+    def _fallback_column_name(self, column: ColumnClause[Any]) -> str:
         return "<name unknown>"
 
     @util.preload_module("sqlalchemy.engine.url")
-    def visit_unsupported_compilation(self, element, err, **kw):
+    def visit_unsupported_compilation(
+        self,
+        element: ColumnElement[Any],
+        err: exc.CompileError,
+        **kw: Any
+    ) -> Any:
         if element.stringify_dialect != "default":
             url = util.preloaded.engine_url
             dialect = url.URL.create(element.stringify_dialect).get_dialect()()
@@ -6623,19 +6756,34 @@ class StrSQLCompiler(SQLCompiler):
 
         return super().visit_unsupported_compilation(element, err)
 
-    def visit_getitem_binary(self, binary, operator, **kw):
+    def visit_getitem_binary(
+        self,
+        binary: BinaryExpression[Any],
+        operator: operators.OperatorType,
+        **kw: Any
+    ) -> str:
         return "%s[%s]" % (
             self.process(binary.left, **kw),
             self.process(binary.right, **kw),
         )
 
-    def visit_json_getitem_op_binary(self, binary, operator, **kw):
+    def visit_json_getitem_op_binary(
+        self,
+        binary: BinaryExpression[Any],
+        operator: operators.OperatorType,
+        **kw: Any
+    ) -> str:
         return self.visit_getitem_binary(binary, operator, **kw)
 
-    def visit_json_path_getitem_op_binary(self, binary, operator, **kw):
+    def visit_json_path_getitem_op_binary(
+        self,
+        binary: BinaryExpression[Any],
+        operator: operators.OperatorType,
+        **kw: Any
+    ) -> str:
         return self.visit_getitem_binary(binary, operator, **kw)
 
-    def visit_sequence(self, sequence, **kw):
+    def visit_sequence(self, sequence: schema.Sequence, **kw: Any) -> str:
         return (
             f"<next sequence value: {self.preparer.format_sequence(sequence)}>"
         )
@@ -6655,8 +6803,13 @@ class StrSQLCompiler(SQLCompiler):
         return "RETURNING " + ", ".join(columns)
 
     def update_from_clause(
-        self, update_stmt, from_table, extra_froms, from_hints, **kw
-    ):
+        self,
+        update_stmt: Update,
+        from_table: FromClause,
+        extra_froms: Iterable[FromClause],
+        from_hints: _FromHintsType,
+        **kw: Any
+    ) -> str:
         kw["asfrom"] = True
         return "FROM " + ", ".join(
             t._compiler_dispatch(self, fromhints=from_hints, **kw)
@@ -6664,33 +6817,61 @@ class StrSQLCompiler(SQLCompiler):
         )
 
     def delete_extra_from_clause(
-        self, delete_stmt, from_table, extra_froms, from_hints, **kw
-    ):
+        self,
+        delete_stmt: Delete,
+        from_table: FromClause,
+        extra_froms: Iterable[FromClause],
+        from_hints: _FromHintsType,
+        **kw: Any
+    ) -> str:
         kw["asfrom"] = True
         return ", " + ", ".join(
             t._compiler_dispatch(self, fromhints=from_hints, **kw)
             for t in extra_froms
         )
 
-    def visit_empty_set_expr(self, element_types, **kw):
+    def visit_empty_set_expr(
+        self,
+        element_types: Any,
+        **kw: Any
+    ) -> str:
         return "SELECT 1 WHERE 1!=1"
 
-    def get_from_hint_text(self, table, text):
+    def get_from_hint_text(
+        self,
+        table: FromClause,
+        text: Optional[str]
+    ) -> str:
         return "[%s]" % text
 
-    def visit_regexp_match_op_binary(self, binary, operator, **kw):
+    def visit_regexp_match_op_binary(
+        self,
+        binary: BinaryExpression[Any],
+        operator: operators.OperatorType,
+        **kw: Any
+    ) -> str:
         return self._generate_generic_binary(binary, " <regexp> ", **kw)
 
-    def visit_not_regexp_match_op_binary(self, binary, operator, **kw):
+    def visit_not_regexp_match_op_binary(
+        self,
+        binary: BinaryExpression[Any],
+        operator: operators.OperatorType,
+        **kw: Any
+    ) -> str:
         return self._generate_generic_binary(binary, " <not regexp> ", **kw)
 
-    def visit_regexp_replace_op_binary(self, binary, operator, **kw):
+    def visit_regexp_replace_op_binary(
+        self,
+        binary: BinaryExpression[Any],
+        operator: operators.OperatorType,
+        **kw: Any
+    ) -> str:
         return "<regexp replace>(%s, %s)" % (
             binary.left._compiler_dispatch(self, **kw),
             binary.right._compiler_dispatch(self, **kw),
         )
 
-    def visit_try_cast(self, cast, **kwargs):
+    def visit_try_cast(self, cast: ColumnClause[Any], **kwargs: Any) -> str:
         return "TRY_CAST(%s AS %s)" % (
             cast.clause._compiler_dispatch(self, **kwargs),
             cast.typeclause._compiler_dispatch(self, **kwargs),
@@ -6698,7 +6879,7 @@ class StrSQLCompiler(SQLCompiler):
 
 
 class DDLCompiler(Compiled):
-    is_ddl = True
+    is_ddl: bool = True
 
     if TYPE_CHECKING:
 
@@ -6718,7 +6899,7 @@ class DDLCompiler(Compiled):
         )
 
     @util.memoized_property
-    def type_compiler(self):
+    def type_compiler(self) -> TypeCompiler:
         return self.dialect.type_compiler_instance
 
     def construct_params(
@@ -6729,7 +6910,9 @@ class DDLCompiler(Compiled):
     ) -> Optional[_MutableCoreSingleExecuteParams]:
         return None
 
-    def visit_ddl(self, ddl, **kwargs):
+    def visit_ddl(
+        self, ddl: ddl.DDL, **kwargs: Any
+    ) -> Any:
         # table events can substitute table and schema name
         context = ddl.context
         if isinstance(ddl.target, schema.Table):
@@ -6748,13 +6931,13 @@ class DDLCompiler(Compiled):
 
         return self.sql_compiler.post_process_text(ddl.statement % context)
 
-    def visit_create_schema(self, create, **kw):
+    def visit_create_schema(self, create: ddl.CreateSchema, **kw: Any) -> str:
         text = "CREATE SCHEMA "
         if create.if_not_exists:
             text += "IF NOT EXISTS "
         return text + self.preparer.format_schema(create.element)
 
-    def visit_drop_schema(self, drop, **kw):
+    def visit_drop_schema(self, drop: ddl.DropSchema, **kw: Any) -> str:
         text = "DROP SCHEMA "
         if drop.if_exists:
             text += "IF EXISTS "
@@ -6763,7 +6946,7 @@ class DDLCompiler(Compiled):
             text += " CASCADE"
         return text
 
-    def visit_create_table(self, create, **kw):
+    def visit_create_table(self, create: ddl.CreateTable, **kw: Any) -> str:
         table = create.element
         preparer = self.preparer
 
@@ -6815,7 +6998,7 @@ class DDLCompiler(Compiled):
         text += "\n)%s\n\n" % self.post_create_table(table)
         return text
 
-    def visit_create_column(self, create, first_pk=False, **kw):
+    def visit_create_column(self, create: ddl.CreateColumn, first_pk: bool = False, **kw: Any) -> Optional[str]:
         column = create.element
 
         if column.system:
@@ -6831,8 +7014,11 @@ class DDLCompiler(Compiled):
         return text
 
     def create_table_constraints(
-        self, table, _include_foreign_key_constraints=None, **kw
-    ):
+        self,
+        table: Table,
+        _include_foreign_key_constraints: Optional[Sequence[ForeignKeyConstraint]] = None,
+        **kw: Any
+    ) -> str:
         # On some DB order is significant: visit PK first, then the
         # other constraints (engine.ReflectionTest.testbasic failed on FB2)
         constraints = []
@@ -6847,7 +7033,7 @@ class DDLCompiler(Compiled):
 
         constraints.extend(
             [
-                c
+                c   # type: ignore[misc]
                 for c in table._sorted_constraints
                 if c is not table.primary_key and c not in omit_fkcs
             ]
@@ -6867,13 +7053,13 @@ class DDLCompiler(Compiled):
             if p is not None
         )
 
-    def visit_drop_table(self, drop, **kw):
+    def visit_drop_table(self, drop: ddl.DropTable, **kw: Any) -> str:
         text = "\nDROP TABLE "
         if drop.if_exists:
             text += "IF EXISTS "
         return text + self.preparer.format_table(drop.element)
 
-    def visit_drop_view(self, drop, **kw):
+    def visit_drop_view(self, drop: ddl._DropView, **kw: Any) -> str:
         return "\nDROP VIEW " + self.preparer.format_table(drop.element)
 
     def _verify_index_table(self, index: Index) -> None:
@@ -6883,8 +7069,12 @@ class DDLCompiler(Compiled):
             )
 
     def visit_create_index(
-        self, create, include_schema=False, include_table_schema=True, **kw
-    ):
+        self,
+        create: ddl.CreateIndex,
+        include_schema: bool = False,
+        include_table_schema: bool = True,
+        **kw: Any
+    ) -> str:
         index = create.element
         self._verify_index_table(index)
         preparer = self.preparer
@@ -6903,18 +7093,18 @@ class DDLCompiler(Compiled):
         text += "%s ON %s (%s)" % (
             self._prepared_index_name(index, include_schema=include_schema),
             preparer.format_table(
-                index.table, use_schema=include_table_schema
+                index.table, use_schema=include_table_schema    # type: ignore[arg-type]
             ),
             ", ".join(
                 self.sql_compiler.process(
-                    expr, include_table=False, literal_binds=True
+                    expr, include_table=False, literal_binds=True   # type: ignore[arg-type]
                 )
                 for expr in index.expressions
             ),
         )
         return text
 
-    def visit_drop_index(self, drop, **kw):
+    def visit_drop_index(self, drop: ddl.DropIndex, **kw: Any) -> str:
         index = drop.element
 
         if index.name is None:
@@ -6945,13 +7135,15 @@ class DDLCompiler(Compiled):
             index_name = schema_name + "." + index_name
         return index_name
 
-    def visit_add_constraint(self, create, **kw):
+    def visit_add_constraint(
+            self, create: ddl.AddConstraint , **kw: Any
+    ) -> str:
         return "ALTER TABLE %s ADD %s" % (
             self.preparer.format_table(create.element.table),
             self.process(create.element),
         )
 
-    def visit_set_table_comment(self, create, **kw):
+    def visit_set_table_comment(self, create: ddl.SetTableComment, **kw: Any) -> str:
         return "COMMENT ON TABLE %s IS %s" % (
             self.preparer.format_table(create.element),
             self.sql_compiler.render_literal_value(
@@ -6959,12 +7151,12 @@ class DDLCompiler(Compiled):
             ),
         )
 
-    def visit_drop_table_comment(self, drop, **kw):
+    def visit_drop_table_comment(self, drop: ddl.DropTableComment, **kw: Any) -> str:
         return "COMMENT ON TABLE %s IS NULL" % self.preparer.format_table(
             drop.element
         )
 
-    def visit_set_column_comment(self, create, **kw):
+    def visit_set_column_comment(self, create: ddl.SetColumnComment, **kw: Any) -> str:
         return "COMMENT ON COLUMN %s IS %s" % (
             self.preparer.format_column(
                 create.element, use_table=True, use_schema=True
@@ -6974,15 +7166,15 @@ class DDLCompiler(Compiled):
             ),
         )
 
-    def visit_drop_column_comment(self, drop, **kw):
+    def visit_drop_column_comment(self, drop: ddl.DropColumnComment, **kw: Any) -> str:
         return "COMMENT ON COLUMN %s IS NULL" % self.preparer.format_column(
             drop.element, use_table=True
         )
 
-    def visit_set_constraint_comment(self, create, **kw):
+    def visit_set_constraint_comment(self, create: ddl.SetConstraintComment, **kw: Any) -> str:
         raise exc.UnsupportedCompilationError(self, type(create))
 
-    def visit_drop_constraint_comment(self, drop, **kw):
+    def visit_drop_constraint_comment(self, drop: ddl.DropColumnComment, **kw: Any) -> str:
         raise exc.UnsupportedCompilationError(self, type(drop))
 
     def get_identity_options(self, identity_options):
@@ -7005,7 +7197,7 @@ class DDLCompiler(Compiled):
             text.append("CYCLE" if identity_options.cycle else "NO CYCLE")
         return " ".join(text)
 
-    def visit_create_sequence(self, create, prefix=None, **kw):
+    def visit_create_sequence(self, create: ddl.CreateSequence, prefix: Any = None, **kw: Any) -> str:
         text = "CREATE SEQUENCE "
         if create.if_not_exists:
             text += "IF NOT EXISTS "
@@ -7018,13 +7210,15 @@ class DDLCompiler(Compiled):
             text += " " + options
         return text
 
-    def visit_drop_sequence(self, drop, **kw):
+    def visit_drop_sequence(self, drop: ddl.DropSequence, **kw: Any) -> str:
         text = "DROP SEQUENCE "
         if drop.if_exists:
             text += "IF EXISTS "
         return text + self.preparer.format_sequence(drop.element)
 
-    def visit_drop_constraint(self, drop, **kw):
+    def visit_drop_constraint(
+            self, drop: ddl.DropConstraint, **kw: Any
+    ) -> str:
         constraint = drop.element
         if constraint.name is not None:
             formatted_name = self.preparer.format_constraint(constraint)
@@ -7043,7 +7237,7 @@ class DDLCompiler(Compiled):
             " CASCADE" if drop.cascade else "",
         )
 
-    def get_column_specification(self, column, **kwargs):
+    def get_column_specification(self, column: Column[Any], **kwargs: Any) -> str:
         colspec = (
             self.preparer.format_column(column)
             + " "
@@ -7070,10 +7264,10 @@ class DDLCompiler(Compiled):
             colspec += " NOT NULL"
         return colspec
 
-    def create_table_suffix(self, table):
+    def create_table_suffix(self, table: Table) -> LiteralString:
         return ""
 
-    def post_create_table(self, table):
+    def post_create_table(self, table: Table) -> LiteralString:
         return ""
 
     def get_column_default_string(self, column: Column[Any]) -> Optional[str]:
@@ -7090,13 +7284,13 @@ class DDLCompiler(Compiled):
         else:
             return self.sql_compiler.process(default, literal_binds=True)
 
-    def visit_table_or_column_check_constraint(self, constraint, **kw):
+    def visit_table_or_column_check_constraint(self, constraint: schema.CheckConstraint, **kw: Any) -> str:
         if constraint.is_column_level:
             return self.visit_column_check_constraint(constraint)
         else:
             return self.visit_check_constraint(constraint)
 
-    def visit_check_constraint(self, constraint, **kw):
+    def visit_check_constraint(self, constraint: schema.CheckConstraint, **kw: Any) -> str:
         text = ""
         if constraint.name is not None:
             formatted_name = self.preparer.format_constraint(constraint)
@@ -7108,7 +7302,7 @@ class DDLCompiler(Compiled):
         text += self.define_constraint_deferrability(constraint)
         return text
 
-    def visit_column_check_constraint(self, constraint, **kw):
+    def visit_column_check_constraint(self, constraint: schema.CheckConstraint, **kw: Any) -> str:
         text = ""
         if constraint.name is not None:
             formatted_name = self.preparer.format_constraint(constraint)
@@ -7142,7 +7336,7 @@ class DDLCompiler(Compiled):
         text += self.define_constraint_deferrability(constraint)
         return text
 
-    def visit_foreign_key_constraint(self, constraint, **kw):
+    def visit_foreign_key_constraint(self, constraint: ForeignKeyConstraint, **kw: Any) -> str:
         preparer = self.preparer
         text = ""
         if constraint.name is not None:
@@ -7166,7 +7360,12 @@ class DDLCompiler(Compiled):
         text += self.define_constraint_deferrability(constraint)
         return text
 
-    def define_constraint_remote_table(self, constraint, table, preparer):
+    def define_constraint_remote_table(
+            self,
+            constraint: Constraint,
+            table: Table,
+            preparer: IdentifierPreparer
+    ) -> str:
         """Format the remote table clause of a CREATE CONSTRAINT clause."""
 
         return preparer.format_table(table)
@@ -7231,13 +7430,13 @@ class DDLCompiler(Compiled):
             )
         return text
 
-    def define_constraint_match(self, constraint):
+    def define_constraint_match(self, constraint: ForeignKeyConstraint) -> str:
         text = ""
         if constraint.match is not None:
             text += " MATCH %s" % constraint.match
         return text
 
-    def visit_computed_column(self, generated, **kw):
+    def visit_computed_column(self, generated: ColumnClause[Any], **kw: Any) -> str:
         text = "GENERATED ALWAYS AS (%s)" % self.sql_compiler.process(
             generated.sqltext, include_table=False, literal_binds=True
         )
@@ -7428,7 +7627,7 @@ class GenericTypeCompiler(TypeCompiler):
     def visit_enum(self, type_: sqltypes.Enum, **kw: Any) -> str:
         return self.visit_VARCHAR(type_, **kw)
 
-    def visit_null(self, type_, **kw):
+    def visit_null(self, type_: sqltypes.NullType, **kw: Any) -> str:
         raise exc.CompileError(
             "Can't generate DDL for %r; "
             "did you forget to specify a "
@@ -7447,7 +7646,7 @@ class GenericTypeCompiler(TypeCompiler):
 
 
 class StrSQLTypeCompiler(GenericTypeCompiler):
-    def process(self, type_, **kw):
+    def process(self, type_: TypeEngine[Any], **kw: Any) -> str:
         try:
             _compiler_dispatch = type_._compiler_dispatch
         except AttributeError:
@@ -7455,22 +7654,22 @@ class StrSQLTypeCompiler(GenericTypeCompiler):
         else:
             return _compiler_dispatch(self, **kw)
 
-    def __getattr__(self, key):
+    def __getattr__(self, key: str) -> Callable[[TypeEngine[Any]], str]:
         if key.startswith("visit_"):
             return self._visit_unknown
         else:
             raise AttributeError(key)
 
-    def _visit_unknown(self, type_, **kw):
+    def _visit_unknown(self, type_: TypeEngine[Any], **kw: Any) -> str:
         if type_.__class__.__name__ == type_.__class__.__name__.upper():
             return type_.__class__.__name__
         else:
             return repr(type_)
 
-    def visit_null(self, type_, **kw):
+    def visit_null(self, type_: TypeEngine[Any], **kw: Any) -> LiteralString:
         return "NULL"
 
-    def visit_user_defined(self, type_, **kw):
+    def visit_user_defined(self, type_: UserDefinedType[Any], **kw: Any) -> Any:
         try:
             get_col_spec = type_.get_col_spec
         except AttributeError:
@@ -7490,11 +7689,11 @@ class _BindNameForColProtocol(Protocol):
 class IdentifierPreparer:
     """Handle quoting and case-folding of identifiers based on options."""
 
-    reserved_words = RESERVED_WORDS
+    reserved_words: Set[str] = RESERVED_WORDS
 
-    legal_characters = LEGAL_CHARACTERS
+    legal_characters: _RegexPatternStr = LEGAL_CHARACTERS
 
-    illegal_initial_characters = ILLEGAL_INITIAL_CHARACTERS
+    illegal_initial_characters: Set[str] = ILLEGAL_INITIAL_CHARACTERS
 
     initial_quote: str
 
@@ -7523,7 +7722,7 @@ class IdentifierPreparer:
         escape_quote: str = '"',
         quote_case_sensitive_collations: bool = True,
         omit_schema: bool = False,
-    ):
+    ) -> None:
         """Construct a new ``IdentifierPreparer`` object.
 
         initial_quote
@@ -7551,7 +7750,9 @@ class IdentifierPreparer:
             "pyformat",
         )
 
-    def _with_schema_translate(self, schema_translate_map):
+    def _with_schema_translate(
+        self, schema_translate_map: SchemaTranslateMapType
+    ) -> IdentifierPreparer:
         prep = self.__class__.__new__(self.__class__)
         prep.__dict__.update(self.__dict__)
 
@@ -7591,7 +7792,7 @@ class IdentifierPreparer:
 
             d["_none"] = d[None]  # type: ignore[index]
 
-        def replace(m):
+        def replace(m: _RegexMatchStr) -> str:
             name = m.group(2)
             if name in d:
                 effective_schema = d[name]
@@ -7639,7 +7840,9 @@ class IdentifierPreparer:
 
         return value.replace(self.escape_to_quote, self.escape_quote)
 
-    def validate_sql_phrase(self, element, reg):
+    def validate_sql_phrase(
+        self, element: Optional[str], reg: _RegexPatternStr
+    ) -> Optional[str]:
         """keyword sequence filter.
 
         a filter for elements that are intended to represent keyword sequences,
@@ -7678,7 +7881,7 @@ class IdentifierPreparer:
             or (lc_value != value)
         )
 
-    def _requires_quotes_illegal_chars(self, value):
+    def _requires_quotes_illegal_chars(self, value: str) -> bool:
         """Return True if the given identifier requires quoting, but
         not taking case convention into account."""
         return not self.legal_characters.match(str(value))
@@ -7726,7 +7929,7 @@ class IdentifierPreparer:
         else:
             return ident
 
-    def format_collation(self, collation_name):
+    def format_collation(self, collation_name: str) -> str:
         if self.quote_case_sensitive_collations:
             return self.quote(collation_name)
         else:
@@ -7761,7 +7964,9 @@ class IdentifierPreparer:
         else:
             return self.quote(name)
 
-    def format_savepoint(self, savepoint, name=None):
+    def format_savepoint(
+        self, savepoint: SavepointClause, name: Optional[str] = None
+    ) -> str:
         # Running the savepoint name through quoting is unnecessary
         # for all known dialects.  This is here to support potential
         # third party use cases
@@ -7845,7 +8050,7 @@ class IdentifierPreparer:
 
     def format_table(
         self,
-        table: FromClause,
+        table: Table,
         use_schema: bool = True,
         name: Optional[str] = None,
     ) -> str:
@@ -7863,16 +8068,16 @@ class IdentifierPreparer:
             result = self.quote_schema(effective_schema) + "." + result
         return result
 
-    def format_schema(self, name):
+    def format_schema(self, name: str) -> str:
         """Prepare a quoted schema name."""
 
         return self.quote(name)
 
     def format_label_name(
         self,
-        name,
-        anon_map=None,
-    ):
+        name: str,
+        anon_map: Optional[prefix_anon_map] = None,
+    ) -> str:
         """Prepare a quoted column name."""
 
         if anon_map is not None and isinstance(
@@ -7889,7 +8094,7 @@ class IdentifierPreparer:
         name: Optional[str] = None,
         table_name: Optional[str] = None,
         use_schema: bool = False,
-        anon_map: Optional[Mapping[str, Any]] = None,
+        anon_map: Optional[prefix_anon_map] = None,
     ) -> str:
         """Prepare a quoted column name."""
 
@@ -7928,7 +8133,9 @@ class IdentifierPreparer:
             else:
                 return name
 
-    def format_table_seq(self, table, use_schema=True):
+    def format_table_seq(
+        self, table: Table, use_schema: bool = True
+    ) -> Tuple[str, ...]:
         """Format table name and schema as a tuple."""
 
         # Dialects with more levels in their fully qualified references
@@ -7946,7 +8153,7 @@ class IdentifierPreparer:
             return (self.format_table(table, use_schema=False),)
 
     @util.memoized_property
-    def _r_identifiers(self):
+    def _r_identifiers(self) -> _RegexPatternStr:
         initial, final, escaped_final = (
             re.escape(s)
             for s in (


### PR DESCRIPTION
TEMP PR FOR ASKING QUERY:

Hii @CaselIT,

I'm currently working on adding type annotations to the compiler module, and I’ve made good progress (around 70–80% complete). While going through the `Compiler` unit, I encountered several type-checking issues related to assignments that seem inconsistent or potentially problematic.

For example::

```bash

lib/sqlalchemy/util/_collections_cy.py:142: error: Argument 1 to "clear" of "MutableSet" has incompatible type "OrderedSet[_T@OrderedSet]"; expected "MutableSet[_T@MutableSet]"  [arg-type]
lib/sqlalchemy/sql/schema.py:5737: error: Argument 1 to "clear" of "MutableMapping" has incompatible type "FacadeDict[str, Table]"; expected "MutableMapping[_KT, _VT]"  [arg-type]
lib/sqlalchemy/sql/util.py:1177: error: Incompatible return value type (got "Alias", expected "_ET | None")  [return-value]
lib/sqlalchemy/sql/compiler.py:3597: error: Incompatible types in assignment (expression has type "ilike_case_insensitive", variable has type "ColumnElement[Any]")  [assignment]
lib/sqlalchemy/sql/compiler.py:3622: error: Incompatible types in assignment (expression has type "ilike_case_insensitive", variable has type "ColumnElement[Any]")  [assignment]
lib/sqlalchemy/sql/compiler.py:3631: error: Incompatible types in assignment (expression has type "ilike_case_insensitive", variable has type "ColumnElement[Any]")  [assignment]
lib/sqlalchemy/sql/compiler.py:3667: error: Incompatible types in assignment (expression has type "ilike_case_insensitive", variable has type "ColumnElement[Any]")  [assignment]
lib/sqlalchemy/sql/compiler.py:3668: error: Incompatible types in assignment (expression has type "ilike_case_insensitive", variable has type "ColumnElement[Any]")  [assignment]
lib/sqlalchemy/sql/compiler.py:3678: error: Incompatible types in assignment (expression has type "ilike_case_insensitive", variable has type "ColumnElement[Any]")  [assignment]
lib/sqlalchemy/sql/compiler.py:3679: error: Incompatible types in assignment (expression has type "ilike_case_insensitive", variable has type "ColumnElement[Any]")  [assignment]
lib/sqlalchemy/orm/decl_base.py:1207: error: Unused "type: ignore" comment  [unused-ignore]
Found 11 errors in 5 files (checked 249 source files)


``` 
In various Units we are doing assignment of different kind of object which doesn't belongs to there any interface and parent class Which causing unexpected behaviour.

`REMARK` : This is temp PR so I will cancel it later once my query resolved and propose a correct PR.
