### PR TITLE
Fix mssql index column order

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -3479,6 +3479,9 @@ join sys.schemas as sch on
 where
     tab.name = :tabname
     and sch.name = :schname
+order by
+    ind_col.index_id,
+    ind_col.key_ordinal
             """
             )
             .bindparams(

--- a/lib/sqlalchemy/testing/requirements.py
+++ b/lib/sqlalchemy/testing/requirements.py
@@ -797,6 +797,11 @@ class SuiteRequirements(Requirements):
         return exclusions.closed()
 
     @property
+    def indexes_check_column_order(self):
+        """target database supports CREATE INDEX with column order check."""
+        return exclusions.closed()
+
+    @property
     def indexes_with_expressions(self):
         """target database supports CREATE INDEX against SQL expressions."""
         return exclusions.closed()

--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -2699,6 +2699,25 @@ class ComponentReflectionTestExtra(ComparesIndexes, fixtures.TestBase):
             ],
         )
 
+    def test_index_column_order(self, metadata, inspect_for_table):
+         """test for #12894"""
+         with inspect_for_table("sa_multi_index") as (schema, inspector):
+             test_table = Table(
+                 "sa_multi_index",
+                 metadata,
+                 Column("Column1", Integer, primary_key=True),
+                 Column("Column2", Integer),
+                 Column("Column3", Integer),
+             )
+             Index(
+                 "Index_Example",
+                 test_table.c.Column3,
+                 test_table.c.Column1,
+                 test_table.c.Column2,
+             )
+         indexes = inspector.get_indexes("sa_multi_index")
+         eq_(indexes[0]["column_names"], ["Column3", "Column1", "Column2"])
+
     @testing.requires.indexes_with_expressions
     def test_reflect_expression_based_indexes(self, metadata, connection):
         t = Table(

--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -2701,23 +2701,23 @@ class ComponentReflectionTestExtra(ComparesIndexes, fixtures.TestBase):
 
     @testing.requires.indexes_check_column_order
     def test_index_column_order(self, metadata, inspect_for_table):
-         """test for #12894"""
-         with inspect_for_table("sa_multi_index") as (schema, inspector):
-             test_table = Table(
-                 "sa_multi_index",
-                 metadata,
-                 Column("Column1", Integer, primary_key=True),
-                 Column("Column2", Integer),
-                 Column("Column3", Integer),
-             )
-             Index(
-                 "Index_Example",
-                 test_table.c.Column3,
-                 test_table.c.Column1,
-                 test_table.c.Column2,
-             )
-         indexes = inspector.get_indexes("sa_multi_index")
-         eq_(indexes[0]["column_names"], ["Column3", "Column1", "Column2"])
+        """test for #12894"""
+        with inspect_for_table("sa_multi_index") as (schema, inspector):
+            test_table = Table(
+                "sa_multi_index",
+                metadata,
+                Column("Column1", Integer, primary_key=True),
+                Column("Column2", Integer),
+                Column("Column3", Integer),
+            )
+            Index(
+                "Index_Example",
+                test_table.c.Column3,
+                test_table.c.Column1,
+                test_table.c.Column2,
+            )
+        indexes = inspector.get_indexes("sa_multi_index")
+        eq_(indexes[0]["column_names"], ["Column3", "Column1", "Column2"])
 
     @testing.requires.indexes_with_expressions
     def test_reflect_expression_based_indexes(self, metadata, connection):

--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -2699,6 +2699,7 @@ class ComponentReflectionTestExtra(ComparesIndexes, fixtures.TestBase):
             ],
         )
 
+    @testing.requires.indexes_check_column_order
     def test_index_column_order(self, metadata, inspect_for_table):
          """test for #12894"""
          with inspect_for_table("sa_multi_index") as (schema, inspector):

--- a/test/dialect/mssql/test_reflection.py
+++ b/test/dialect/mssql/test_reflection.py
@@ -723,7 +723,7 @@ class ReflectionTest(fixtures.TestBase, ComparesTables, AssertsCompiledSQL):
             Column("id", Integer, primary_key=True),
             Column("x", Integer),
             Column("y", Integer),
-            PrimaryKeyConstraint('id', mssql_clustered=False),
+            PrimaryKeyConstraint("id", mssql_clustered=False),
         )
         Index(
             "idx_x",

--- a/test/dialect/mssql/test_reflection.py
+++ b/test/dialect/mssql/test_reflection.py
@@ -736,25 +736,6 @@ class ReflectionTest(fixtures.TestBase, ComparesTables, AssertsCompiledSQL):
         indexes = testing.db.dialect.get_indexes(connection, "t", None)
         eq_(indexes[0]["column_names"], ["y", "id", "x"])
 
-    def test_index_column_order_nonclustered(self, metadata, connection):
-        """test for #12894"""
-        test_table = Table(
-            "t",
-            metadata,
-            Column("id", Integer, primary_key=True),
-            Column("x", Integer),
-            Column("y", Integer),
-        )
-        Index(
-            "idx_x",
-            test_table.c.y,
-            test_table.c.id,
-            test_table.c.x,
-        )
-        metadata.create_all(connection)
-        indexes = testing.db.dialect.get_indexes(connection, "t", None)
-        eq_(indexes[0]["column_names"], ["y", "id", "x"])
-
     @testing.only_if("mssql>=12")
     def test_index_reflection_colstore_clustered(self, metadata, connection):
         t1 = Table(

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -668,6 +668,10 @@ class DefaultRequirements(SuiteRequirements):
         )
 
     @property
+    def indexes_check_column_order(self):
+        return exclusions.open()
+
+    @property
     def indexes_with_expressions(self):
         return only_on(["postgresql", "sqlite>=3.9.0", "oracle"])
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->


### Description
This pr make mssql clustered index columns return with correct order.  
Fixes: #12894
Closes: #12894

local test:
**before**
```
(venv) e2ne0@MacBook-Pro .../GitHub/sqlalchemy (fix-mssql-index-column-order*) % pytest test/dialect/mssql/test_reflection.py --db docker_mssql -v
================================================================ sqlalchemy installation ================================================================
SQLAlchemy 2.1.0b1 (user site loaded)
Path: /Users/e2ne0/Documents/GitHub/sqlalchemy/lib/sqlalchemy/__init__.py
compiled extension enabled, e.g. /Users/e2ne0/Documents/GitHub/sqlalchemy/lib/sqlalchemy/engine/_util_cy.cpython-311-darwin.so 
================================================================== test session starts ==================================================================
platform darwin -- Python 3.11.13, pytest-8.4.2, pluggy-1.6.0 -- /Users/e2ne0/Documents/GitHub/sqlalchemy/venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/e2ne0/Documents/GitHub/sqlalchemy
configfile: pyproject.toml
collected 65 items                                                                                                                                      

test/dialect/mssql/test_reflection.py::IdentityReflectionTest_mssql+pyodbc_15_0_4445_1::test_reflect_identity PASSED                              [  1%]
test/dialect/mssql/test_reflection.py::IdentityReflectionTest_mssql+pyodbc_15_0_4445_1::test_reflect_views PASSED                                 [  3%]
test/dialect/mssql/test_reflection.py::InfoCoerceUnicodeTest::test_info_unicode_cast PASSED                                                       [  4%]
test/dialect/mssql/test_reflection.py::InfoCoerceUnicodeTest::test_info_unicode_cast_no_2000 PASSED                                               [  6%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_default_schema_name_not_interpreted_as_tokenized PASSED                              [  7%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[Foo.Bar-Foo-Bar-use [Foo]] PASSED                               [  9%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[[Foo.Bar]-None-Foo.Bar-use [Foo.Bar]] PASSED                    [ 10%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[[Foo.Bar].[bat]-Foo.Bar-bat-use [Foo.Bar]] PASSED               [ 12%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[[abc].[def].[efg].[hij]-[abc].[def].[efg]-hij-use [abc].[def].[efg]] PASSED [ 13%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[[foo].]do something; select [foo-foo-do something; select foo-use foo] PASSED [ 15%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[abc.def.efg.hij-abc.def.efg-hij-use [abc.def.efg]] PASSED       [ 16%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[foo-None-foo-use foo] PASSED                                    [ 18%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[foo.bar-foo-bar-use foo] PASSED                                 [ 20%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[something; select [foo].bar-something; select foo-bar-use [something; select foo]] PASSED [ 21%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs_dont_use_for_same_db PASSED                                     [ 23%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs_switch_for_different_db PASSED                                  [ 24%]
test/dialect/mssql/test_reflection.py::ReflectHugeViewTest_mssql+pyodbc_15_0_4445_1::test_inspect_view_definition PASSED                          [ 26%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_assorted_types[FLOAT-FLOAT(53)] PASSED                       [ 27%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_assorted_types[IMAGE-IMAGE] PASSED                           [ 29%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_assorted_types[MONEY-MONEY] PASSED                           [ 30%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_assorted_types[REAL-REAL] PASSED                             [ 32%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_assorted_types[XML-XML] PASSED                               [ 33%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_assorted_types[type_obj3-NUMERIC(10, 2)] PASSED              [ 35%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_assorted_types[type_obj6-REAL] PASSED                        [ 36%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_basic_reflection PASSED                                      [ 38%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_comments PASSED                                              [ 40%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_comments_not_supported PASSED                                [ 41%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_comments_with_dropped_column PASSED                          [ 43%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_cross_schema_fk_pk_name_overlaps PASSED                      [ 44%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_db_qualified_items PASSED                                    [ 46%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_fk_on_unique_index PASSED                                    [ 47%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_global_temp_different_collation PASSED                       [ 49%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_temp_not_present_but_another_session PASSED        [ 50%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_temp_temp_present_both_sessions PASSED             [ 52%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_temporary[global_temp] PASSED                      [ 53%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_temporary[local_temp] PASSED                       [ 55%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_temporary[nonexistent] PASSED                      [ 56%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_with_single_token_schema[get_columns-[test_schema]] PASSED [ 58%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_with_single_token_schema[get_columns-test_schema] PASSED [ 60%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_with_single_token_schema[has_table-[test_schema]] PASSED [ 61%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_with_single_token_schema[has_table-test_schema] PASSED [ 63%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_with_single_token_schema[reflect_table-[test_schema]] PASSED [ 64%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_with_single_token_schema[reflect_table-test_schema] PASSED [ 66%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_identity PASSED                                              [ 67%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_column_order_clustered FAILED                          [ 69%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_column_order_nonclustered PASSED                       [ 70%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_reflection_clustered PASSED                            [ 72%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_reflection_colstore_clustered PASSED                   [ 73%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_reflection_colstore_nonclustered PASSED                [ 75%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_reflection_colstore_nonclustered_multicol PASSED       [ 76%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_reflection_colstore_nonclustered_none PASSED           [ 78%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_reflection_filtered_and_clustered PASSED               [ 80%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_reflection_nonclustered PASSED                         [ 81%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_indexes_cols PASSED                                          [ 83%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_indexes_cols_with_commas PASSED                              [ 84%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_indexes_cols_with_spaces PASSED                              [ 86%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_indexes_with_filtered PASSED                                 [ 87%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_max_ident_in_varchar_not_present PASSED                      [ 89%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_primary_key_reflection_clustered PASSED                      [ 90%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_primary_key_reflection_nonclustered PASSED                   [ 92%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_skip_types PASSED                                            [ 93%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_table_name_that_is_greater_than_16_chars PASSED              [ 95%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_temporary_table[global_temp] PASSED                          [ 96%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_temporary_table[local_temp] PASSED                           [ 98%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_temporary_table[nonexistent] PASSED                          [100%]

======================================================================= FAILURES ========================================================================
_______________________________________ ReflectionTest_mssql+pyodbc_15_0_4445_1.test_index_column_order_clustered _______________________________________
Traceback (most recent call last):
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/_pytest/runner.py", line 344, in from_call
    result: TResult | None = func()
                             ^^^^^^
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/_pytest/runner.py", line 246, in <lambda>
    lambda: runtest_hook(item=item, **kwds), when=when, reraise=reraise
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/_pytest/logging.py", line 850, in pytest_runtest_call
    yield
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/_pytest/capture.py", line 900, in pytest_runtest_call
    return (yield)
            ^^^^^
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/_pytest/skipping.py", line 263, in pytest_runtest_call
    return (yield)
            ^^^^^
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/_pytest/runner.py", line 178, in pytest_runtest_call
    item.runtest()
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/_pytest/python.py", line 1671, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/venv/lib/python3.11/site-packages/_pytest/python.py", line 157, in pytest_pyfunc_call
    result = testfunction(**testargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/test/dialect/mssql/test_reflection.py", line 737, in test_index_column_order_clustered
    eq_(indexes[0]["column_names"], ["y", "id", "x"])
  File "/Users/e2ne0/Documents/GitHub/sqlalchemy/lib/sqlalchemy/testing/assertions.py", line 289, in eq_
    assert a == b, msg or "%r != %r" % (a, b)
AssertionError: ['id', 'x', 'y'] != ['y', 'id', 'x']
assert ['id', 'x', 'y'] == ['y', 'id', 'x']
  
  At index 0 diff: 'id' != 'y'
  
  Full diff:
    [
  -     'y',
        'id',
        'x',
  +     'y',
    ]
================================================================ short test summary info ================================================================
FAILED test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_column_order_clustered - AssertionError: ['id', 'x', 'y'] != ['y', 'id', 'x']
assert ['id', 'x', 'y'] == ['y', 'id', 'x']
  
  At index 0 diff: 'id' != 'y'
  
  Full diff:
    [
  -     'y',
        'id',
        'x',
  +     'y',
    ]
============================================================= 1 failed, 64 passed in 2.39s ==============================================================
```
**after**
```
(venv) e2ne0@MacBook-Pro .../GitHub/sqlalchemy (fix-mssql-index-column-order*) % pytest test/dialect/mssql/test_reflection.py --db docker_mssql -v
================================================================ sqlalchemy installation ================================================================
SQLAlchemy 2.1.0b1 (user site loaded)
Path: /Users/e2ne0/Documents/GitHub/sqlalchemy/lib/sqlalchemy/__init__.py
compiled extension enabled, e.g. /Users/e2ne0/Documents/GitHub/sqlalchemy/lib/sqlalchemy/engine/_util_cy.cpython-311-darwin.so 
================================================================== test session starts ==================================================================
platform darwin -- Python 3.11.13, pytest-8.4.2, pluggy-1.6.0 -- /Users/e2ne0/Documents/GitHub/sqlalchemy/venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/e2ne0/Documents/GitHub/sqlalchemy
configfile: pyproject.toml
collected 65 items                                                                                                                                      

test/dialect/mssql/test_reflection.py::IdentityReflectionTest_mssql+pyodbc_15_0_4445_1::test_reflect_identity PASSED                              [  1%]
test/dialect/mssql/test_reflection.py::IdentityReflectionTest_mssql+pyodbc_15_0_4445_1::test_reflect_views PASSED                                 [  3%]
test/dialect/mssql/test_reflection.py::InfoCoerceUnicodeTest::test_info_unicode_cast PASSED                                                       [  4%]
test/dialect/mssql/test_reflection.py::InfoCoerceUnicodeTest::test_info_unicode_cast_no_2000 PASSED                                               [  6%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_default_schema_name_not_interpreted_as_tokenized PASSED                              [  7%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[Foo.Bar-Foo-Bar-use [Foo]] PASSED                               [  9%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[[Foo.Bar]-None-Foo.Bar-use [Foo.Bar]] PASSED                    [ 10%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[[Foo.Bar].[bat]-Foo.Bar-bat-use [Foo.Bar]] PASSED               [ 12%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[[abc].[def].[efg].[hij]-[abc].[def].[efg]-hij-use [abc].[def].[efg]] PASSED [ 13%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[[foo].]do something; select [foo-foo-do something; select foo-use foo] PASSED [ 15%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[abc.def.efg.hij-abc.def.efg-hij-use [abc.def.efg]] PASSED       [ 16%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[foo-None-foo-use foo] PASSED                                    [ 18%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[foo.bar-foo-bar-use foo] PASSED                                 [ 20%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs[something; select [foo].bar-something; select foo-bar-use [something; select foo]] PASSED [ 21%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs_dont_use_for_same_db PASSED                                     [ 23%]
test/dialect/mssql/test_reflection.py::OwnerPlusDBTest::test_owner_database_pairs_switch_for_different_db PASSED                                  [ 24%]
test/dialect/mssql/test_reflection.py::ReflectHugeViewTest_mssql+pyodbc_15_0_4445_1::test_inspect_view_definition PASSED                          [ 26%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_assorted_types[FLOAT-FLOAT(53)] PASSED                       [ 27%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_assorted_types[IMAGE-IMAGE] PASSED                           [ 29%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_assorted_types[MONEY-MONEY] PASSED                           [ 30%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_assorted_types[REAL-REAL] PASSED                             [ 32%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_assorted_types[XML-XML] PASSED                               [ 33%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_assorted_types[type_obj3-NUMERIC(10, 2)] PASSED              [ 35%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_assorted_types[type_obj6-REAL] PASSED                        [ 36%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_basic_reflection PASSED                                      [ 38%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_comments PASSED                                              [ 40%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_comments_not_supported PASSED                                [ 41%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_comments_with_dropped_column PASSED                          [ 43%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_cross_schema_fk_pk_name_overlaps PASSED                      [ 44%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_db_qualified_items PASSED                                    [ 46%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_fk_on_unique_index PASSED                                    [ 47%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_global_temp_different_collation PASSED                       [ 49%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_temp_not_present_but_another_session PASSED        [ 50%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_temp_temp_present_both_sessions PASSED             [ 52%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_temporary[global_temp] PASSED                      [ 53%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_temporary[local_temp] PASSED                       [ 55%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_temporary[nonexistent] PASSED                      [ 56%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_with_single_token_schema[get_columns-[test_schema]] PASSED [ 58%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_with_single_token_schema[get_columns-test_schema] PASSED [ 60%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_with_single_token_schema[has_table-[test_schema]] PASSED [ 61%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_with_single_token_schema[has_table-test_schema] PASSED [ 63%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_with_single_token_schema[reflect_table-[test_schema]] PASSED [ 64%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_has_table_with_single_token_schema[reflect_table-test_schema] PASSED [ 66%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_identity PASSED                                              [ 67%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_column_order_clustered PASSED                          [ 69%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_column_order_nonclustered PASSED                       [ 70%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_reflection_clustered PASSED                            [ 72%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_reflection_colstore_clustered PASSED                   [ 73%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_reflection_colstore_nonclustered PASSED                [ 75%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_reflection_colstore_nonclustered_multicol PASSED       [ 76%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_reflection_colstore_nonclustered_none PASSED           [ 78%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_reflection_filtered_and_clustered PASSED               [ 80%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_index_reflection_nonclustered PASSED                         [ 81%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_indexes_cols PASSED                                          [ 83%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_indexes_cols_with_commas PASSED                              [ 84%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_indexes_cols_with_spaces PASSED                              [ 86%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_indexes_with_filtered PASSED                                 [ 87%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_max_ident_in_varchar_not_present PASSED                      [ 89%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_primary_key_reflection_clustered PASSED                      [ 90%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_primary_key_reflection_nonclustered PASSED                   [ 92%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_skip_types PASSED                                            [ 93%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_table_name_that_is_greater_than_16_chars PASSED              [ 95%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_temporary_table[global_temp] PASSED                          [ 96%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_temporary_table[local_temp] PASSED                           [ 98%]
test/dialect/mssql/test_reflection.py::ReflectionTest_mssql+pyodbc_15_0_4445_1::test_temporary_table[nonexistent] PASSED                          [100%]

================================================================== 65 passed in 1.85s ===================================================================
```

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

- [x] Create test for mssql to check clustered and nonclustered index
- [x] Add test for the suite. thanks @zzzeek 
- [x] Add `order by` command in sqlalchemy/dialects/mssql/base.py get_indexes() method


This pull request is:

- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.


**Have a nice day!**
