### PR TITLE
Fix parameter mutation in orm_pre_session_exec()

### DIFF
--- a/lib/sqlalchemy/orm/bulk_persistence.py
+++ b/lib/sqlalchemy/orm/bulk_persistence.py
@@ -1257,6 +1257,7 @@ class _BulkORMInsert(_ORMDMLState, InsertDMLState):
             util.immutabledict(execution_options).union(
                 {"_sa_orm_insert_options": insert_options}
             ),
+            params,
         )
 
     @classmethod

--- a/lib/sqlalchemy/orm/bulk_persistence.py
+++ b/lib/sqlalchemy/orm/bulk_persistence.py
@@ -809,6 +809,7 @@ class _BulkUDCompileState(_ORMDMLState):
             util.immutabledict(execution_options).union(
                 {"_sa_orm_update_options": update_options}
             ),
+            params,
         )
 
     @classmethod

--- a/lib/sqlalchemy/orm/context.py
+++ b/lib/sqlalchemy/orm/context.py
@@ -368,7 +368,7 @@ class _AutoflushOnlyORMCompileState(_AbstractORMCompileState):
         if not is_pre_event and load_options._autoflush:
             session._autoflush()
 
-        return statement, execution_options
+        return statement, execution_options, params
 
     @classmethod
     def orm_setup_cursor_result(
@@ -590,7 +590,7 @@ class _ORMCompileState(_AbstractORMCompileState):
         if not is_pre_event and load_options._autoflush:
             session._autoflush()
 
-        return statement, execution_options
+        return statement, execution_options, params
 
     @classmethod
     def orm_setup_cursor_result(

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -2212,6 +2212,7 @@ class Session(_SessionClassMethods, EventTarget):
                 (
                     statement,
                     combined_execution_options,
+                    params,
                 ) = compile_state_cls.orm_pre_session_exec(
                     self,
                     statement,
@@ -2253,6 +2254,7 @@ class Session(_SessionClassMethods, EventTarget):
             (
                 statement,
                 combined_execution_options,
+                params,
             ) = compile_state_cls.orm_pre_session_exec(
                 self,
                 statement,

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -2244,6 +2244,7 @@ class Session(_SessionClassMethods, EventTarget):
 
             statement = orm_exec_state.statement
             combined_execution_options = orm_exec_state.local_execution_options
+            params = orm_exec_state.parameters
 
         if compile_state_cls is not None:
             # now run orm_pre_session_exec() "for real".   if there were

--- a/test/orm/test_events.py
+++ b/test/orm/test_events.py
@@ -934,7 +934,8 @@ class ORMExecuteTest(RemoveORMEventsGlobally, _fixtures.FixtureTest):
 
         with self.sql_execution_asserter() as asserter:
             sess.execute(
-                update(User).where(User.id == 7).values(name="original_name")
+                update(User).where(User.id == 7),
+                {"name": "original_name"},
             )
         asserter.assert_(
             CompiledSQL(


### PR DESCRIPTION
Fixes #12921

### Description

Modified orm_pre_session_exec() to return params in addition to statement and execution_options, allowing event hooks to mutate query parameters during ORM execution.

Changes:
  - Updated _AutoflushOnlyORMCompileState.orm_pre_session_exec() to return params
  - Updated _ORMCompileState.orm_pre_session_exec() to return params
  - Updated _BulkUDCompileState.orm_pre_session_exec() to return params
  - Updated Session._execute_internal() to capture returned params from both orm_pre_session_exec() call sites

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
