### PR TITLE
_row_cy.py and related cython stuff

### DIFF
--- a/doc/build/changelog/unreleased_20/6511.rst
+++ b/doc/build/changelog/unreleased_20/6511.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: usecase, postgresql
+    :tickets: 6511
+
+    Added support for reflection of collation in types for PostgreSQL.
+    The ``collation`` will be set only if different from the default
+    one for the type.
+    Pull request courtesy Denis Laxalde.

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -983,8 +983,13 @@ to the PostgreSQL dialect.
 Covering Indexes
 ^^^^^^^^^^^^^^^^
 
-The ``postgresql_include`` option renders INCLUDE(colname) for the given
-string names::
+A covering index includes additional columns that are not part of the index key
+but are stored in the index, allowing PostgreSQL to satisfy queries using only
+the index without accessing the table (an "index-only scan").   This is
+indicated on the index using the ``INCLUDE`` clause.  The
+``postgresql_include`` option for :class:`.Index` (as well as
+:class:`.UniqueConstraint`) renders ``INCLUDE(colname)`` for the given string
+names::
 
     Index("my_index", table.c.x, postgresql_include=["y"])
 
@@ -994,9 +999,11 @@ Note that this feature requires PostgreSQL 11 or later.
 
 .. seealso::
 
-  :ref:`postgresql_constraint_options`
+  :ref:`postgresql_constraint_options_include` - the same feature implemented
+  for :class:`.UniqueConstraint`
 
-.. versionadded:: 1.4
+.. versionadded:: 1.4 - support for covering indexes with :class:`.Index`.
+   support for :class:`.UniqueConstraint` was in 2.0.41
 
 .. _postgresql_partial_indexes:
 
@@ -1166,20 +1173,44 @@ PostgreSQL Table Options
 ------------------------
 
 Several options for CREATE TABLE are supported directly by the PostgreSQL
-dialect in conjunction with the :class:`_schema.Table` construct:
+dialect in conjunction with the :class:`_schema.Table` construct, listed in
+the following sections.
 
-* ``INHERITS``::
+.. seealso::
+
+    `PostgreSQL CREATE TABLE options
+    <https://www.postgresql.org/docs/current/static/sql-createtable.html>`_ -
+    in the PostgreSQL documentation.
+
+``INHERITS``
+^^^^^^^^^^^^
+
+Specifies one or more parent tables from which this table inherits columns and
+constraints, enabling table inheritance hierarchies in PostgreSQL.
+
+::
 
     Table("some_table", metadata, ..., postgresql_inherits="some_supertable")
 
     Table("some_table", metadata, ..., postgresql_inherits=("t1", "t2", ...))
 
-* ``ON COMMIT``::
+``ON COMMIT``
+^^^^^^^^^^^^^
+
+Controls the behavior of temporary tables at transaction commit, with options
+to preserve rows, delete rows, or drop the table.
+
+::
 
     Table("some_table", metadata, ..., postgresql_on_commit="PRESERVE ROWS")
 
-*
-  ``PARTITION BY``::
+``PARTITION BY``
+^^^^^^^^^^^^^^^^
+
+Declares the table as a partitioned table using the specified partitioning
+strategy (RANGE, LIST, or HASH) on the given column(s).
+
+::
 
     Table(
         "some_table",
@@ -1188,139 +1219,171 @@ dialect in conjunction with the :class:`_schema.Table` construct:
         postgresql_partition_by="LIST (part_column)",
     )
 
-*
-  ``TABLESPACE``::
+``TABLESPACE``
+^^^^^^^^^^^^^^
+
+Specifies the tablespace where the table will be stored, allowing control over
+the physical location of table data on disk.
+
+::
 
     Table("some_table", metadata, ..., postgresql_tablespace="some_tablespace")
 
-  The above option is also available on the :class:`.Index` construct.
+The above option is also available on the :class:`.Index` construct.
 
-*
-  ``USING``::
+``USING``
+^^^^^^^^^
+
+Specifies the table access method to use for storing table data, such as
+``heap`` (the default) or other custom access methods.
+
+::
 
     Table("some_table", metadata, ..., postgresql_using="heap")
 
-  .. versionadded:: 2.0.26
+.. versionadded:: 2.0.26
 
-* ``WITH OIDS``::
+``WITH OIDS``
+^^^^^^^^^^^^^
+
+Enables the legacy OID (object identifier) system column for the table, which
+assigns a unique identifier to each row.
+
+::
 
     Table("some_table", metadata, ..., postgresql_with_oids=True)
 
-* ``WITHOUT OIDS``::
+``WITHOUT OIDS``
+^^^^^^^^^^^^^^^^
+
+Explicitly disables the OID system column for the table (the default behavior
+in modern PostgreSQL versions).
+
+::
 
     Table("some_table", metadata, ..., postgresql_with_oids=False)
-
-.. seealso::
-
-    `PostgreSQL CREATE TABLE options
-    <https://www.postgresql.org/docs/current/static/sql-createtable.html>`_ -
-    in the PostgreSQL documentation.
 
 .. _postgresql_constraint_options:
 
 PostgreSQL Constraint Options
 -----------------------------
 
-The following option(s) are supported by the PostgreSQL dialect in conjunction
-with selected constraint constructs:
+The following sections indicate options which are supported by the PostgreSQL
+dialect in conjunction with selected constraint constructs.
 
-* ``NOT VALID``:  This option applies towards CHECK and FOREIGN KEY constraints
-  when the constraint is being added to an existing table via ALTER TABLE,
-  and has the effect that existing rows are not scanned during the ALTER
-  operation against the constraint being added.
 
-  When using a SQL migration tool such as `Alembic <https://alembic.sqlalchemy.org>`_
-  that renders ALTER TABLE constructs, the ``postgresql_not_valid`` argument
-  may be specified as an additional keyword argument within the operation
-  that creates the constraint, as in the following Alembic example::
+``NOT VALID``
+^^^^^^^^^^^^^
 
-        def update():
-            op.create_foreign_key(
-                "fk_user_address",
-                "address",
-                "user",
-                ["user_id"],
-                ["id"],
-                postgresql_not_valid=True,
-            )
+Allows a constraint to be added without validating existing rows, improving
+performance when adding constraints to large tables. This option applies
+towards CHECK and FOREIGN KEY constraints when the constraint is being added
+to an existing table via ALTER TABLE, and has the effect that existing rows
+are not scanned during the ALTER operation against the constraint being added.
 
-  The keyword is ultimately accepted directly by the
-  :class:`_schema.CheckConstraint`, :class:`_schema.ForeignKeyConstraint`
-  and :class:`_schema.ForeignKey` constructs; when using a tool like
-  Alembic, dialect-specific keyword arguments are passed through to
-  these constructs from the migration operation directives::
+When using a SQL migration tool such as `Alembic <https://alembic.sqlalchemy.org>`_
+that renders ALTER TABLE constructs, the ``postgresql_not_valid`` argument
+may be specified as an additional keyword argument within the operation
+that creates the constraint, as in the following Alembic example::
 
-       CheckConstraint("some_field IS NOT NULL", postgresql_not_valid=True)
+      def update():
+          op.create_foreign_key(
+              "fk_user_address",
+              "address",
+              "user",
+              ["user_id"],
+              ["id"],
+              postgresql_not_valid=True,
+          )
 
-       ForeignKeyConstraint(
-           ["some_id"], ["some_table.some_id"], postgresql_not_valid=True
-       )
+The keyword is ultimately accepted directly by the
+:class:`_schema.CheckConstraint`, :class:`_schema.ForeignKeyConstraint`
+and :class:`_schema.ForeignKey` constructs; when using a tool like
+Alembic, dialect-specific keyword arguments are passed through to
+these constructs from the migration operation directives::
 
-  .. versionadded:: 1.4.32
+     CheckConstraint("some_field IS NOT NULL", postgresql_not_valid=True)
 
-  .. seealso::
+     ForeignKeyConstraint(
+         ["some_id"], ["some_table.some_id"], postgresql_not_valid=True
+     )
 
-      `PostgreSQL ALTER TABLE options
-      <https://www.postgresql.org/docs/current/static/sql-altertable.html>`_ -
-      in the PostgreSQL documentation.
+.. versionadded:: 1.4.32
 
-* ``INCLUDE``:  This option adds one or more columns as a "payload" to the
-  unique index created automatically by PostgreSQL for the constraint.
-  For example, the following table definition::
+.. seealso::
 
-      Table(
-          "mytable",
-          metadata,
-          Column("id", Integer, nullable=False),
-          Column("value", Integer, nullable=False),
-          UniqueConstraint("id", postgresql_include=["value"]),
+    `PostgreSQL ALTER TABLE options
+    <https://www.postgresql.org/docs/current/static/sql-altertable.html>`_ -
+    in the PostgreSQL documentation.
+
+.. _postgresql_constraint_options_include:
+
+``INCLUDE``
+^^^^^^^^^^^
+
+This keyword is applicable to both a ``UNIQUE`` constraint as well as an
+``INDEX``. The ``postgresql_include`` option available for
+:class:`.UniqueConstraint` as well as :class:`.Index` creates a covering index
+by including additional columns in the underlying index without making them
+part of the key constraint. This option adds one or more columns as a "payload"
+to the index created automatically by PostgreSQL for the constraint. For
+example, the following table definition::
+
+    Table(
+        "mytable",
+        metadata,
+        Column("id", Integer, nullable=False),
+        Column("value", Integer, nullable=False),
+        UniqueConstraint("id", postgresql_include=["value"]),
+    )
+
+would produce the DDL statement
+
+.. sourcecode:: sql
+
+     CREATE TABLE mytable (
+         id INTEGER NOT NULL,
+         value INTEGER NOT NULL,
+         UNIQUE (id) INCLUDE (value)
       )
 
-  would produce the DDL statement
+Note that this feature requires PostgreSQL 11 or later.
 
-  .. sourcecode:: sql
+.. versionadded:: 2.0.41 - added support for ``postgresql_include`` to
+   :class:`.UniqueConstraint`, to complement the existing feature in
+   :class:`.Index`.
 
-       CREATE TABLE mytable (
-           id INTEGER NOT NULL,
-           value INTEGER NOT NULL,
-           UNIQUE (id) INCLUDE (value)
-        )
+.. seealso::
 
-  Note that this feature requires PostgreSQL 11 or later.
+    :ref:`postgresql_covering_indexes` - background on ``postgresql_include``
+    for the :class:`.Index` construct.
 
-  .. versionadded:: 2.0.41
 
-  .. seealso::
+Column list with foreign key ``ON DELETE SET`` actions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-      :ref:`postgresql_covering_indexes`
+Allows selective column updates when a foreign key action is triggered, limiting
+which columns are set to NULL or DEFAULT upon deletion of a referenced row.
+This applies to :class:`.ForeignKey` and :class:`.ForeignKeyConstraint`, the
+:paramref:`.ForeignKey.ondelete` parameter will accept on the PostgreSQL
+backend only a string list of column names inside parenthesis, following the
+``SET NULL`` or ``SET DEFAULT`` phrases, which will limit the set of columns
+that are subject to the action::
 
-  .. seealso::
+      fktable = Table(
+          "fktable",
+          metadata,
+          Column("tid", Integer),
+          Column("id", Integer),
+          Column("fk_id_del_set_null", Integer),
+          ForeignKeyConstraint(
+              columns=["tid", "fk_id_del_set_null"],
+              refcolumns=[pktable.c.tid, pktable.c.id],
+              ondelete="SET NULL (fk_id_del_set_null)",
+          ),
+      )
 
-      `PostgreSQL CREATE TABLE options
-      <https://www.postgresql.org/docs/current/static/sql-createtable.html>`_ -
-      in the PostgreSQL documentation.
-
-* Column list with foreign key ``ON DELETE SET`` actions:  This applies to
-  :class:`.ForeignKey` and :class:`.ForeignKeyConstraint`, the :paramref:`.ForeignKey.ondelete`
-  parameter will accept on the PostgreSQL backend only a string list of column
-  names inside parenthesis, following the ``SET NULL`` or ``SET DEFAULT``
-  phrases, which will limit the set of columns that are subject to the
-  action::
-
-        fktable = Table(
-            "fktable",
-            metadata,
-            Column("tid", Integer),
-            Column("id", Integer),
-            Column("fk_id_del_set_null", Integer),
-            ForeignKeyConstraint(
-                columns=["tid", "fk_id_del_set_null"],
-                refcolumns=[pktable.c.tid, pktable.c.id],
-                ondelete="SET NULL (fk_id_del_set_null)",
-            ),
-        )
-
-  .. versionadded:: 2.0.40
+.. versionadded:: 2.0.40
 
 
 .. _postgresql_table_valued_overview:

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3799,6 +3799,32 @@ class PGDialect(default.DefaultDialect):
             .scalar_subquery()
             .label("default")
         )
+
+        # get the name of the collate when it's different from the default one
+        collate = sql.case(
+            (
+                sql.and_(
+                    pg_catalog.pg_attribute.c.attcollation != 0,
+                    select(pg_catalog.pg_type.c.typcollation)
+                    .where(
+                        pg_catalog.pg_type.c.oid
+                        == pg_catalog.pg_attribute.c.atttypid,
+                    )
+                    .correlate(pg_catalog.pg_attribute)
+                    .scalar_subquery()
+                    != pg_catalog.pg_attribute.c.attcollation,
+                ),
+                select(pg_catalog.pg_collation.c.collname)
+                .where(
+                    pg_catalog.pg_collation.c.oid
+                    == pg_catalog.pg_attribute.c.attcollation
+                )
+                .correlate(pg_catalog.pg_attribute)
+                .scalar_subquery(),
+            ),
+            else_=sql.null(),
+        ).label("collation")
+
         relkinds = self._kind_to_relkinds(kind)
         query = (
             select(
@@ -3813,6 +3839,7 @@ class PGDialect(default.DefaultDialect):
                 pg_catalog.pg_description.c.description.label("comment"),
                 generated,
                 identity,
+                collate,
             )
             .select_from(pg_catalog.pg_class)
             # NOTE: postgresql support table with no user column, meaning
@@ -3891,6 +3918,7 @@ class PGDialect(default.DefaultDialect):
         domains: Dict[str, ReflectedDomain],
         enums: Dict[str, ReflectedEnum],
         type_description: str,
+        collation: Optional[str],
     ) -> sqltypes.TypeEngine[Any]:
         """
         Attempts to reconstruct a column type defined in ischema_names based
@@ -3991,6 +4019,7 @@ class PGDialect(default.DefaultDialect):
                     domains,
                     enums,
                     type_description="DOMAIN '%s'" % domain["name"],
+                    collation=domain["collation"],
                 )
                 args = (domain["name"], data_type)
 
@@ -4023,6 +4052,9 @@ class PGDialect(default.DefaultDialect):
             )
             return sqltypes.NULLTYPE
 
+        if collation is not None:
+            kwargs["collation"] = collation
+
         data_type = schema_type(*args, **kwargs)
         if array_dim >= 1:
             # postgres does not preserve dimensionality or size of array types.
@@ -4041,11 +4073,14 @@ class PGDialect(default.DefaultDialect):
                 continue
             table_cols = columns[(schema, row_dict["table_name"])]
 
+            collation = row_dict["collation"]
+
             coltype = self._reflect_type(
                 row_dict["format_type"],
                 domains,
                 enums,
                 type_description="column '%s'" % row_dict["name"],
+                collation=collation,
             )
 
             default = row_dict["default"]

--- a/lib/sqlalchemy/engine/_row_cy.py
+++ b/lib/sqlalchemy/engine/_row_cy.py
@@ -142,10 +142,17 @@ try:
     from cython.cimports.cpython import PySequence_Length
 except ImportError:
     if not cython.compiled:
-        PyTuple_New = lambda n: [None] * n # actually list
-        def PyTuple_SET_ITEM(tup, idx, item): tup[idx] = item # type: ignore
+
+        def PyTuple_New(n: int) -> list:
+            """Actually produces list if not compiled"""
+            return [None] * n
+
+        def PyTuple_SET_ITEM(tup, idx, item):
+            tup[idx] = item  # type: ignore
+
         PySequence_Length = len
         Py_INCREF = cython._no_op
+
 
 @cython.inline
 @cython.cfunc

--- a/lib/sqlalchemy/engine/_row_cy.py
+++ b/lib/sqlalchemy/engine/_row_cy.py
@@ -135,20 +135,35 @@ class BaseRow:
         return self._data
 
 
+try:
+    from cython.cimports.cpython import PyTuple_New, PyTuple_SET_ITEM, PySequence_Length
+except ImportError:
+    if not cython.compiled:
+        PyTuple_New = lambda n: [] # actually list
+        def PyTuple_SET_ITEM(tup, idx, item): tup[idx] = item
+        PySequence_Length = len
+
 @cython.inline
 @cython.cfunc
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.returns(tuple)
+@cython.locals(res=tuple, proc_size=cython.Py_ssize_t, p=object, value=object)
 def _apply_processors(
     proc: _ProcessorsType, data: Sequence[Any]
 ) -> Tuple[Any, ...]:
-    res: List[Any] = list(data)
-    proc_size: cython.Py_ssize_t = len(proc)
+    proc_size = PySequence_Length(data)
+    res = PyTuple_New(proc_size)
     # TODO: would be nice to do this only on the fist row
     assert len(res) == proc_size
     for i in range(proc_size):
         p = proc[i]
         if p is not None:
-            res[i] = p(res[i])
-    return tuple(res)
+            value = p(data[i])
+        else:
+            value = data[i]
+        PyTuple_SET_ITEM(res, i, value)
+    return tuple(res) if not isinstance(res, tuple) else res
 
 
 # This reconstructor is necessary so that pickles with the Cy extension or

--- a/lib/sqlalchemy/engine/_row_cy.py
+++ b/lib/sqlalchemy/engine/_row_cy.py
@@ -143,12 +143,12 @@ try:
 except ImportError:
     if not cython.compiled:
 
-        def PyTuple_New(n: int) -> list:
+        def PyTuple_New(n):  # type: ignore
             """Actually produces list if not compiled"""
             return [None] * n
 
-        def PyTuple_SET_ITEM(tup, idx, item):
-            tup[idx] = item  # type: ignore
+        def PyTuple_SET_ITEM(tup, idx, item):  # type: ignore
+            tup[idx] = item
 
         PySequence_Length = len
         Py_INCREF = cython._no_op

--- a/lib/sqlalchemy/engine/_row_cy.py
+++ b/lib/sqlalchemy/engine/_row_cy.py
@@ -139,14 +139,12 @@ try:
     from cython.cimports.cpython import PyTuple_New, PyTuple_SET_ITEM, PySequence_Length
 except ImportError:
     if not cython.compiled:
-        PyTuple_New = lambda n: [] # actually list
+        PyTuple_New = lambda _: [] # actually list
         def PyTuple_SET_ITEM(tup, idx, item): tup[idx] = item # type: ignore
         PySequence_Length = len
 
 @cython.inline
 @cython.cfunc
-@cython.boundscheck(False)
-@cython.wraparound(False)
 @cython.returns(tuple)
 @cython.locals(res=tuple, proc_size=cython.Py_ssize_t, p=object, value=object)
 def _apply_processors(

--- a/lib/sqlalchemy/engine/_row_cy.py
+++ b/lib/sqlalchemy/engine/_row_cy.py
@@ -136,7 +136,9 @@ class BaseRow:
 
 
 try:
-    from cython.cimports.cpython import PyTuple_New, PyTuple_SET_ITEM, PySequence_Length
+    from cython.cimports.cpython import PyTuple_New
+    from cython.cimports.cpython import PyTuple_SET_ITEM
+    from cython.cimports.cpython import PySequence_Length
 except ImportError:
     if not cython.compiled:
         PyTuple_New = lambda n: [None] * n # actually list
@@ -150,10 +152,10 @@ except ImportError:
 def _apply_processors(
     proc: _ProcessorsType, data: Sequence[Any]
 ) -> Tuple[Any, ...]:
-    proc_size = PySequence_Length(data)
+    proc_size = PySequence_Length(proc)
     res = PyTuple_New(proc_size)
     # TODO: would be nice to do this only on the fist row
-    assert len(res) == proc_size
+    assert PySequence_Length(data) == proc_size
     for i in range(proc_size):
         p = proc[i]
         if p is not None:

--- a/lib/sqlalchemy/engine/_row_cy.py
+++ b/lib/sqlalchemy/engine/_row_cy.py
@@ -140,7 +140,7 @@ try:
 except ImportError:
     if not cython.compiled:
         PyTuple_New = lambda n: [] # actually list
-        def PyTuple_SET_ITEM(tup, idx, item): tup[idx] = item
+        def PyTuple_SET_ITEM(tup, idx, item): tup[idx] = item # type: ignore
         PySequence_Length = len
 
 @cython.inline

--- a/lib/sqlalchemy/engine/_row_cy.py
+++ b/lib/sqlalchemy/engine/_row_cy.py
@@ -161,7 +161,7 @@ def _apply_processors(
         else:
             value = data[i]
         PyTuple_SET_ITEM(res, i, value)
-    return tuple(res) if not isinstance(res, tuple) else res
+    return tuple(res) if not cython.compiled else res
 
 
 # This reconstructor is necessary so that pickles with the Cy extension or

--- a/lib/sqlalchemy/engine/_row_cy.py
+++ b/lib/sqlalchemy/engine/_row_cy.py
@@ -139,7 +139,7 @@ try:
     from cython.cimports.cpython import PyTuple_New, PyTuple_SET_ITEM, PySequence_Length
 except ImportError:
     if not cython.compiled:
-        PyTuple_New = lambda _: [] # actually list
+        PyTuple_New = lambda n: [None] * n # actually list
         def PyTuple_SET_ITEM(tup, idx, item): tup[idx] = item # type: ignore
         PySequence_Length = len
 

--- a/lib/sqlalchemy/testing/requirements.py
+++ b/lib/sqlalchemy/testing/requirements.py
@@ -690,6 +690,15 @@ class SuiteRequirements(Requirements):
         return exclusions.closed()
 
     @property
+    def column_collation_reflection(self):
+        """Indicates if the database support column collation reflection.
+
+        This requirement also uses ``get_order_by_collation`` to get
+        an available collation.
+        """
+        return exclusions.closed()
+
+    @property
     def view_column_reflection(self):
         """target database must support retrieval of the columns in a view,
         similarly to how a table is inspected.

--- a/lib/sqlalchemy/util/cython.py
+++ b/lib/sqlalchemy/util/cython.py
@@ -11,7 +11,6 @@ from typing import Callable
 from typing import overload
 from typing import Protocol
 from typing import Type
-from typing import TYPE_CHECKING
 from typing import TypeVar
 
 _T = TypeVar("_T")
@@ -63,23 +62,23 @@ def exceptval(value: Any = None, *, check: bool = False) -> _NO_OP[_T]:
 def cast(type_: Type[_T], value: Any, *, typecheck: bool = False) -> _T:
     return value  # type: ignore[no-any-return]
 
-if TYPE_CHECKING:
-    class _DecoratorProtocol(Protocol):
-        @overload
-        def __call__(self, __fn: _T) -> _T: ... 
-        @overload
-        def __call__(self, *args: Any, **kwargs: Any) -> Callable[[_T], _T]: ...
+
+class _DecoratorProtocol(Protocol):
+    @overload
+    def __call__(self, __fn: _T) -> _T: ... 
+    @overload
+    def __call__(self, *args: Any, **kwargs: Any) -> Callable[[_T], _T]: ...
 
 
-    def __getattr__(name: str) -> _DecoratorProtocol:
-        class _DecoratorShim:
-            def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                # Direct decorator
-                if len(args) == 1 and not kwargs and callable(args[0]):
-                    return args[0]
-                # Decorator factory
-                def _decorator(obj: _T) -> _T:
-                    return obj
-                return _decorator
-            
-        return _DecoratorShim() 
+def __getattr__(name: str) -> _DecoratorProtocol:
+    class _DecoratorShim:
+        def __call__(self, *args: Any, **kwargs: Any) -> Any:
+            # Direct decorator
+            if len(args) == 1 and not kwargs and callable(args[0]):
+                return args[0]
+            # Decorator factory
+            def _decorator(obj: _T) -> _T:
+                return obj
+            return _decorator
+
+    return _DecoratorShim() 

--- a/lib/sqlalchemy/util/cython.py
+++ b/lib/sqlalchemy/util/cython.py
@@ -6,11 +6,8 @@
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
 from __future__ import annotations
 
-import inspect
 from typing import Any
 from typing import Callable
-from typing import overload
-from typing import Protocol
 from typing import Type
 from typing import TypeVar
 
@@ -63,8 +60,10 @@ def exceptval(value: Any = None, *, check: bool = False) -> _NO_OP[_T]:
 def cast(type_: Type[_T], value: Any, *, typecheck: bool = False) -> _T:
     return value  # type: ignore[no-any-return]
 
+
 def returns(_: type) -> _NO_OP[_T]:
     return _no_op
 
-def locals(**kwargs: Any) -> _NO_OP[_T]:
+
+def locals(**kwargs: Any) -> _NO_OP[_T]:  # noqa: A001
     return _no_op

--- a/lib/sqlalchemy/util/cython.py
+++ b/lib/sqlalchemy/util/cython.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 from typing import Callable
+from typing import overload
 from typing import Protocol
 from typing import Type
 from typing import TYPE_CHECKING
@@ -64,19 +65,21 @@ def cast(type_: Type[_T], value: Any, *, typecheck: bool = False) -> _T:
 
 if TYPE_CHECKING:
     class _DecoratorProtocol(Protocol):
-        def __call__(self, __fn: _T) -> _T: ... # type: ignore
+        @overload
+        def __call__(self, __fn: _T) -> _T: ... 
+        @overload
         def __call__(self, *args: Any, **kwargs: Any) -> Callable[[_T], _T]: ...
 
 
     def __getattr__(name: str) -> _DecoratorProtocol:
         class _DecoratorShim:
             def __call__(self, *args: Any, **kwargs: Any) -> Any:
-                # Direct decorator: @shim
+                # Direct decorator
                 if len(args) == 1 and not kwargs and callable(args[0]):
                     return args[0]
-                # Decorator factory: @shim(...)
+                # Decorator factory
                 def _decorator(obj: _T) -> _T:
                     return obj
                 return _decorator
             
-        return _DecoratorShim()  # type: ignore[return-value]
+        return _DecoratorShim() 

--- a/lib/sqlalchemy/util/cython.py
+++ b/lib/sqlalchemy/util/cython.py
@@ -6,6 +6,7 @@
 # the MIT License: https://www.opensource.org/licenses/mit-license.php
 from __future__ import annotations
 
+import inspect
 from typing import Any
 from typing import Callable
 from typing import overload
@@ -70,15 +71,16 @@ class _DecoratorProtocol(Protocol):
     def __call__(self, *args: Any, **kwargs: Any) -> Callable[[_T], _T]: ...
 
 
-def __getattr__(name: str) -> _DecoratorProtocol:
-    class _DecoratorShim:
-        def __call__(self, *args: Any, **kwargs: Any) -> Any:
-            # Direct decorator
-            if len(args) == 1 and not kwargs and callable(args[0]):
-                return args[0]
-            # Decorator factory
-            def _decorator(obj: _T) -> _T:
-                return obj
-            return _decorator
+class _DecoratorShim:
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        # Direct decorator
+        if len(args) == 1 and not kwargs and inspect.isfunction(args[0]):
+            return args[0]
+        # Decorator factory
+        def _decorator(obj: _T) -> _T:
+            return obj
+        return _decorator
 
-    return _DecoratorShim() 
+
+def __getattr__(name: str) -> _DecoratorProtocol:
+    return _DecoratorShim()

--- a/lib/sqlalchemy/util/cython.py
+++ b/lib/sqlalchemy/util/cython.py
@@ -63,24 +63,8 @@ def exceptval(value: Any = None, *, check: bool = False) -> _NO_OP[_T]:
 def cast(type_: Type[_T], value: Any, *, typecheck: bool = False) -> _T:
     return value  # type: ignore[no-any-return]
 
+def returns(_: type) -> _NO_OP[_T]:
+    return _no_op
 
-class _DecoratorProtocol(Protocol):
-    @overload
-    def __call__(self, __fn: _T) -> _T: ... 
-    @overload
-    def __call__(self, *args: Any, **kwargs: Any) -> Callable[[_T], _T]: ...
-
-
-class _DecoratorShim:
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        # Direct decorator
-        if len(args) == 1 and not kwargs and inspect.isfunction(args[0]):
-            return args[0]
-        # Decorator factory
-        def _decorator(obj: _T) -> _T:
-            return obj
-        return _decorator
-
-
-def __getattr__(name: str) -> _DecoratorProtocol:
-    return _DecoratorShim()
+def locals(**kwargs: Any) -> _NO_OP[_T]:
+    return _no_op

--- a/test/aaa_profiling/test_resultset.py
+++ b/test/aaa_profiling/test_resultset.py
@@ -265,7 +265,7 @@ class RowTest(fixtures.TestBase):
 
             def __iter__(self):
                 return iter(self.data)
-            
+
             def __len__(self):
                 return len(self.data)
 

--- a/test/aaa_profiling/test_resultset.py
+++ b/test/aaa_profiling/test_resultset.py
@@ -265,5 +265,8 @@ class RowTest(fixtures.TestBase):
 
             def __iter__(self):
                 return iter(self.data)
+            
+            def __len__(self):
+                return len(self.data)
 
         self._test_getitem_value_refcounts_new(CustomSeq)

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -2714,9 +2714,10 @@ class ReflectionTest(
 
 class CustomTypeReflectionTest(fixtures.TestBase):
     class CustomType:
-        def __init__(self, arg1=None, arg2=None):
+        def __init__(self, arg1=None, arg2=None, collation=None):
             self.arg1 = arg1
             self.arg2 = arg2
+            self.collation = collation
 
     ischema_names = None
 
@@ -2742,6 +2743,7 @@ class CustomTypeReflectionTest(fixtures.TestBase):
                 "format_type": sch,
                 "default": None,
                 "not_null": False,
+                "collation": "cc" if sch == "my_custom_type()" else None,
                 "comment": None,
                 "generated": "",
                 "identity_options": None,
@@ -2756,6 +2758,10 @@ class CustomTypeReflectionTest(fixtures.TestBase):
             assert isinstance(column_info["type"], self.CustomType)
             eq_(column_info["type"].arg1, args[0])
             eq_(column_info["type"].arg2, args[1])
+            if sch == "my_custom_type()":
+                eq_(column_info["type"].collation, "cc")
+            else:
+                eq_(column_info["type"].collation, None)
 
     def test_clslevel(self):
         postgresql.PGDialect.ischema_names["my_custom_type"] = self.CustomType
@@ -2784,6 +2790,7 @@ class CustomTypeReflectionTest(fixtures.TestBase):
                 "format_type": None,
                 "default": None,
                 "not_null": False,
+                "collation": None,
                 "comment": None,
                 "generated": "",
                 "identity_options": None,

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -2713,6 +2713,11 @@ class ReflectionTest(
 
 
 class CustomTypeReflectionTest(fixtures.TestBase):
+    class NTL:
+        def __init__(self, enums, domains):
+            self.enums = enums
+            self.domains = domains
+
     class CustomType:
         def __init__(self, arg1=None, arg2=None, collation=None):
             self.arg1 = arg1
@@ -2749,7 +2754,7 @@ class CustomTypeReflectionTest(fixtures.TestBase):
                 "identity_options": None,
             }
             column_info = dialect._get_columns_info(
-                [row_dict], {}, {}, "public"
+                [row_dict], self.NTL({}, {}), "public"
             )
             assert ("public", "tblname") in column_info
             column_info = column_info[("public", "tblname")]
@@ -2796,7 +2801,7 @@ class CustomTypeReflectionTest(fixtures.TestBase):
                 "identity_options": None,
             }
             column_info = dialect._get_columns_info(
-                [row_dict], {}, {}, "public"
+                [row_dict], self.NTL({}, {}), "public"
             )
             assert ("public", "tblname") in column_info
             column_info = column_info[("public", "tblname")]

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -176,6 +176,10 @@ class DefaultRequirements(SuiteRequirements):
         return only_on(["postgresql"])
 
     @property
+    def column_collation_reflection(self):
+        return only_on(["postgresql"])
+
+    @property
     def unbounded_varchar(self):
         """Target database must support VARCHAR with no length"""
 


### PR DESCRIPTION
Hi! I’m going to close this PR and open a new one with a clean commit history and the benchmarks included.

I’m opening this draft mostly to share a rough sketch, get some initial feedback, and document a couple of things I discovered along the way.

### Discovery 1

Unfortunately, Cython can’t emit specialised C APIs based on protocol-style types (like `Sequence`). It requires concrete types instead.
Reference: https://groups.google.com/g/cython-users/c/yzLAkAJEjMA

So if we want to mirror Python 3.11+ behaviour with the specializing interpreter, we need to narrow type hints down to concrete ones (`tuple`, `list`, etc.) and avoid relying on protocol-based annotations.

### Discovery 2

It might be possible to implement a module-level `__getattr__` in `util.cython.py` that satisfies type checkers without affecting runtime behaviour. That could eliminate the need to define no-op fallbacks for every `cython.something` in non-compiled mode.

I experimented with it, but the results were not so good, my relationship with Python’s type “system” is complicated



I’d really appreciate any thoughts on these discoveries or suggestions for alternative approaches — especially if there are patterns already used in the codebase that I might be missing