### PR TITLE
Add support for Python 3.14 template strings (t-strings) to text()

### DIFF
--- a/doc/build/changelog/unreleased_21/12548.rst
+++ b/doc/build/changelog/unreleased_21/12548.rst
@@ -1,0 +1,26 @@
+.. change::
+    :tags: feature, sql
+    :tickets: 12548
+
+    Added support for Python 3.14+ template strings (t-strings) in the
+    :func:`_sql.text` construct. When a t-string is passed to
+    :func:`_sql.text`, interpolated literal values are automatically converted
+    to bound parameters, while SQLAlchemy column expressions and table
+    references are compiled into their SQL representation::
+
+        # Python 3.14+
+        user_id = 42
+        stmt = text(t"SELECT * FROM users WHERE id = {user_id}")
+
+    Column and table objects can also be interpolated::
+
+        users = table("users", column("id"), column("name"))
+        user_id = 42
+        stmt = text(t"SELECT {users.c.name} FROM {users} WHERE {users.c.id} = {user_id}")
+
+    This feature requires Python 3.14 or later. On earlier Python versions,
+    the :func:`_sql.text` construct continues to accept only string arguments.
+
+    .. seealso::
+
+        :pep:`750` - Template Strings


### PR DESCRIPTION
Fixes #12548

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Implements PEP 750 template string support in the text() construct, allowing t-strings to be used for building SQL statements with automatic parameter binding.

Features:
- Literal values in t-string interpolations are converted to bound parameters
- SQLAlchemy ColumnElement and FromClause objects are compiled to SQL
- Backward compatible - only activates on Python 3.14+
- Added comprehensive test coverage with mock-based tests

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
