### PR TITLE
perf tuning of `BaseRow`

### DIFF
--- a/lib/sqlalchemy/engine/row.py
+++ b/lib/sqlalchemy/engine/row.py
@@ -18,9 +18,7 @@ from typing import Callable
 from typing import Dict
 from typing import Generic
 from typing import Iterator
-from typing import List
 from typing import Mapping
-from typing import NoReturn
 from typing import Optional
 from typing import Sequence
 from typing import Tuple
@@ -74,12 +72,6 @@ class Row(BaseRow, _RowBase[Unpack[_Ts]], Generic[Unpack[_Ts]]):
     """
 
     __slots__ = ()
-
-    def __setattr__(self, name: str, value: Any) -> NoReturn:
-        raise AttributeError("can't set attribute")
-
-    def __delattr__(self, name: str) -> NoReturn:
-        raise AttributeError("can't delete attribute")
 
     @deprecated(
         "2.1.0",
@@ -222,9 +214,6 @@ class Row(BaseRow, _RowBase[Unpack[_Ts]], Generic[Unpack[_Ts]]):
         count = _special_name_accessor("count")
         index = _special_name_accessor("index")
 
-    def __contains__(self, key: Any) -> bool:
-        return key in self._data
-
     def _op(self, other: Any, op: Callable[[Any, Any], bool]) -> bool:
         return (
             op(self._to_tuple_instance(), other._to_tuple_instance())
@@ -274,7 +263,7 @@ class Row(BaseRow, _RowBase[Unpack[_Ts]], Generic[Unpack[_Ts]]):
             :attr:`.Row._mapping`
 
         """
-        return tuple([k for k in self._parent.keys if k is not None])
+        return tuple(k for k in self._parent.keys if k is not None)
 
     def _asdict(self) -> Dict[str, Any]:
         """Return a new dict which maps field names to their corresponding
@@ -374,14 +363,8 @@ class RowMapping(BaseRow, typing.Mapping["_KeyType", Any]):
     else:
         __getitem__ = BaseRow._get_by_key_impl_mapping
 
-    def _values_impl(self) -> List[Any]:
-        return list(self._data)
-
     def __iter__(self) -> Iterator[str]:
         return (k for k in self._parent.keys if k is not None)
-
-    def __len__(self) -> int:
-        return len(self._data)
 
     def __contains__(self, key: object) -> bool:
         return self._parent._has_key(key)

--- a/lib/sqlalchemy/engine/row.py
+++ b/lib/sqlalchemy/engine/row.py
@@ -263,7 +263,7 @@ class Row(BaseRow, _RowBase[Unpack[_Ts]], Generic[Unpack[_Ts]]):
             :attr:`.Row._mapping`
 
         """
-        return tuple(k for k in self._parent.keys if k is not None)
+        return tuple([k for k in self._parent.keys if k is not None])
 
     def _asdict(self) -> Dict[str, Any]:
         """Return a new dict which maps field names to their corresponding

--- a/lib/sqlalchemy/orm/mapper.py
+++ b/lib/sqlalchemy/orm/mapper.py
@@ -3408,7 +3408,7 @@ class Mapper(
 
         mapping: RowMapping
         if hasattr(row, "_mapping"):
-            mapping = row._mapping
+            mapping = row._mapping  # type: ignore[assignment]
         else:
             mapping = row  # type: ignore[assignment]
 

--- a/lib/sqlalchemy/util/cython.py
+++ b/lib/sqlalchemy/util/cython.py
@@ -30,6 +30,7 @@ uint = int
 float = float  # noqa: A001
 double = float
 void = Any
+NULL = None
 
 
 # functions
@@ -59,3 +60,14 @@ def exceptval(value: Any = None, *, check: bool = False) -> _NO_OP[_T]:
 
 def cast(type_: Type[_T], value: Any, *, typecheck: bool = False) -> _T:
     return value  # type: ignore[no-any-return]
+
+
+def returns(_: type) -> _NO_OP[_T]:
+    return _no_op
+
+
+def locals(**kwargs: Any) -> _NO_OP[_T]:  # noqa: A001
+    return _no_op
+
+
+boundscheck = wraparound = annotation_typing

--- a/lib/sqlalchemy/util/cython.py
+++ b/lib/sqlalchemy/util/cython.py
@@ -68,6 +68,3 @@ def returns(_: type) -> _NO_OP[_T]:
 
 def locals(**kwargs: Any) -> _NO_OP[_T]:  # noqa: A001
     return _no_op
-
-
-boundscheck = wraparound = annotation_typing

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ if HAS_CYTHON and IS_CPYTHON and not DISABLE_EXTENSION:
     from Cython.Compiler import Options
 
     Options.docstrings = False
-    Options.lookup_module_cpdef = True
     Options.clear_to_none = False
 
     cython_directives: Dict[str, Any] = {

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,15 @@ CYTHON_MODULES = (
 if HAS_CYTHON and IS_CPYTHON and not DISABLE_EXTENSION:
     assert _cy_Extension is not None
     assert _cy_build_ext is not None
+    from Cython.Compiler import Options
+
+    Options.docstrings = False
+    Options.lookup_module_cpdef = True
+    Options.clear_to_none = False
 
     cython_directives: Dict[str, Any] = {
         "language_level": "3",
+        "initializedcheck": False,
     }
 
     if sys.version_info >= (3, 13):

--- a/test/aaa_profiling/test_resultset.py
+++ b/test/aaa_profiling/test_resultset.py
@@ -266,4 +266,7 @@ class RowTest(fixtures.TestBase):
             def __iter__(self):
                 return iter(self.data)
 
+            def __len__(self):
+                return len(self.data)
+
         self._test_getitem_value_refcounts_new(CustomSeq)


### PR DESCRIPTION
tl;dr: it's now bit faster overall 


Before:
```
Running case BaseRow
Running python     .................. Done
Running cython     .................. Done
                    | python  | cython  | cy / py |
base_row_new        | 1.25334 | 0.16760 | 0.13372 |
row_new             | 1.29170 | 0.20576 | 0.15929 |
base_row_new_proc   | 4.43647 | 2.09866 | 0.47304 |
row_new_proc        | 4.45219 | 2.26768 | 0.50934 |
brow_new_proc_none  | 1.79195 | 0.41670 | 0.23254 |
row_new_proc_none   | 1.87007 | 0.46924 | 0.25092 |
row_dumps           | 0.25029 | 0.32780 | 1.30968 |
row_loads           | 1.48172 | 0.51749 | 0.34925 |
row_values_impl     | 0.26831 | 0.29232 | 1.08948 |
row_iter            | 0.65250 | 0.36315 | 0.55655 |
row_len             | 0.21574 | 0.07232 | 0.33525 |
row_hash            | 0.40309 | 0.24871 | 0.61702 |
getitem             | 0.28383 | 0.16171 | 0.56974 |
getitem_slice       | 0.60968 | 0.34910 | 0.57259 |
get_by_key          | 0.46660 | 0.44169 | 0.94661 |
getattr             | 0.63748 | 1.89029 | 2.96525 |
get_by_key_recreate | 1.92867 | 1.79520 | 0.93079 |
getattr_recreate    | 0.85012 | 1.50871 | 1.77468 |
> mean of values    | —       | —       | 0.76532 |
```

After:

```
Running case BaseRow
Running python     .................. Done
Running cython     .................. Done
                    | python  | cython  | cy / py |
base_row_new        | 1.62721 | 0.20094 | 0.12349 |
row_new             | 1.43012 | 0.29490 | 0.20621 |
base_row_new_proc   | 3.92941 | 1.74143 | 0.44317 |
row_new_proc        | 4.11000 | 1.75141 | 0.42613 |
brow_new_proc_none  | 2.00083 | 0.51876 | 0.25927 |
row_new_proc_none   | 2.09076 | 0.55015 | 0.26313 |
row_dumps           | 0.30078 | 0.47270 | 1.57157 |
row_loads           | 1.48260 | 0.67376 | 0.45444 |
row_values_impl     | 0.33249 | 0.52256 | 1.57165 |
row_iter            | 0.77671 | 0.47556 | 0.61227 |
row_len             | 0.24589 | 0.06300 | 0.25621 |
row_hash            | 0.48600 | 0.22412 | 0.46116 |
getitem             | 0.33727 | 0.16818 | 0.49865 |
getitem_slice       | 0.72768 | 0.38407 | 0.52780 |
get_by_key          | 0.89138 | 0.74737 | 0.83844 |
getattr             | 0.78927 | 0.34847 | 0.44151 |
get_by_key_recreate | 2.79428 | 2.43914 | 0.87290 |
getattr_recreate    | 1.10803 | 0.74660 | 0.67380 |
> mean of values    | —       | —       | 0.58343 |
```