### PR TITLE
Typing: fix type of func.coalesce when used with hybrid properties

### DIFF
--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -1076,7 +1076,7 @@ class _FunctionGenerator:
         @overload
         def coalesce(
             self,
-            col: _ColumnExpressionArgument[_T],
+            col: _ColumnExpressionArgument[Optional[_T]],
             *args: _ColumnExpressionOrLiteralArgument[Any],
             **kwargs: Any,
         ) -> coalesce[_T]: ...
@@ -1084,14 +1084,14 @@ class _FunctionGenerator:
         @overload
         def coalesce(
             self,
-            col: _T,
+            col: Optional[_T],
             *args: _ColumnExpressionOrLiteralArgument[Any],
             **kwargs: Any,
         ) -> coalesce[_T]: ...
 
         def coalesce(
             self,
-            col: _ColumnExpressionOrLiteralArgument[_T],
+            col: _ColumnExpressionOrLiteralArgument[Optional[_T]],
             *args: _ColumnExpressionOrLiteralArgument[Any],
             **kwargs: Any,
         ) -> coalesce[_T]: ...

--- a/test/typing/plain_files/sql/functions_again.py
+++ b/test/typing/plain_files/sql/functions_again.py
@@ -10,6 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.sql.expression import FunctionFilter
 from sqlalchemy.sql.expression import Over
 from sqlalchemy.sql.expression import WithinGroup
@@ -29,6 +30,11 @@ class Foo(Base):
     a: Mapped[int]
     b: Mapped[int]
     c: Mapped[str]
+    _d: Mapped[int | None] = mapped_column("d")
+    
+    @hybrid_property
+    def d(self) -> int | None:
+        return self._d
 
 
 assert_type(
@@ -66,6 +72,7 @@ assert_type(func.coalesce(Foo.c, "a", "b"), coalesce[str])
 assert_type(func.coalesce("a", "b"), coalesce[str])
 assert_type(func.coalesce(column("x", Integer), 3), coalesce[int])
 
+assert_type(func.coalesce(Foo._d, 100), coalesce[int])
 
 stmt2 = select(Foo.a, func.coalesce(Foo.c, "a", "b")).group_by(Foo.a)
 assert_type(stmt2, Select[int, str])

--- a/test/typing/plain_files/sql/functions_again.py
+++ b/test/typing/plain_files/sql/functions_again.py
@@ -7,10 +7,10 @@ from sqlalchemy import Function
 from sqlalchemy import Integer
 from sqlalchemy import Select
 from sqlalchemy import select
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
-from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.sql.expression import FunctionFilter
 from sqlalchemy.sql.expression import Over
 from sqlalchemy.sql.expression import WithinGroup
@@ -31,7 +31,7 @@ class Foo(Base):
     b: Mapped[int]
     c: Mapped[str]
     _d: Mapped[int | None] = mapped_column("d")
-    
+
     @hybrid_property
     def d(self) -> int | None:
         return self._d

--- a/tools/generate_sql_functions.py
+++ b/tools/generate_sql_functions.py
@@ -61,6 +61,7 @@ def process_functions(filename: str, cmd: code_writer_cmd) -> str:
                 builtins = set(dir(__builtins__))
                 for key, fn_class in _fns_in_deterministic_order():
                     is_reserved_word = key in builtins
+                    is_first_arg_optional = fn_class.__name__ == "coalesce"
 
                     if issubclass(fn_class, ReturnTypeFromArgs):
                         buf.write(
@@ -84,7 +85,7 @@ def {key}( {'  # noqa: A001' if is_reserved_word else ''}
 @overload
 def {key}( {'  # noqa: A001' if is_reserved_word else ''}
     self,
-    col: _ColumnExpressionArgument[_T],
+    col: _ColumnExpressionArgument[{'Optional[_T]' if is_first_arg_optional else '_T'}],
     *args: _ColumnExpressionOrLiteralArgument[Any],
     **kwargs: Any,
 ) -> {fn_class.__name__}[_T]:
@@ -93,7 +94,7 @@ def {key}( {'  # noqa: A001' if is_reserved_word else ''}
 @overload
 def {key}( {'  # noqa: A001' if is_reserved_word else ''}
     self,
-    col: _T,
+    col: {'Optional[_T]' if is_first_arg_optional else '_T'},
     *args: _ColumnExpressionOrLiteralArgument[Any],
     **kwargs: Any,
 ) -> {fn_class.__name__}[_T]:
@@ -101,7 +102,7 @@ def {key}( {'  # noqa: A001' if is_reserved_word else ''}
 
 def {key}( {'  # noqa: A001' if is_reserved_word else ''}
     self,
-    col: _ColumnExpressionOrLiteralArgument[_T],
+    col: _ColumnExpressionOrLiteralArgument[{'Optional[_T]' if is_first_arg_optional else '_T'}],
     *args: _ColumnExpressionOrLiteralArgument[Any],
     **kwargs: Any,
 ) -> {fn_class.__name__}[_T]:


### PR DESCRIPTION
### Description
When `func.coalesce` is used with a hybrid property, the return type inferred is wrong. This can lead to suprising mypy errors, such as this:

```python
class Foo(Base):
    __tablename__ = "foo"

    _bar: Mapped[int | None] = mapped_column("bar")
    
    @hybrid_property
    def bar(self) -> int | None:
        return self._bar
    
    @bar.inplace.expression
    @classmethod
    def _bar_expression(cls) -> ColumnElement[int]:
        return func.coalesce(cls._bar, 42)
```

Mypy output:
```
error: Argument 1 to "coalesce" of "_FunctionGenerator" has incompatible type "InstrumentedAttribute[int | None]"; expected "ColumnElement[int] | _HasClauseElement[int] | SQLCoreOperations[int] | ExpressionElementRole[int] | TypedColumnsClauseRole[int] | Callable[[], ColumnElement[int]] | LambdaElement"  [arg-type]
```

This PR aims to fix this issue.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
