### PR TITLE
Factor out constraints into separate methods

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2540,13 +2540,19 @@ class PGDDLCompiler(compiler.DDLCompiler):
         return text
 
     def visit_primary_key_constraint(self, constraint, **kw):
-        text = super().visit_primary_key_constraint(constraint)
+        text = self.define_constraint_preamble(constraint, **kw)
+        text += self.define_primary_key_body(constraint, **kw)
         text += self._define_include(constraint)
+        text += self.define_constraint_deferrability(constraint)
         return text
 
     def visit_unique_constraint(self, constraint, **kw):
-        text = super().visit_unique_constraint(constraint)
+        if len(constraint) == 0:
+            return ""
+        text = self.define_constraint_preamble(constraint, **kw)
+        text += self.define_unique_body(constraint, **kw)
         text += self._define_include(constraint)
+        text += self.define_constraint_deferrability(constraint)
         return text
 
     @util.memoized_property

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -7333,7 +7333,7 @@ class DDLCompiler(Compiled):
         text += self.define_primary_key_body(constraint, **kw)
         text += self.define_constraint_deferrability(constraint)
         return text
-    
+
     def visit_foreign_key_constraint(self, constraint, **kw):
         text = self.define_constraint_preamble(constraint, **kw)
         text += self.define_foreign_key_body(constraint, **kw)
@@ -7356,7 +7356,7 @@ class DDLCompiler(Compiled):
         text += self.define_unique_body(constraint, **kw)
         text += self.define_constraint_deferrability(constraint)
         return text
-    
+
     def define_constraint_preamble(self, constraint: Constraint, **kw: Any):
         text = ""
         if constraint.name is not None:
@@ -7364,8 +7364,10 @@ class DDLCompiler(Compiled):
             if formatted_name is not None:
                 text += "CONSTRAINT %s " % formatted_name
         return text
-    
-    def define_primary_key_body(self, constraint: PrimaryKeyConstraint, **kw: Any):
+
+    def define_primary_key_body(
+        self, constraint: PrimaryKeyConstraint, **kw: Any
+    ):
         text = ""
         text += "PRIMARY KEY "
         text += "(%s)" % ", ".join(
@@ -7378,7 +7380,9 @@ class DDLCompiler(Compiled):
         )
         return text
 
-    def define_foreign_key_body(self, constraint: ForeignKeyConstraint, **kw: Any):
+    def define_foreign_key_body(
+        self, constraint: ForeignKeyConstraint, **kw: Any
+    ):
         preparer = self.preparer
         remote_table = list(constraint.elements)[0].column.table
         text = "FOREIGN KEY(%s) REFERENCES %s (%s)" % (

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -117,6 +117,7 @@ if typing.TYPE_CHECKING:
     from .elements import Null
     from .elements import True_
     from .functions import Function
+    from .schema import CheckConstraint
     from .schema import Column
     from .schema import Constraint
     from .schema import ForeignKeyConstraint
@@ -7312,26 +7313,14 @@ class DDLCompiler(Compiled):
             return self.visit_check_constraint(constraint)
 
     def visit_check_constraint(self, constraint, **kw):
-        text = ""
-        if constraint.name is not None:
-            formatted_name = self.preparer.format_constraint(constraint)
-            if formatted_name is not None:
-                text += "CONSTRAINT %s " % formatted_name
-        text += "CHECK (%s)" % self.sql_compiler.process(
-            constraint.sqltext, include_table=False, literal_binds=True
-        )
+        text = self.define_constraint_preamble(constraint, **kw)
+        text += self.define_check_body(constraint, **kw)
         text += self.define_constraint_deferrability(constraint)
         return text
 
     def visit_column_check_constraint(self, constraint, **kw):
-        text = ""
-        if constraint.name is not None:
-            formatted_name = self.preparer.format_constraint(constraint)
-            if formatted_name is not None:
-                text += "CONSTRAINT %s " % formatted_name
-        text += "CHECK (%s)" % self.sql_compiler.process(
-            constraint.sqltext, include_table=False, literal_binds=True
-        )
+        text = self.define_constraint_preamble(constraint, **kw)
+        text += self.define_check_body(constraint, **kw)
         text += self.define_constraint_deferrability(constraint)
         return text
 
@@ -7340,42 +7329,14 @@ class DDLCompiler(Compiled):
     ) -> str:
         if len(constraint) == 0:
             return ""
-        text = ""
-        if constraint.name is not None:
-            formatted_name = self.preparer.format_constraint(constraint)
-            if formatted_name is not None:
-                text += "CONSTRAINT %s " % formatted_name
-        text += "PRIMARY KEY "
-        text += "(%s)" % ", ".join(
-            self.preparer.quote(c.name)
-            for c in (
-                constraint.columns_autoinc_first
-                if constraint._implicit_generated
-                else constraint.columns
-            )
-        )
+        text = self.define_constraint_preamble(constraint, **kw)
+        text += self.define_primary_key_body(constraint, **kw)
         text += self.define_constraint_deferrability(constraint)
         return text
-
+    
     def visit_foreign_key_constraint(self, constraint, **kw):
-        preparer = self.preparer
-        text = ""
-        if constraint.name is not None:
-            formatted_name = self.preparer.format_constraint(constraint)
-            if formatted_name is not None:
-                text += "CONSTRAINT %s " % formatted_name
-        remote_table = list(constraint.elements)[0].column.table
-        text += "FOREIGN KEY(%s) REFERENCES %s (%s)" % (
-            ", ".join(
-                preparer.quote(f.parent.name) for f in constraint.elements
-            ),
-            self.define_constraint_remote_table(
-                constraint, remote_table, preparer
-            ),
-            ", ".join(
-                preparer.quote(f.column.name) for f in constraint.elements
-            ),
-        )
+        text = self.define_constraint_preamble(constraint, **kw)
+        text += self.define_foreign_key_body(constraint, **kw)
         text += self.define_constraint_match(constraint)
         text += self.define_constraint_cascades(constraint)
         text += self.define_constraint_deferrability(constraint)
@@ -7391,16 +7352,59 @@ class DDLCompiler(Compiled):
     ) -> str:
         if len(constraint) == 0:
             return ""
+        text = self.define_constraint_preamble(constraint, **kw)
+        text += self.define_unique_body(constraint, **kw)
+        text += self.define_constraint_deferrability(constraint)
+        return text
+    
+    def define_constraint_preamble(self, constraint: Constraint, **kw: Any):
         text = ""
         if constraint.name is not None:
             formatted_name = self.preparer.format_constraint(constraint)
             if formatted_name is not None:
                 text += "CONSTRAINT %s " % formatted_name
-        text += "UNIQUE %s(%s)" % (
+        return text
+    
+    def define_primary_key_body(self, constraint: PrimaryKeyConstraint, **kw: Any):
+        text = ""
+        text += "PRIMARY KEY "
+        text += "(%s)" % ", ".join(
+            self.preparer.quote(c.name)
+            for c in (
+                constraint.columns_autoinc_first
+                if constraint._implicit_generated
+                else constraint.columns
+            )
+        )
+        return text
+
+    def define_foreign_key_body(self, constraint: ForeignKeyConstraint, **kw: Any):
+        preparer = self.preparer
+        remote_table = list(constraint.elements)[0].column.table
+        text = "FOREIGN KEY(%s) REFERENCES %s (%s)" % (
+            ", ".join(
+                preparer.quote(f.parent.name) for f in constraint.elements
+            ),
+            self.define_constraint_remote_table(
+                constraint, remote_table, preparer
+            ),
+            ", ".join(
+                preparer.quote(f.column.name) for f in constraint.elements
+            ),
+        )
+        return text
+
+    def define_unique_body(self, constraint: UniqueConstraint, **kw: Any):
+        text = "UNIQUE %s(%s)" % (
             self.define_unique_constraint_distinct(constraint, **kw),
             ", ".join(self.preparer.quote(c.name) for c in constraint),
         )
-        text += self.define_constraint_deferrability(constraint)
+        return text
+
+    def define_check_body(self, constraint: CheckConstraint, **kw: Any):
+        text = "CHECK (%s)" % self.sql_compiler.process(
+            constraint.sqltext, include_table=False, literal_binds=True
+        )
         return text
 
     def define_unique_constraint_distinct(

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -2666,6 +2666,213 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             schema.CreateIndex(idx), "CREATE INDEX foo ON test (x) INCLUDE (y)"
         )
 
+    def test_primary_key_constraint_with_include(self):
+        m = MetaData()
+        tbl = Table(
+            "test",
+            m,
+            Column("id", Integer),
+            Column("data", Integer),
+            PrimaryKeyConstraint("id", postgresql_include=["data"])
+        )
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE test (id SERIAL NOT NULL, data INTEGER, "
+            "PRIMARY KEY (id) INCLUDE (data))"
+        )
+    
+    def test_primary_key_constraint_with_deferrable(self):
+        m = MetaData()
+        tbl = Table(
+            "test",
+            m,
+            Column("id", Integer),
+            PrimaryKeyConstraint("id", deferrable=True)
+        )
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE test (id SERIAL NOT NULL, "
+            "PRIMARY KEY (id) DEFERRABLE)"
+        )
+
+    def test_primary_key_constraint_with_deferrable_and_include(self):
+        m = MetaData()
+        tbl = Table(
+            "test",
+            m,
+            Column("id", Integer),
+            Column("created_at", Integer),
+            PrimaryKeyConstraint(
+                "id",
+                deferrable=True,
+                initially="IMMEDIATE",
+                postgresql_include=["created_at"]
+            )
+        )
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE test (id SERIAL NOT NULL, created_at INTEGER, "
+            "PRIMARY KEY (id) INCLUDE (created_at) "
+            "DEFERRABLE INITIALLY IMMEDIATE)"
+        )
+
+    def test_foreign_key_constraint_with_deferrable(self):
+        m = MetaData()
+        t1 = Table("t1", m, Column("id", Integer, primary_key=True))
+        t2 = Table(
+            "t2",
+            m,
+            Column("t1_id", Integer),
+            ForeignKeyConstraint(["t1_id"], ["t1.id"], deferrable=True)
+        )
+        self.assert_compile(
+            schema.CreateTable(t2),
+            "CREATE TABLE t2 (t1_id INTEGER, "
+            "FOREIGN KEY(t1_id) REFERENCES t1 (id) DEFERRABLE)"
+        )
+
+    def test_foreign_key_constraint_with_not_valid(self):
+        m = MetaData()
+        t1 = Table("t1", m, Column("id", Integer, primary_key=True))
+        t2 = Table(
+            "t2",
+            m,
+            Column("t1_id", Integer),
+            ForeignKeyConstraint(
+                ["t1_id"],
+                ["t1.id"],
+                name="fk_t1",
+                postgresql_not_valid=True
+            )
+        )
+        self.assert_compile(
+            schema.CreateTable(t2),
+            "CREATE TABLE t2 (t1_id INTEGER, "
+            "CONSTRAINT fk_t1 FOREIGN KEY(t1_id) REFERENCES t1 (id) NOT VALID)"
+        )
+
+    def test_foreign_key_constraint_with_cascades_and_not_valid(self):
+        m = MetaData()
+        t1 = Table("t1", m, Column("id", Integer, primary_key=True))
+        t2 = Table("t2", m, Column("t1_id", Integer))
+        constraint = ForeignKeyConstraint(
+            ["t1_id"],
+            ["t1.id"],
+            name="fk_t1",
+            ondelete="CASCADE",
+            onupdate="SET NULL",
+            postgresql_not_valid=True
+        )
+        t2.append_constraint(constraint)
+
+        self.assert_compile(
+            schema.AddConstraint(constraint),
+            "ALTER TABLE t2 ADD CONSTRAINT fk_t1 FOREIGN KEY(t1_id) "
+            "REFERENCES t1 (id) ON DELETE CASCADE ON UPDATE SET NULL NOT VALID"
+        )
+
+    def test_unique_constraint_with_deferrable(self):
+        m = MetaData()
+        tbl = Table(
+            "test",
+            m,
+            Column("id", Integer),
+            UniqueConstraint("id", name="uq_id", deferrable=True)
+        )
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE test (id INTEGER, "
+            "CONSTRAINT uq_id UNIQUE (id) DEFERRABLE)"
+        )
+
+    def test_unique_constraint_with_include(self):
+        m = MetaData()
+        tbl = Table(
+            "test",
+            m,
+            Column("id", Integer),
+            Column("data", Integer),
+            Column("created_at", Integer),
+            UniqueConstraint(
+                "id",
+                name="uq_id",
+                postgresql_include=["data", "created_at"]
+            )
+        )
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE test (id INTEGER, data INTEGER, created_at INTEGER, "
+            "CONSTRAINT uq_id UNIQUE (id) INCLUDE (data, created_at))"
+        )
+    
+    def test_unique_constraint_with_deferrable_and_include(self):
+        m = MetaData()
+        tbl = Table(
+            "test",
+            m,
+            Column("id", Integer),
+            Column("data", Integer),
+            UniqueConstraint(
+                "id",
+                name="uq_id",
+                deferrable=True,
+                initially="DEFERRED",
+                postgresql_include=["data"]
+            )
+        )
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE test (id INTEGER, data INTEGER, "
+            "CONSTRAINT uq_id UNIQUE (id) INCLUDE (data) "
+            "DEFERRABLE INITIALLY DEFERRED)"
+        )
+
+    def test_check_constraint_with_not_valid(self):
+        m = MetaData()
+        tbl = Table(
+            "test",
+            m,
+            Column("data", Integer),
+            CheckConstraint("data > 0", name="ck_data", postgresql_not_valid=True)
+        )
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE test (data INTEGER, "
+            "CONSTRAINT ck_data CHECK (data > 0) NOT VALID)"
+        )
+
+    def test_check_constraint_with_deferrable_and_not_valid(self):
+        m = MetaData()
+        tbl = Table("test", m, Column("data", Integer))
+        constraint = CheckConstraint(
+            "data > 0",
+            name="ck_data",
+            deferrable=True,
+            initially="DEFERRED",
+            postgresql_not_valid=True
+        )
+        tbl.append_constraint(constraint)
+
+        self.assert_compile(
+            schema.AddConstraint(constraint),
+            "ALTER TABLE test ADD CONSTRAINT ck_data CHECK (data > 0) "
+            "DEFERRABLE INITIALLY DEFERRED NOT VALID"
+        )
+
+    def test_check_constraint_with_deferrable(self):
+        m = MetaData()
+        tbl = Table(
+            "test",
+            m,
+            Column("data", Integer),
+            CheckConstraint("data > 0", name="ck_data", deferrable=True)
+        )
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE test (data INTEGER, "
+            "CONSTRAINT ck_data CHECK (data > 0) DEFERRABLE)"
+        )
+
     @testing.fixture
     def update_tables(self):
         self.weather = table(

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -2673,26 +2673,26 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             m,
             Column("id", Integer),
             Column("data", Integer),
-            PrimaryKeyConstraint("id", postgresql_include=["data"])
+            PrimaryKeyConstraint("id", postgresql_include=["data"]),
         )
         self.assert_compile(
             schema.CreateTable(tbl),
             "CREATE TABLE test (id SERIAL NOT NULL, data INTEGER, "
-            "PRIMARY KEY (id) INCLUDE (data))"
+            "PRIMARY KEY (id) INCLUDE (data))",
         )
-    
+
     def test_primary_key_constraint_with_deferrable(self):
         m = MetaData()
         tbl = Table(
             "test",
             m,
             Column("id", Integer),
-            PrimaryKeyConstraint("id", deferrable=True)
+            PrimaryKeyConstraint("id", deferrable=True),
         )
         self.assert_compile(
             schema.CreateTable(tbl),
             "CREATE TABLE test (id SERIAL NOT NULL, "
-            "PRIMARY KEY (id) DEFERRABLE)"
+            "PRIMARY KEY (id) DEFERRABLE)",
         )
 
     def test_primary_key_constraint_with_deferrable_and_include(self):
@@ -2706,14 +2706,14 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
                 "id",
                 deferrable=True,
                 initially="IMMEDIATE",
-                postgresql_include=["created_at"]
-            )
+                postgresql_include=["created_at"],
+            ),
         )
         self.assert_compile(
             schema.CreateTable(tbl),
             "CREATE TABLE test (id SERIAL NOT NULL, created_at INTEGER, "
             "PRIMARY KEY (id) INCLUDE (created_at) "
-            "DEFERRABLE INITIALLY IMMEDIATE)"
+            "DEFERRABLE INITIALLY IMMEDIATE)",
         )
 
     def test_foreign_key_constraint_with_deferrable(self):
@@ -2723,12 +2723,12 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             "t2",
             m,
             Column("t1_id", Integer),
-            ForeignKeyConstraint(["t1_id"], ["t1.id"], deferrable=True)
+            ForeignKeyConstraint(["t1_id"], ["t1.id"], deferrable=True),
         )
         self.assert_compile(
             schema.CreateTable(t2),
             "CREATE TABLE t2 (t1_id INTEGER, "
-            "FOREIGN KEY(t1_id) REFERENCES t1 (id) DEFERRABLE)"
+            "FOREIGN KEY(t1_id) REFERENCES t1 (id) DEFERRABLE)",
         )
 
     def test_foreign_key_constraint_with_not_valid(self):
@@ -2739,16 +2739,14 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             m,
             Column("t1_id", Integer),
             ForeignKeyConstraint(
-                ["t1_id"],
-                ["t1.id"],
-                name="fk_t1",
-                postgresql_not_valid=True
-            )
+                ["t1_id"], ["t1.id"], name="fk_t1", postgresql_not_valid=True
+            ),
         )
         self.assert_compile(
             schema.CreateTable(t2),
             "CREATE TABLE t2 (t1_id INTEGER, "
-            "CONSTRAINT fk_t1 FOREIGN KEY(t1_id) REFERENCES t1 (id) NOT VALID)"
+            "CONSTRAINT fk_t1 FOREIGN KEY(t1_id) REFERENCES "
+            "t1 (id) NOT VALID)",
         )
 
     def test_foreign_key_constraint_with_cascades_and_not_valid(self):
@@ -2761,14 +2759,15 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             name="fk_t1",
             ondelete="CASCADE",
             onupdate="SET NULL",
-            postgresql_not_valid=True
+            postgresql_not_valid=True,
         )
         t2.append_constraint(constraint)
 
         self.assert_compile(
             schema.AddConstraint(constraint),
             "ALTER TABLE t2 ADD CONSTRAINT fk_t1 FOREIGN KEY(t1_id) "
-            "REFERENCES t1 (id) ON DELETE CASCADE ON UPDATE SET NULL NOT VALID"
+            "REFERENCES t1 (id) ON DELETE CASCADE "
+            "ON UPDATE SET NULL NOT VALID",
         )
 
     def test_unique_constraint_with_deferrable(self):
@@ -2777,12 +2776,12 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             "test",
             m,
             Column("id", Integer),
-            UniqueConstraint("id", name="uq_id", deferrable=True)
+            UniqueConstraint("id", name="uq_id", deferrable=True),
         )
         self.assert_compile(
             schema.CreateTable(tbl),
             "CREATE TABLE test (id INTEGER, "
-            "CONSTRAINT uq_id UNIQUE (id) DEFERRABLE)"
+            "CONSTRAINT uq_id UNIQUE (id) DEFERRABLE)",
         )
 
     def test_unique_constraint_with_include(self):
@@ -2794,17 +2793,15 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             Column("data", Integer),
             Column("created_at", Integer),
             UniqueConstraint(
-                "id",
-                name="uq_id",
-                postgresql_include=["data", "created_at"]
-            )
+                "id", name="uq_id", postgresql_include=["data", "created_at"]
+            ),
         )
         self.assert_compile(
             schema.CreateTable(tbl),
             "CREATE TABLE test (id INTEGER, data INTEGER, created_at INTEGER, "
-            "CONSTRAINT uq_id UNIQUE (id) INCLUDE (data, created_at))"
+            "CONSTRAINT uq_id UNIQUE (id) INCLUDE (data, created_at))",
         )
-    
+
     def test_unique_constraint_with_deferrable_and_include(self):
         m = MetaData()
         tbl = Table(
@@ -2817,14 +2814,14 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
                 name="uq_id",
                 deferrable=True,
                 initially="DEFERRED",
-                postgresql_include=["data"]
-            )
+                postgresql_include=["data"],
+            ),
         )
         self.assert_compile(
             schema.CreateTable(tbl),
             "CREATE TABLE test (id INTEGER, data INTEGER, "
             "CONSTRAINT uq_id UNIQUE (id) INCLUDE (data) "
-            "DEFERRABLE INITIALLY DEFERRED)"
+            "DEFERRABLE INITIALLY DEFERRED)",
         )
 
     def test_check_constraint_with_not_valid(self):
@@ -2833,12 +2830,14 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             "test",
             m,
             Column("data", Integer),
-            CheckConstraint("data > 0", name="ck_data", postgresql_not_valid=True)
+            CheckConstraint(
+                "data > 0", name="ck_data", postgresql_not_valid=True
+            ),
         )
         self.assert_compile(
             schema.CreateTable(tbl),
             "CREATE TABLE test (data INTEGER, "
-            "CONSTRAINT ck_data CHECK (data > 0) NOT VALID)"
+            "CONSTRAINT ck_data CHECK (data > 0) NOT VALID)",
         )
 
     def test_check_constraint_with_deferrable_and_not_valid(self):
@@ -2849,14 +2848,14 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             name="ck_data",
             deferrable=True,
             initially="DEFERRED",
-            postgresql_not_valid=True
+            postgresql_not_valid=True,
         )
         tbl.append_constraint(constraint)
 
         self.assert_compile(
             schema.AddConstraint(constraint),
             "ALTER TABLE test ADD CONSTRAINT ck_data CHECK (data > 0) "
-            "DEFERRABLE INITIALLY DEFERRED NOT VALID"
+            "DEFERRABLE INITIALLY DEFERRED NOT VALID",
         )
 
     def test_check_constraint_with_deferrable(self):
@@ -2865,12 +2864,12 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             "test",
             m,
             Column("data", Integer),
-            CheckConstraint("data > 0", name="ck_data", deferrable=True)
+            CheckConstraint("data > 0", name="ck_data", deferrable=True),
         )
         self.assert_compile(
             schema.CreateTable(tbl),
             "CREATE TABLE test (data INTEGER, "
-            "CONSTRAINT ck_data CHECK (data > 0) DEFERRABLE)"
+            "CONSTRAINT ck_data CHECK (data > 0) DEFERRABLE)",
         )
 
     @testing.fixture

--- a/test/sql/test_constraints.py
+++ b/test/sql/test_constraints.py
@@ -1397,7 +1397,7 @@ class ConstraintCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
 
         self.assert_compile(
             schema.AddConstraint(constraint),
-            "ALTER TABLE tbl ADD CHECK (a > 5)"
+            "ALTER TABLE tbl ADD CHECK (a > 5)",
         )
 
     def test_define_check_body_column_level(self):
@@ -1405,12 +1405,12 @@ class ConstraintCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
         t = Table(
             "tbl",
             m,
-            Column("a", Integer, CheckConstraint("a > 5", name="ck_a"))
+            Column("a", Integer, CheckConstraint("a > 5", name="ck_a")),
         )
 
         self.assert_compile(
             schema.CreateTable(t),
-            "CREATE TABLE tbl (a INTEGER CONSTRAINT ck_a CHECK (a > 5))"
+            "CREATE TABLE tbl (a INTEGER CONSTRAINT ck_a CHECK (a > 5))",
         )
 
     def test_define_foreign_key_body_single_column(self):
@@ -1420,24 +1420,25 @@ class ConstraintCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
 
         self.assert_compile(
             schema.AddConstraint(constraint),
-            "ALTER TABLE tbl ADD FOREIGN KEY(b) REFERENCES t2 (a)"
+            "ALTER TABLE tbl ADD FOREIGN KEY(b) REFERENCES t2 (a)",
         )
 
     def test_define_foreign_key_body_multi_column(self):
         m = MetaData()
-        t1 = Table("t1", m,
+        t1 = Table(
+            "t1",
+            m,
             Column("id", Integer, primary_key=True),
-            Column("id2", Integer, primary_key=True))
-        t2 = Table("t2", m,
-            Column("a", Integer),
-            Column("b", Integer))
+            Column("id2", Integer, primary_key=True),
+        )
+        t2 = Table("t2", m, Column("a", Integer), Column("b", Integer))
 
         constraint = ForeignKeyConstraint(["a", "b"], ["t1.id", "t1.id2"])
         t2.append_constraint(constraint)
 
         self.assert_compile(
             schema.AddConstraint(constraint),
-            "ALTER TABLE t2 ADD FOREIGN KEY(a, b) REFERENCES t1 (id, id2)"
+            "ALTER TABLE t2 ADD FOREIGN KEY(a, b) REFERENCES t1 (id, id2)",
         )
 
     def test_define_unique_body_single_column(self):
@@ -1447,7 +1448,7 @@ class ConstraintCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
 
         self.assert_compile(
             schema.AddConstraint(constraint),
-            "ALTER TABLE tbl ADD CONSTRAINT uq_a UNIQUE (a)"
+            "ALTER TABLE tbl ADD CONSTRAINT uq_a UNIQUE (a)",
         )
 
     def test_define_unique_body_multi_column(self):
@@ -1457,7 +1458,7 @@ class ConstraintCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
 
         self.assert_compile(
             schema.AddConstraint(constraint),
-            "ALTER TABLE tbl ADD CONSTRAINT uq_ab UNIQUE (a, b)"
+            "ALTER TABLE tbl ADD CONSTRAINT uq_ab UNIQUE (a, b)",
         )
 
     def test_define_constraint_preamble_named(self):
@@ -1466,7 +1467,7 @@ class ConstraintCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
 
         self.assert_compile(
             schema.AddConstraint(constraint),
-            "ALTER TABLE tbl ADD CONSTRAINT ck_test CHECK (a > 5)"
+            "ALTER TABLE tbl ADD CONSTRAINT ck_test CHECK (a > 5)",
         )
 
     def test_define_constraint_preamble_unnamed(self):
@@ -1475,7 +1476,7 @@ class ConstraintCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
 
         self.assert_compile(
             schema.AddConstraint(constraint),
-            "ALTER TABLE tbl ADD CHECK (a > 5)"
+            "ALTER TABLE tbl ADD CHECK (a > 5)",
         )
 
     def test_visit_check_constraint_composition(self):
@@ -1485,13 +1486,13 @@ class ConstraintCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
             name="ck_test",
             deferrable=True,
             initially="DEFERRED",
-            table=t
+            table=t,
         )
 
         self.assert_compile(
             schema.AddConstraint(constraint),
             "ALTER TABLE tbl ADD CONSTRAINT ck_test CHECK (a < b) "
-            "DEFERRABLE INITIALLY DEFERRED"
+            "DEFERRABLE INITIALLY DEFERRED",
         )
 
     def test_visit_foreign_key_constraint_composition(self):
@@ -1500,13 +1501,14 @@ class ConstraintCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
         t2 = Table("t2", m, Column("b", Integer))
 
         constraint = ForeignKeyConstraint(
-            ["b"], ["t1.a"],
+            ["b"],
+            ["t1.a"],
             name="fk_test",
             ondelete="CASCADE",
             onupdate="SET NULL",
             match="FULL",
             deferrable=True,
-            initially="IMMEDIATE"
+            initially="IMMEDIATE",
         )
         t2.append_constraint(constraint)
 
@@ -1514,21 +1516,18 @@ class ConstraintCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
             schema.AddConstraint(constraint),
             "ALTER TABLE t2 ADD CONSTRAINT fk_test FOREIGN KEY(b) "
             "REFERENCES t1 (a) MATCH FULL ON DELETE CASCADE "
-            "ON UPDATE SET NULL DEFERRABLE INITIALLY IMMEDIATE"
+            "ON UPDATE SET NULL DEFERRABLE INITIALLY IMMEDIATE",
         )
 
     def test_visit_unique_constraint_composition(self):
         t, _ = self._constraint_create_fixture()
         constraint = UniqueConstraint(
-            "a", "b",
-            name="uq_test",
-            deferrable=True,
-            initially="DEFERRED"
+            "a", "b", name="uq_test", deferrable=True, initially="DEFERRED"
         )
         t.append_constraint(constraint)
 
         self.assert_compile(
             schema.AddConstraint(constraint),
             "ALTER TABLE tbl ADD CONSTRAINT uq_test UNIQUE (a, b) "
-            "DEFERRABLE INITIALLY DEFERRED"
+            "DEFERRABLE INITIALLY DEFERRED",
         )

--- a/test/sql/test_constraints.py
+++ b/test/sql/test_constraints.py
@@ -1380,3 +1380,155 @@ class ConstraintCompilationTest(fixtures.TestBase, AssertsCompiledSQL):
         self.assert_compile(
             schema.CreateIndex(constraint), "CREATE INDEX name ON tbl (a + 5)"
         )
+
+
+class ConstraintCompositionTest(fixtures.TestBase, AssertsCompiledSQL):
+    __dialect__ = "default"
+
+    def _constraint_create_fixture(self):
+        m = MetaData()
+        t = Table("tbl", m, Column("a", Integer), Column("b", Integer))
+        t2 = Table("t2", m, Column("a", Integer), Column("b", Integer))
+        return t, t2
+
+    def test_define_check_body(self):
+        t, _ = self._constraint_create_fixture()
+        constraint = CheckConstraint("a > 5", table=t)
+
+        self.assert_compile(
+            schema.AddConstraint(constraint),
+            "ALTER TABLE tbl ADD CHECK (a > 5)"
+        )
+
+    def test_define_check_body_column_level(self):
+        m = MetaData()
+        t = Table(
+            "tbl",
+            m,
+            Column("a", Integer, CheckConstraint("a > 5", name="ck_a"))
+        )
+
+        self.assert_compile(
+            schema.CreateTable(t),
+            "CREATE TABLE tbl (a INTEGER CONSTRAINT ck_a CHECK (a > 5))"
+        )
+
+    def test_define_foreign_key_body_single_column(self):
+        t, _ = self._constraint_create_fixture()
+        constraint = ForeignKeyConstraint(["b"], ["t2.a"])
+        t.append_constraint(constraint)
+
+        self.assert_compile(
+            schema.AddConstraint(constraint),
+            "ALTER TABLE tbl ADD FOREIGN KEY(b) REFERENCES t2 (a)"
+        )
+
+    def test_define_foreign_key_body_multi_column(self):
+        m = MetaData()
+        t1 = Table("t1", m,
+            Column("id", Integer, primary_key=True),
+            Column("id2", Integer, primary_key=True))
+        t2 = Table("t2", m,
+            Column("a", Integer),
+            Column("b", Integer))
+
+        constraint = ForeignKeyConstraint(["a", "b"], ["t1.id", "t1.id2"])
+        t2.append_constraint(constraint)
+
+        self.assert_compile(
+            schema.AddConstraint(constraint),
+            "ALTER TABLE t2 ADD FOREIGN KEY(a, b) REFERENCES t1 (id, id2)"
+        )
+
+    def test_define_unique_body_single_column(self):
+        t, _ = self._constraint_create_fixture()
+        constraint = UniqueConstraint("a", name="uq_a")
+        t.append_constraint(constraint)
+
+        self.assert_compile(
+            schema.AddConstraint(constraint),
+            "ALTER TABLE tbl ADD CONSTRAINT uq_a UNIQUE (a)"
+        )
+
+    def test_define_unique_body_multi_column(self):
+        t, _ = self._constraint_create_fixture()
+        constraint = UniqueConstraint("a", "b", name="uq_ab")
+        t.append_constraint(constraint)
+
+        self.assert_compile(
+            schema.AddConstraint(constraint),
+            "ALTER TABLE tbl ADD CONSTRAINT uq_ab UNIQUE (a, b)"
+        )
+
+    def test_define_constraint_preamble_named(self):
+        t, _ = self._constraint_create_fixture()
+        constraint = CheckConstraint("a > 5", name="ck_test", table=t)
+
+        self.assert_compile(
+            schema.AddConstraint(constraint),
+            "ALTER TABLE tbl ADD CONSTRAINT ck_test CHECK (a > 5)"
+        )
+
+    def test_define_constraint_preamble_unnamed(self):
+        t, _ = self._constraint_create_fixture()
+        constraint = CheckConstraint("a > 5", table=t)
+
+        self.assert_compile(
+            schema.AddConstraint(constraint),
+            "ALTER TABLE tbl ADD CHECK (a > 5)"
+        )
+
+    def test_visit_check_constraint_composition(self):
+        t, _ = self._constraint_create_fixture()
+        constraint = CheckConstraint(
+            "a < b",
+            name="ck_test",
+            deferrable=True,
+            initially="DEFERRED",
+            table=t
+        )
+
+        self.assert_compile(
+            schema.AddConstraint(constraint),
+            "ALTER TABLE tbl ADD CONSTRAINT ck_test CHECK (a < b) "
+            "DEFERRABLE INITIALLY DEFERRED"
+        )
+
+    def test_visit_foreign_key_constraint_composition(self):
+        m = MetaData()
+        t1 = Table("t1", m, Column("a", Integer, primary_key=True))
+        t2 = Table("t2", m, Column("b", Integer))
+
+        constraint = ForeignKeyConstraint(
+            ["b"], ["t1.a"],
+            name="fk_test",
+            ondelete="CASCADE",
+            onupdate="SET NULL",
+            match="FULL",
+            deferrable=True,
+            initially="IMMEDIATE"
+        )
+        t2.append_constraint(constraint)
+
+        self.assert_compile(
+            schema.AddConstraint(constraint),
+            "ALTER TABLE t2 ADD CONSTRAINT fk_test FOREIGN KEY(b) "
+            "REFERENCES t1 (a) MATCH FULL ON DELETE CASCADE "
+            "ON UPDATE SET NULL DEFERRABLE INITIALLY IMMEDIATE"
+        )
+
+    def test_visit_unique_constraint_composition(self):
+        t, _ = self._constraint_create_fixture()
+        constraint = UniqueConstraint(
+            "a", "b",
+            name="uq_test",
+            deferrable=True,
+            initially="DEFERRED"
+        )
+        t.append_constraint(constraint)
+
+        self.assert_compile(
+            schema.AddConstraint(constraint),
+            "ALTER TABLE tbl ADD CONSTRAINT uq_test UNIQUE (a, b) "
+            "DEFERRABLE INITIALLY DEFERRED"
+        )


### PR DESCRIPTION
Fixes #12867
Factor out constraints into separate methods

### Description
Separated constraints creation into multiple methods to allow appending `INCLUDE` before `DEFERRABLE` for PostgreSQL dialect.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
