### PR TITLE
docs: Add OceanBase SQLAlchemy plugin to dialects documentation

### DIFF
--- a/doc/build/dialects/index.rst
+++ b/doc/build/dialects/index.rst
@@ -122,6 +122,8 @@ Currently maintained external dialect projects for SQLAlchemy include:
 +------------------------------------------------+---------------------------------------+
 | MonetDB                                        | sqlalchemy-monetdb_                   |
 +------------------------------------------------+---------------------------------------+
+| OceanBase                                      | oceanbase-sqlalchemy_                 |
++------------------------------------------------+---------------------------------------+
 | OpenGauss                                      | openGauss-sqlalchemy_                 |
 +------------------------------------------------+---------------------------------------+
 | Rockset                                        | rockset-sqlalchemy_                   |
@@ -180,6 +182,7 @@ Currently maintained external dialect projects for SQLAlchemy include:
 .. _sqlalchemy-hsqldb: https://pypi.org/project/sqlalchemy-hsqldb/
 .. _databricks: https://docs.databricks.com/en/dev-tools/sqlalchemy.html
 .. _clickhouse-sqlalchemy: https://pypi.org/project/clickhouse-sqlalchemy/
+.. _oceanbase-sqlalchemy: https://github.com/oceanbase/ecology-plugins/tree/main/oceanbase-sqlalchemy-plugin
 .. _sqlalchemy-kinetica: https://github.com/kineticadb/sqlalchemy-kinetica/
 .. _sqlalchemy-tidb: https://github.com/pingcap/sqlalchemy-tidb
 .. _ydb-sqlalchemy: https://github.com/ydb-platform/ydb-sqlalchemy/


### PR DESCRIPTION
## Overview

This PR adds the OceanBase SQLAlchemy plugin to the SQLAlchemy dialects documentation page.

## Changes

- Added OceanBase entry to the External Dialects table
- Added link to the oceanbase-sqlalchemy plugin repository
- Positioned alphabetically between MonetDB and OpenGauss

## Related Links

- OceanBase SQLAlchemy Plugin: https://github.com/oceanbase/ecology-plugins/tree/main/oceanbase-sqlalchemy-plugin
- PyPI Package: https://pypi.org/project/oceanbase-sqlalchemy/
- SQLAlchemy Dialects Documentation: https://docs.sqlalchemy.org/en/20/dialects/index.html

## Testing

- [x] Documentation format is correct
- [x] Links are valid
- [x] Alphabetically ordered

## Description

OceanBase is a distributed relational database. The OceanBase SQLAlchemy plugin has been published to PyPI and is now available for use with SQLAlchemy applications that need to connect to OceanBase databases.

This addition follows the same pattern as other external dialects in the documentation, providing users with easy access to the OceanBase SQLAlchemy plugin information.