### PR TITLE
[Fixes #12829] Added support for Annotated Aliases to DeclarativeBase

### DIFF
--- a/lib/sqlalchemy/orm/decl_api.py
+++ b/lib/sqlalchemy/orm/decl_api.py
@@ -29,6 +29,8 @@ from typing import Type
 from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
+from typing import Annotated
+from typing import get_origin, get_args
 import weakref
 
 from . import attributes
@@ -1249,6 +1251,10 @@ class registry:
         else:
             python_type_type = python_type  # type: ignore[assignment]
             search = ((python_type, python_type_type),)
+
+            if get_origin(python_type.__value__) is Annotated:
+                type_alias_annotated_value = get_args(python_type)[0]
+                search = ((type_alias_annotated_value, python_type_type),)
 
         for pt, flattened in search:
             # we search through full __mro__ for types.  however...


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
After the fix, I've succesfully created an alembic migration. Minimal example:
```py
type PrimaryKey[T] = Annotated[T, mapped_column(primary_key=True)]

class User(BaseDbModel):
    id: Mapped[PrimaryKey[UUID]]
```
```py
# alembic migration

def upgrade() -> None:
    op.create_table('user',
    sa.Column('id', sa.Uuid(), nullable=False),
    sa.PrimaryKeyConstraint('id')
    )
```

What is hidden under the variables from this example:
```py
python_type == PrimaryKey[uuid.UUID]
python_type.__args__ == (<class 'uuid.UUID'>,)
python_type.__value__ == typing.Annotated[T, <sqlalchemy.orm.properties.MappedColumn object at 0x1045e2cb0>]
```

### Checklist
This pull request is:


- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
