### PR TITLE
PostgreSQL / HSTORE: add parameter to use subscripting operator

### DIFF
--- a/doc/build/changelog/unreleased_21/12948.rst
+++ b/doc/build/changelog/unreleased_21/12948.rst
@@ -1,0 +1,9 @@
+.. change::
+    :tags: feature, postgresql
+    :tickets: 12948
+
+    Added new parameter :paramref:`_postgresql.HSTORE.use_subscripting_operator`
+    to :class:`_postgresql.HSTORE` columns, making indexing use subscription
+    (``data['key']``) instead of the ``->`` operator.  This requires
+    PostgreSQL 14+, and allows to update individual values in :func:`.update`
+    statements.  Pull request courtesy Loïc Simon.


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Add a new opt-in parameter `use_subscripting_operator` to the `dialects.postgresql.hstore.HSTORE` type:

| Mode | `__getitem__` operator | Usable in SELECT | Usable in UPDATE |
|-------|----------|-------------------|-------------------|
| `use_subscripting_operator=False` (default) | `data -> %(key)s` (`dialects.postgresql.operators.GETITEM`) | ✅ | ❌ |
| `use_subscripting_operator=True` |`data[%(key)s]` (`sql.operators.getitem`) | ✅ | ✅ |

I'm not totally sure of the parameter name, totally open to bikeshedding!


### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
- [ ] A short code fix
- [X] A new feature implementation
	- Issue: #12948 
	- Tests: new tests inheriting of existing HSTORE test classes:
	    - code generation (offline)
	    - round-trip tests (online), including a new test using subscription to update a specific key