### PR TITLE
Add list subtype to ARRAY

### DIFF
--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -3199,7 +3199,7 @@ class ARRAY(
 
     @property
     def python_type(self) -> Type[Any]:
-        return list
+        return list[self.item_type.python_type]
 
     def compare_values(self, x: Any, y: Any) -> bool:
         return x == y  # type: ignore[no-any-return]


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
When using [sqlacodegen](https://github.com/agronholm/sqlacodegen), it is unable to correctly generate the type for postgres columns that use `ARRAY`, it just gets left as `list`. I'm hoping to have it correctly generate a type like `list[str]`

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
