### PR TITLE
Add Mimer SQL to list of external dialects

### DIFF
--- a/doc/build/dialects/index.rst
+++ b/doc/build/dialects/index.rst
@@ -120,6 +120,8 @@ Currently maintained external dialect projects for SQLAlchemy include:
 +------------------------------------------------+---------------------------------------+
 | Microsoft SQL Server (via turbodbc)            | sqlalchemy-turbodbc_                  |
 +------------------------------------------------+---------------------------------------+
+| Mimer SQL                                      | sqlalchemy-mimer_                     |
++------------------------------------------------+---------------------------------------+
 | MonetDB                                        | sqlalchemy-monetdb_                   |
 +------------------------------------------------+---------------------------------------+
 | OceanBase                                      | oceanbase-sqlalchemy_                 |
@@ -161,6 +163,7 @@ Currently maintained external dialect projects for SQLAlchemy include:
 .. _sqlalchemy-solr: https://github.com/aadel/sqlalchemy-solr
 .. _sqlalchemy_exasol: https://github.com/blue-yonder/sqlalchemy_exasol
 .. _sqlalchemy-sqlany: https://github.com/sqlanywhere/sqlalchemy-sqlany
+.. _sqlalchemy-mimer: https://pypi.org/project/sqlalchemy-mimer
 .. _sqlalchemy-monetdb: https://github.com/MonetDB/sqlalchemy-monetdb
 .. _snowflake-sqlalchemy: https://github.com/snowflakedb/snowflake-sqlalchemy
 .. _sqlalchemy-pytds: https://pypi.org/project/sqlalchemy-pytds/


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

This PR adds **Mimer SQL** to the list of external SQLAlchemy dialects in
`doc/build/dialects/index.rst`.

**Project:** [sqlalchemy-mimer](https://github.com/mimersql/sqlalchemy-mimer)  
**PyPI:** [sqlalchemy-mimer](https://pypi.org/project/sqlalchemy-mimer/)  
**Maintainer:** Mimer Information Technology AB

Mimer SQL is a fully standards-based relational database system with its own
Python DB-API driver ([MimerPy](https://pypi.org/project/mimerpy/)) and a complete
SQLAlchemy dialect supporting both Core and ORM.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
