### PR TITLE
fix: pass dialect-specific kwargs to MetaData.reflect

### DIFF
--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -5939,7 +5939,7 @@ class MetaData(HasSchemaAttr):
 
             kind = util.preloaded.engine_reflection.ObjectKind.TABLE
             available: util.OrderedSet[str] = util.OrderedSet(
-                insp.get_table_names(schema)
+                insp.get_table_names(schema, **dialect_kwargs)
             )
             if views:
                 kind = util.preloaded.engine_reflection.ObjectKind.ANY

--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -5943,9 +5943,13 @@ class MetaData(HasSchemaAttr):
             )
             if views:
                 kind = util.preloaded.engine_reflection.ObjectKind.ANY
-                available.update(insp.get_view_names(schema))
+                available.update(insp.get_view_names(schema, **dialect_kwargs))
                 try:
-                    available.update(insp.get_materialized_view_names(schema))
+                    available.update(
+                        insp.get_materialized_view_names(
+                            schema, **dialect_kwargs
+                        )
+                    )
                 except NotImplementedError:
                     pass
 

--- a/test/engine/test_reflection.py
+++ b/test/engine/test_reflection.py
@@ -250,15 +250,34 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
         is_true(t1.c.t2id.references(t2.c.id))
 
     def test_reflect_forwards_multiple_kwargs(self, connection, metadata):
-        with mock.patch(
-            "sqlalchemy.engine.reflection.Inspector.get_table_names",
-            return_value=None,
-        ) as mocked:
+        with (
+            mock.patch(
+                "sqlalchemy.engine.reflection.Inspector.get_table_names",
+                return_value=None,
+            ) as mocked_get_table_names,
+            mock.patch(
+                "sqlalchemy.engine.reflection.Inspector.get_view_names",
+                return_value=set(),
+            ) as mocked_get_view_names,
+            mock.patch(
+                (
+                    "sqlalchemy.engine.reflection.Inspector."
+                    "get_materialized_view_names"
+                ),
+                return_value=set(),
+            ) as mocked_get_materialized_view_names,
+        ):
             metadata.reflect(
-                bind=connection, flag1=True, flag2=123, flag3="abc"
+                bind=connection, flag1=True, flag2=123, flag3="abc", views=True
             )
 
-            mocked.assert_called_once_with(
+            mocked_get_table_names.assert_called_once_with(
+                None, flag1=True, flag2=123, flag3="abc"
+            )
+            mocked_get_view_names.assert_called_once_with(
+                None, flag1=True, flag2=123, flag3="abc"
+            )
+            mocked_get_materialized_view_names.assert_called_once_with(
                 None, flag1=True, flag2=123, flag3="abc"
             )
 

--- a/test/engine/test_reflection.py
+++ b/test/engine/test_reflection.py
@@ -249,6 +249,19 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
         t2 = meta2.tables["t2"]
         is_true(t1.c.t2id.references(t2.c.id))
 
+    def test_reflect_forwards_multiple_kwargs(self, connection, metadata):
+        with mock.patch(
+            "sqlalchemy.engine.reflection.Inspector.get_table_names",
+            return_value=None,
+        ) as mocked:
+            metadata.reflect(
+                bind=connection, flag1=True, flag2=123, flag3="abc"
+            )
+
+            mocked.assert_called_once_with(
+                None, flag1=True, flag2=123, flag3="abc"
+            )
+
     def test_nonexistent(self, connection):
         meta = MetaData()
         assert_raises(


### PR DESCRIPTION
Previously, MetaData.reflect did not forward dialect-specific keyword
arguments to the Inspector methods, causing options like
`oracle_resolve_synonyms` to be ignored during reflection.

This change ensures that all extra kwargs passed to MetaData.reflect
are forwarded to Inspector.get_table_names and related reflection
methods.

A new test `test_reflect_forwards_kwargs_to_get_table_names` verifies
that arbitrary dialect kwargs are passed through.

Fixes #12884
