### PR TITLE
Add native BOOLEAN type support for Oracle 23c and later versions

### DIFF
--- a/doc/build/changelog/unreleased_21/11633.rst
+++ b/doc/build/changelog/unreleased_21/11633.rst
@@ -1,0 +1,9 @@
+.. change::
+    :tags: feature, oracle
+    :tickets: 11633
+
+    Added support for native BOOLEAN type in Oracle Database 23c and above.
+    The Oracle dialect now automatically uses the native BOOLEAN type when
+    connected to Oracle Database 23c or later, as determined by the server
+    version. For Oracle versions prior to 23c, boolean values continue to be
+    emulated using SMALLINT as before.

--- a/doc/build/dialects/oracle.rst
+++ b/doc/build/dialects/oracle.rst
@@ -15,6 +15,7 @@ originate from :mod:`sqlalchemy.types` or from the local dialect::
     from sqlalchemy.dialects.oracle import (
         BFILE,
         BLOB,
+        BOOLEAN,
         CHAR,
         CLOB,
         DATE,
@@ -47,6 +48,9 @@ construction arguments, are as follows:
 
 .. autoclass:: BINARY_FLOAT
   :members: __init__
+
+.. autoclass:: BOOLEAN
+   :members: __init__
 
 .. autoclass:: DATE
    :members: __init__

--- a/lib/sqlalchemy/dialects/oracle/__init__.py
+++ b/lib/sqlalchemy/dialects/oracle/__init__.py
@@ -14,6 +14,7 @@ from .base import BFILE
 from .base import BINARY_DOUBLE
 from .base import BINARY_FLOAT
 from .base import BLOB
+from .base import BOOLEAN
 from .base import CHAR
 from .base import CLOB
 from .base import DATE
@@ -71,6 +72,7 @@ __all__ = (
     "NVARCHAR2",
     "ROWID",
     "REAL",
+    "BOOLEAN",
     "VECTOR",
     "VectorDistanceType",
     "VectorIndexType",

--- a/lib/sqlalchemy/dialects/oracle/types.py
+++ b/lib/sqlalchemy/dialects/oracle/types.py
@@ -23,6 +23,9 @@ if TYPE_CHECKING:
     from ...sql.type_api import _LiteralProcessorType
 
 
+BOOLEAN = sqltypes.BOOLEAN
+
+
 class RAW(sqltypes._Binary):
     __visit_name__ = "RAW"
 

--- a/test/dialect/oracle/test_dialect.py
+++ b/test/dialect/oracle/test_dialect.py
@@ -740,6 +740,17 @@ class CompatFlagsTest(fixtures.TestBase, AssertsCompiledSQL):
         self.assert_compile(Unicode(50), "NVARCHAR2(50)", dialect=dialect)
         self.assert_compile(UnicodeText(), "NCLOB", dialect=dialect)
 
+    def test_native_boolean_flag(self):
+        dialect = self._dialect((19, 0, 0))
+        assert dialect.supports_native_boolean
+        dialect.initialize(Mock())
+        assert not dialect.supports_native_boolean
+
+        dialect = self._dialect((23, 0, 0))
+        assert dialect.supports_native_boolean
+        dialect.initialize(Mock())
+        assert dialect.supports_native_boolean
+
     def test_ident_length_in_13_is_30(self):
         from sqlalchemy import __version__
 

--- a/test/dialect/oracle/test_reflection.py
+++ b/test/dialect/oracle/test_reflection.py
@@ -722,6 +722,21 @@ class TableReflectionTest(fixtures.TestBase):
         tb1 = Table("test_vector", m2, autoload_with=connection)
         assert tb1.columns.keys() == ["id", "name", "embedding"]
 
+    @testing.only_on("oracle>=23")
+    def test_reflection_w_boolean_column(self, connection, metadata):
+        tb1 = Table(
+            "test_boolean",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("flag", oracle.BOOLEAN),
+        )
+        metadata.create_all(connection)
+
+        m2 = MetaData()
+
+        tb1 = Table("test_boolean", m2, autoload_with=connection)
+        assert isinstance(tb1.c.flag.type, oracle.BOOLEAN)
+
 
 class ViewReflectionTest(fixtures.TestBase):
     __only_on__ = "oracle"


### PR DESCRIPTION
Oracle Database 23c introduced native BOOLEAN type support. This change adds automatic detection and usage of native BOOLEAN when connected to Oracle 23c or later. For earlier versions, boolean values continue to be emulated using SMALLINT.

Fixes: #11633

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
