### PR TITLE
Support for Create Table As

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+__pycache__/
 *.pyd
 *.pyo
 *.egg

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -1737,6 +1737,23 @@ class SQLiteDDLCompiler(compiler.DDLCompiler):
 
         return colspec
 
+    def visit_create_table_as(self, element, **kw):
+        prep = self.preparer
+        select_sql = self.sql_compiler.process(
+            element.selectable, literal_binds=True
+        )
+
+        parts = [
+            "CREATE",
+            "TEMPORARY" if element.temporary else None,
+            "TABLE",
+            "IF NOT EXISTS" if element.if_not_exists else None,
+            prep.format_table(element.table),
+            "AS",
+            select_sql,
+        ]
+        return " ".join(p for p in parts if p)
+
     def visit_primary_key_constraint(self, constraint, **kw):
         # for columns with sqlite_autoincrement=True,
         # the PRIMARY KEY constraint can only be inline

--- a/lib/sqlalchemy/sql/ddl.py
+++ b/lib/sqlalchemy/sql/ddl.py
@@ -555,12 +555,12 @@ class CreateTableAs(ExecutableDDLElement):
     :param selectable: :class:`_sql.Selectable`
         The SELECT (or other selectable) providing the columns and rows.
 
-    :param target: str | :class:`_sql.TableClause`
+    :param element: str | :class:`_sql.TableClause`
         Table name or object. If passed as a string, it must be
         unqualified; use the ``schema`` argument for qualification.
 
     :param schema: str, optional
-        Schema or owner name.  If both ``schema`` and the target object
+        Schema or owner name.  If both ``schema`` and the element object
         specify a schema, they must match.
 
     :param temporary: bool, default False.
@@ -599,7 +599,7 @@ class CreateTableAs(ExecutableDDLElement):
                 and schema != t_schema
             ):
                 raise exc.ArgumentError(
-                    f"Conflicting schema: target={t_schema!r}, "
+                    f"Conflicting schema: element={t_schema!r}, "
                     f"schema={schema!r}"
                 )
             final_schema = (

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -138,6 +138,7 @@ if TYPE_CHECKING:
     from .base import ReadOnlyColumnCollection
     from .cache_key import _CacheKeyTraversalType
     from .compiler import SQLCompiler
+    from .ddl import CreateTableAs
     from .dml import Delete
     from .dml import Update
     from .elements import BinaryExpression
@@ -148,6 +149,7 @@ if TYPE_CHECKING:
     from .functions import Function
     from .schema import ForeignKey
     from .schema import ForeignKeyConstraint
+    from .schema import Table
     from .sqltypes import TableValueType
     from .type_api import TypeEngine
     from .visitors import _CloneCallableType
@@ -6822,6 +6824,24 @@ class Select(
 
         """
         return CompoundSelect._create_intersect_all(self, *other)
+
+    def into(
+        self,
+        target: Union[str, TableClause, Table],
+        *,
+        schema: Optional[str] = None,
+        temporary: bool = False,
+        if_not_exists: bool = False,
+    ) -> "CreateTableAs":
+        from .ddl import CreateTableAs
+
+        return CreateTableAs(
+            self,
+            target,
+            schema=schema,
+            temporary=temporary,
+            if_not_exists=if_not_exists,
+        )
 
 
 class ScalarSelect(

--- a/test/sql/test_create_table_as.py
+++ b/test/sql/test_create_table_as.py
@@ -1,0 +1,281 @@
+import re
+
+from sqlalchemy import bindparam
+from sqlalchemy import literal
+from sqlalchemy.engine import default as default_engine
+from sqlalchemy.exc import ArgumentError
+from sqlalchemy.sql import column
+from sqlalchemy.sql import select
+from sqlalchemy.sql import table
+from sqlalchemy.sql.ddl import CreateTableAs
+from sqlalchemy.testing import fixtures
+from sqlalchemy.testing.assertions import AssertsCompiledSQL
+from sqlalchemy.testing.assertions import expect_raises_message
+
+
+class CreateTableAsDefaultDialectTest(fixtures.TestBase, AssertsCompiledSQL):
+    __dialect__ = "default"
+
+    def _source(self):
+        return table("src", column("id"), column("name"))
+
+    def assert_inner_params(self, stmt, expected, dialect=None):
+        d = default_engine.DefaultDialect() if dialect is None else dialect
+        inner = stmt.selectable.compile(dialect=d)
+        assert (
+            inner.params == expected
+        ), f"Got {inner.params}, expected {expected}"
+
+    def test_basic_element(self):
+        src = self._source()
+        stmt = CreateTableAs(
+            select(src.c.id, src.c.name).select_from(src),
+            "dst",
+        )
+        self.assert_compile(
+            stmt,
+            "CREATE TABLE dst AS SELECT src.id, src.name FROM src",
+        )
+
+    def test_schema_element_qualified(self):
+        src = self._source()
+        stmt = CreateTableAs(
+            select(src.c.id).select_from(src),
+            "dst",
+            schema="analytics",
+        )
+        self.assert_compile(
+            stmt,
+            "CREATE TABLE analytics.dst AS SELECT src.id FROM src",
+        )
+
+    def test_blank_schema_treated_as_none(self):
+        src = self._source()
+        stmt = CreateTableAs(
+            select(src.c.id).select_from(src), "dst", schema=""
+        )
+        self.assert_compile(stmt, "CREATE TABLE dst AS SELECT src.id FROM src")
+
+    def test_binds_preserved(self):
+        src = self._source()
+        stmt = CreateTableAs(
+            select(bindparam("tag", value="x").label("tag")).select_from(src),
+            "dst",
+        )
+        self.assert_compile(
+            stmt,
+            "CREATE TABLE dst AS SELECT :tag AS tag FROM src",
+        )
+        self.assert_inner_params(stmt, {"tag": "x"})
+
+    def test_flags_not_rendered_in_default(self):
+        src = self._source()
+        stmt = CreateTableAs(
+            select(src.c.id).select_from(src),
+            "dst",
+            schema="sch",
+            temporary=True,
+            if_not_exists=True,
+        )
+        # Default baseline omits TEMPORARY / IF NOT EXISTS; dialects add them.
+        self.assert_compile(
+            stmt,
+            "CREATE TABLE sch.dst AS SELECT src.id FROM src",
+        )
+
+    def test_join_with_binds_preserved(self):
+        a = table("a", column("id"), column("name"))
+        b = table("b", column("id"), column("status"))
+
+        s = (
+            select(a.c.id, a.c.name)
+            .select_from(a.join(b, a.c.id == b.c.id))
+            .where(b.c.status == bindparam("p_status"))
+        ).into("dest")
+
+        # Ensure WHERE survives into CTAS and params are preserved
+        self.assert_compile(
+            s,
+            "CREATE TABLE dest AS "
+            "SELECT a.id, a.name FROM a JOIN b ON a.id = b.id "
+            "WHERE b.status = :p_status",
+        )
+        self.assert_inner_params(s, {"p_status": None})
+
+    def test_into_equivalent_to_element(self):
+        src = self._source()
+        s = select(src.c.id).select_from(src).where(src.c.id == bindparam("p"))
+        via_into = s.into("dst")
+        via_element = CreateTableAs(s, "dst")
+
+        self.assert_compile(
+            via_into,
+            "CREATE TABLE dst AS SELECT src.id FROM src WHERE src.id = :p",
+        )
+        self.assert_compile(
+            via_element,
+            "CREATE TABLE dst AS SELECT src.id FROM src WHERE src.id = :p",
+        )
+        # Param parity (inner SELECT of both)
+        self.assert_inner_params(via_into, {"p": None})
+        self.assert_inner_params(via_element, {"p": None})
+
+    def test_into_does_not_mutate_original_select(self):
+        src = self._source()
+        s = select(src.c.id).select_from(src).where(src.c.id == 5)
+
+        # compile original SELECT
+        self.assert_compile(
+            s,
+            "SELECT src.id FROM src WHERE src.id = :id_1",
+        )
+
+        # build CTAS
+        _ = s.into("dst")
+
+        # original is still a SELECT
+        self.assert_compile(
+            s,
+            "SELECT src.id FROM src WHERE src.id = :id_1",
+        )
+
+    def test_into_with_schema_argument(self):
+        src = self._source()
+        s = select(src.c.id).select_from(src).into("t", schema="analytics")
+        self.assert_compile(
+            s,
+            "CREATE TABLE analytics.t AS SELECT src.id FROM src",
+        )
+
+    def test_target_table_without_schema_accepts_schema_kw(self):
+        tgt = table("dst")
+
+        s = select(bindparam("v", value=1).label("anon_1")).select_from(
+            table("x")
+        )
+
+        stmt = CreateTableAs(
+            s,
+            tgt,
+            schema="sch",
+        )
+        self.assert_compile(
+            stmt,
+            "CREATE TABLE sch.dst AS SELECT :v AS anon_1 FROM x",
+        )
+        self.assert_inner_params(stmt, {"v": 1})
+
+    def test_target_as_table_with_schema_and_conflict(self):
+        # Target object with schema set
+        tgt = table("dst", schema="sch")
+
+        # Conflicting schema in ctor should raise ArgumentError
+        with expect_raises_message(
+            ArgumentError,
+            r"Conflicting schema",
+        ):
+            CreateTableAs(
+                select(literal(1)).select_from(table("x")),
+                tgt,
+                schema="other",
+            )
+
+    def test_target_string_must_be_unqualified(self):
+        src = self._source()
+        with expect_raises_message(
+            ArgumentError,
+            re.escape("Target string must be unqualified (use schema=)."),
+        ):
+            CreateTableAs(select(src.c.id).select_from(src), "sch.dst")
+
+    def test_empty_name(self):
+        with expect_raises_message(
+            ArgumentError, "Table name must be non-empty"
+        ):
+            CreateTableAs(select(literal(1)), "")
+
+    def test_generated_table_property(self):
+        src = self._source()
+        stmt = CreateTableAs(
+            select(src.c.id).select_from(src), "dst", schema="sch"
+        )
+        gt = stmt.generated_table
+        assert gt.name == "dst"
+        assert gt.schema == "sch"
+
+    def test_labels_in_select_list_preserved(self):
+        src = self._source()
+        stmt = CreateTableAs(
+            select(
+                src.c.id.label("user_id"), src.c.name.label("user_name")
+            ).select_from(src),
+            "dst",
+        )
+        self.assert_compile(
+            stmt,
+            "CREATE TABLE dst AS "
+            "SELECT src.id AS user_id, src.name AS user_name FROM src",
+        )
+
+    def test_distinct_and_group_by_survive(self):
+        src = self._source()
+        sel = (
+            select(src.c.name).select_from(src).distinct().group_by(src.c.name)
+        )
+        stmt = CreateTableAs(sel, "dst")
+        self.assert_compile(
+            stmt,
+            "CREATE TABLE dst AS "
+            "SELECT DISTINCT src.name FROM src GROUP BY src.name",
+        )
+
+    def test_union_all_with_binds_preserved(self):
+        a = table("a", column("id"))
+        b = table("b", column("id"))
+
+        # Named binds so params are deterministic
+        s1 = (
+            select(a.c.id)
+            .select_from(a)
+            .where(a.c.id == bindparam("p_a", value=1))
+        )
+        s2 = (
+            select(b.c.id)
+            .select_from(b)
+            .where(b.c.id == bindparam("p_b", value=2))
+        )
+
+        u_all = s1.union_all(s2)
+        stmt = CreateTableAs(u_all, "dst")
+
+        self.assert_compile(
+            stmt,
+            "CREATE TABLE dst AS "
+            "SELECT a.id FROM a WHERE a.id = :p_a "
+            "UNION ALL SELECT b.id FROM b WHERE b.id = :p_b",
+        )
+
+        self.assert_inner_params(stmt, {"p_a": 1, "p_b": 2})
+
+    def test_union_labels_follow_first_select(self):
+        # Many engines take column names
+        # of a UNION from the first SELECT’s labels.
+        a = table("a", column("val"))
+        b = table("b", column("val"))
+
+        s1 = select(a.c.val.label("first_name")).select_from(a)
+        s2 = select(b.c.val).select_from(b)  # unlabeled second branch
+
+        u = s1.union(s2)
+        stmt = CreateTableAs(u, "dst")
+
+        # We only assert what’s stable across dialects:
+        #  - first SELECT has the label
+        #  - a UNION occurs
+        self.assert_compile(
+            stmt,
+            "CREATE TABLE dst AS "
+            "SELECT a.val AS first_name FROM a "
+            "UNION "
+            "SELECT b.val FROM b",
+        )


### PR DESCRIPTION
This PR adds support for the Create Table AS construct, along with a new .into() constructor on Select. 

### Description

Introduces `CreateTableAs` element  which can then be used to render `CREATE TABLE ... AS ...` statements.
A CreateTableAs can either be constructed directly or from a Select / Selectable by using the new .into constructor method added to the `Select` class.

Compilation with the default dialect does not render any flags like TEMPORARY or IF NOT EXISTS. Support for these can be added in the dialect specific compilers. Compilation of CreateTableAs for SQLite supports TEMPORARY and IF NOT EXISTS.

```python
#Basic CreateTableAs usage
CreateTableAs(select(users.c.id, users.c.name).select_from(users), "active_users")

# Using .into() on a Select
select(users.c.id).where(users.c.status == "inactive").into("inactive_users")

# With schema and IF NOT EXISTS
select(users.c.id).into("archived", schema="analytics", if_not_exists=True)

# Temporary table
select(users.c.id, users.c.name).into("temp_snapshot", temporary=True)
```

Fixes issue : #4950 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)
-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.
