### PR TITLE
fix: Handle Enum naming conflict with built-in types #12761

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2394,7 +2394,7 @@ class PGDDLCompiler(compiler.DDLCompiler):
     def visit_drop_enum_type(self, drop, **kw):
         type_ = drop.element
 
-        return "DROP TYPE " f"{self.preparer.format_type(type_)}"
+        return "DROP TYPE %s" % (self.preparer.format_type(type_))
 
     def visit_create_domain_type(self, create, **kw):
         domain: DOMAIN = create.element
@@ -2419,15 +2419,14 @@ class PGDDLCompiler(compiler.DDLCompiler):
             options.append(f"CHECK ({check})")
 
         return (
-            "CREATE DOMAIN "
-            f"{self.preparer.format_type(domain)} AS "
+            f"CREATE DOMAIN {self.preparer.format_type(domain)} AS "
             f"{self.type_compiler.process(domain.data_type)} "
             f"{' '.join(options)}"
         )
 
     def visit_drop_domain_type(self, drop, **kw):
         domain = drop.element
-        return "DROP DOMAIN" f" {self.preparer.format_type(domain)}"
+        return f"DROP DOMAIN {self.preparer.format_type(domain)}"
 
     def visit_create_index(self, create, **kw):
         preparer = self.preparer

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2873,7 +2873,8 @@ class PGIdentifierPreparer(compiler.IdentifierPreparer):
         schema (excluding "public" to preserve legacy behavior), and
         enforces explicit schema for builtin names when unresolved.
         """
-        schema = getattr(type_, "schema", None)
+
+        schema = self.schema_for_object(type_)
 
         # Apply schema translation first (if available)
         if getattr(self, "schema_translate_map", None):
@@ -2907,9 +2908,7 @@ class PGIdentifierPreparer(compiler.IdentifierPreparer):
         name = self.quote(type_.name)
 
         # prefer schema from object, fall back to override
-        effective_schema = self.schema_for_object(
-            type_
-        ) or self._get_schema_for_type(type_)
+        effective_schema = self._get_schema_for_type(type_)
 
         if (
             not self.omit_schema


### PR DESCRIPTION
### Title

`fix: Handle ENUM and DOMAIN naming conflicts with PostgreSQL built-in types #12761`

### Description

This PR fixes a bug in PostgreSQL where user-defined `ENUM` and `DOMAIN` types with names matching PostgreSQL built-in types (e.g., `text`, `char`) were incorrectly resolved to the built-in type instead of the intended user-defined type.

### Root Cause

PostgreSQL prioritizes `pg_catalog` when resolving unqualified type names. This can shadow user-defined types in other schemas when their names collide with built-in types.

### Solution

* Centralized schema resolution for `ENUM` and `DOMAIN` in `PGIdentifierPreparer.format_type()`.
* The schema resolution logic:

  * Respects explicit schema on the type.
  * Applies schema translation maps when available.
  * Falls back to the dialect’s `default_schema_name` (if configured).
  * Raises `CompileError` if the type name collides with a PostgreSQL built-in type and no schema can be determined.

This avoids collisions with built-in types while maintaining expected behavior for explicitly namespaced and schema-inherited types.

### Test Plan

* New regression tests were added to cover both `ENUM` and `DOMAIN` under different schema configurations, including:

  * Compile-time failure when no schema or default schema is configured.
  * Explicit schema provided.
  * Schema inherited from table definition.
  * Schema inherited from metadata.
  * Schema translation mapping.
* Tests are placed in `test_types` and `test_compiler` and pass across PostgreSQL drivers (`asyncpg`, `pg8000`, `psycopg2`, `psycopg2cffi`).

### Logic Explanation

`PGIdentifierPreparer.format_type()` now performs schema resolution internally instead of requiring explicit `schema` arguments. This ensures consistent handling of:

* Explicit schema and schema translation maps.
* Fallback to dialect’s `default_schema_name`.
* Compile-time errors for unresolved collisions with built-in types.

This centralization avoids duplicate logic across compilers, respects DRY & SRP principles, and ensures correctness in all compilation paths.

Fixes: #12761