### PR TITLE
Add order by clause to dialect tests to ensure expected result order

### DIFF
--- a/lib/sqlalchemy/testing/suite/test_select.py
+++ b/lib/sqlalchemy/testing/suite/test_select.py
@@ -234,7 +234,9 @@ class FetchLimitOffsetTest(fixtures.TablesTest):
 
     def test_limit_render_multiple_times(self, connection):
         table = self.tables.some_table
-        stmt = select(table.c.id).limit(1).scalar_subquery()
+        stmt = (
+            select(table.c.id).order_by(table.c.id).limit(1).scalar_subquery()
+        )
 
         u = union(select(stmt), select(stmt)).subquery().select()
 

--- a/lib/sqlalchemy/testing/suite/test_types.py
+++ b/lib/sqlalchemy/testing/suite/test_types.py
@@ -433,7 +433,9 @@ class StringTest(_LiteralRoundTripFixture, fixtures.TestBase):
         connection.execute(t.insert(), [{"x": "AB"}, {"x": "BC"}, {"x": "AC"}])
 
         eq_(
-            connection.scalars(select(t.c.x).where(t.c.x.like(expr))).all(),
+            connection.scalars(
+                select(t.c.x).where(t.c.x.like(expr)).order_by(t.c.x)
+            ).all(),
             expected,
         )
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Failing for Starrocks dialect currently without overrides, the amended dialect tests require an order by clause to ensure the expected result.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.

Fixes https://github.com/sqlalchemy/sqlalchemy/issues/12956
