### PR TITLE
Fix get_columns sqlite reflection rejecting tables with WITHOUT_ROWID and/or STRICT for generated column case

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2377,7 +2377,10 @@ class SQLiteDialect(default.DefaultDialect):
                 )
                 # remove create table
                 match = re.match(
-                    r"create table .*?\((.*)\)$",
+                    (
+                        r"create table .*?\((.*)\)"
+                        r"(?:\s*,?\s*(?:WITHOUT\s+ROWID|STRICT))*$"
+                    ),
                     tablesql.strip(),
                     re.DOTALL | re.IGNORECASE,
                 )

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -3980,6 +3980,25 @@ class ComputedReflectionTest(fixtures.TestBase):
                 x INTEGER GENERATED ALWAYS AS (INSTR(s, ",")) STORED,
                 y INTEGER GENERATED ALWAYS AS (INSTR(x, ",")) STORED
             );""",
+            """CREATE TABLE test9 (
+                id INTEGER PRIMARY KEY,
+                s VARCHAR,
+                x VARCHAR GENERATED ALWAYS AS (s || 'x')
+            ) WITHOUT ROWID;""",
+            """CREATE TABLE test10 (
+                s TEXT,
+                x TEXT GENERATED ALWAYS AS (s || 'x')
+            ) STRICT;""",
+            """CREATE TABLE test11 (
+                id INTEGER PRIMARY KEY,
+                s TEXT,
+                x TEXT GENERATED ALWAYS AS (s || 'x')
+            ) STRICT, WITHOUT ROWID;""",
+            """CREATE TABLE test12 (
+                id INTEGER PRIMARY KEY,
+                s TEXT,
+                x TEXT GENERATED ALWAYS AS (s || 'x')
+            ) WITHOUT ROWID, STRICT;""",
         ]
 
         with testing.db.begin() as conn:
@@ -4013,6 +4032,10 @@ class ComputedReflectionTest(fixtures.TestBase):
             "x": {"text": 'INSTR(s, ",")', "stored": True},
             "y": {"text": 'INSTR(x, ",")', "stored": True},
         },
+        "test9": {"x": {"text": "s || 'x'", "stored": False}},
+        "test10": {"x": {"text": "s || 'x'", "stored": False}},
+        "test11": {"x": {"text": "s || 'x'", "stored": False}},
+        "test12": {"x": {"text": "s || 'x'", "stored": False}},
     }
 
     def test_reflection(self, connection):


### PR DESCRIPTION
### Description
Fixes a problem where SQLite tables that included the STRICT and WITHOUT ROWID could not be reflected if they had generated columns, since in that case a regex match is performed that assumed nothing comes after the final parenthesis. 

Note on the new regex:
```
create table .*?\((.*)\)(?:\s*,?\s*(?:WITHOUT\s+ROWID|STRICT))*$
```
It's not perfect, it does allow e.g. `<rest of table>) , WITHOUT ROWID` or ` <rest of table>) STRICT, STRICT, STRICT`, but I think for the particular usecase of this regex it's the best we can do without having an overly complex regex that hard to understand.

### Checklist
This pull request is:
- A short code fix for #12864. Added tests which just add some additional tables that include STRICT, WITHOUT ROWID in the possible combinations for the generated column tests. Note that you can't use VARCHAR for STRICT tables  and that WITHOUT ROWID tables need a primary key column.

Verified that the tests failed on main and pass with this patch using `tox -e py313-sqlite`.

Fixes: #12864
