### PR TITLE
Fix type hint for with_for_update() to support tuples of table classes

### DIFF
--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -179,8 +179,13 @@ _ForUpdateOfArgument = Union[
         "_ColumnExpressionArgument[Any]",
         "_FromClauseArgument",
     ],
-    # or sequence of single column elements
-    Sequence["_ColumnExpressionArgument[Any]"],
+    # or sequence of column elements or from clauses
+    Sequence[
+        Union[
+            "_ColumnExpressionArgument[Any]",
+            "_FromClauseArgument",
+        ]
+    ],
 ]
 
 

--- a/test/typing/plain_files/sql/common_sql_element.py
+++ b/test/typing/plain_files/sql/common_sql_element.py
@@ -163,6 +163,24 @@ user = session.query(user_table).with_for_update(
     of=[user_table.c.id, user_table.c.email]
 )
 
+# test 12730 - tuples of DeclarativeBase classes
+
+
+class A(Base):
+    __tablename__ = "a"
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+
+class B(Base):
+    __tablename__ = "b"
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+
+s12730_1 = select(A, B).with_for_update(of=(A, B))
+s12730_2 = select(A, B).with_for_update(of=(A,))
+s12730_3 = select(A, B).with_for_update(of=[A, B])
+s12730_4 = session.query(A, B).with_for_update(of=(A, B))
+
 # literal
 assert_type(literal("5"), BindParameter[str])
 assert_type(literal("5", None), BindParameter[str])


### PR DESCRIPTION
Fixes #12730

### Description

Updated _ForUpdateOfArgument type alias to accept sequences of both column expressions and FROM clause arguments (tables, ORM entities). Previously only sequences of column expressions were supported, causing type checker errors when passing tuples of DeclarativeBase classes to with_for_update(of=...).

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
