### PR TITLE
Fix missing back_populates in Note.item relationship in example code

### DIFF
--- a/doc/build/orm/collection_api.rst
+++ b/doc/build/orm/collection_api.rst
@@ -220,7 +220,7 @@ of the ``Note.text`` field::
         keyword: Mapped[str]
         text: Mapped[str]
 
-        item: Mapped["Item"] = relationship()
+        item: Mapped["Item"] = relationship(back_populates="notes")
 
         @property
         def note_key(self):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
Without back_populates, the subsequent code would not automatically populate Item.notes or generate the key, which contradicts what the documentation intends to demonstrate.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
