### PR TITLE
Fix adding property to mapper before mapping is complete

### DIFF
--- a/lib/sqlalchemy/orm/mapper.py
+++ b/lib/sqlalchemy/orm/mapper.py
@@ -2100,6 +2100,10 @@ class Mapper(
                 # to be addressable in subqueries
                 col.key = col._tq_key_label = key
 
+            # In the rare case of adding a ColumnProperty before the mapper is fully configured (e.g. deferring a reflected column)
+            if not hasattr(self, "columns") or not hasattr(self, "_props"):
+                return prop
+            
             self.columns.add(col, key)
 
             for col in prop.columns:
@@ -2299,7 +2303,7 @@ class Mapper(
 
         descriptor_props = util.preloaded.orm_descriptor_props
 
-        prop = self._props.get(key)
+        prop = self._props.get(key) if hasattr(self, "_props") else None
 
         if isinstance(prop, properties.ColumnProperty):
             return self._reconcile_prop_with_incoming_columns(

--- a/lib/sqlalchemy/orm/mapper.py
+++ b/lib/sqlalchemy/orm/mapper.py
@@ -2100,10 +2100,11 @@ class Mapper(
                 # to be addressable in subqueries
                 col.key = col._tq_key_label = key
 
-            # In the rare case of adding a ColumnProperty before the mapper is fully configured (e.g. deferring a reflected column)
+            # In the rare case of adding a ColumnProperty before the mapper
+            # is fully configured (e.g. deferring a reflected column)
             if not hasattr(self, "columns") or not hasattr(self, "_props"):
                 return prop
-            
+
             self.columns.add(col, key)
 
             for col in prop.columns:

--- a/test/orm/test_mapper.py
+++ b/test/orm/test_mapper.py
@@ -1030,9 +1030,11 @@ class MapperTest(_fixtures.FixtureTest, AssertsCompiledSQL):
         User()
         assert hasattr(User, "addresses")
         assert "addresses" in [p.key for p in m1._polymorphic_properties]
-    
+
     @testing.variation("property_type", ["Column", "ColumnProperty"])
-    def test_add_property_before_mapping_is_complete(self, property_type, connection):
+    def test_add_property_before_mapping_is_complete(
+        self, property_type, connection
+    ):
         m = MetaData()
         users = Table(
             "deferred_users",
@@ -1042,18 +1044,25 @@ class MapperTest(_fixtures.FixtureTest, AssertsCompiledSQL):
             Column("new_column", String),
         )
         User = self.classes.User
+
         class UserWithDeferred(User):
             pass
-        
+
         from sqlalchemy import event
-        # Listen for the event to be able to retrieve the mapper before completing the mapping process
-        @event.listens_for(UserWithDeferred, "instrument_class", propagate=True)
+
+        # Listen for the event to be able to retrieve the mapper
+        # before completing the mapping process
+        @event.listens_for(
+            UserWithDeferred, "instrument_class", propagate=True
+        )
         def before_mapper_configured(mapper, class_):
             assert mapper.configured is False
 
             col = mapper.local_table.c.new_column
             if property_type.ColumnProperty:
-                mapper.add_property(col.key, deferred(col, group="deferred_group"))
+                mapper.add_property(
+                    col.key, deferred(col, group="deferred_group")
+                )
             else:
                 mapper.add_property(col.key, col)
 
@@ -1064,7 +1073,7 @@ class MapperTest(_fixtures.FixtureTest, AssertsCompiledSQL):
                 users,
                 properties={
                     "name": deferred(users.c.name, group="deferred_group")
-                }
+                },
             )
         else:
             self.mapper(UserWithDeferred, users)
@@ -1090,9 +1099,8 @@ class MapperTest(_fixtures.FixtureTest, AssertsCompiledSQL):
             eq_(user.new_column, "test_value")
 
             assert "new_column" in user.__dict__
-            assert "name" in user.__dict__ 
+            assert "name" in user.__dict__
             eq_(user.name, "testuser")
-
 
         else:
             assert "id" in user.__dict__
@@ -1102,7 +1110,9 @@ class MapperTest(_fixtures.FixtureTest, AssertsCompiledSQL):
             eq_(user.name, "testuser")
 
         sess.close()
-        event.remove(UserWithDeferred, "instrument_class", before_mapper_configured)
+        event.remove(
+            UserWithDeferred, "instrument_class", before_mapper_configured
+        )
 
     def test_replace_col_prop_w_syn(self):
         users, User = self.tables.users, self.classes.User


### PR DESCRIPTION
Issue #12858 
Added checks that will allow `mapper.add_property` to work without raising an exception when used before the mapping process is complete.

### Description
`Mapper.configure_property()` is changed to check if the `_props` dict does not exist, i.e. mapper is not done mapping, and return the inputted property to store in the `_init_properties` dict. Also, allow a `Column` type to be used as a parameter which gets converted to a `ColumnProperty`. Added tests that cover both input types and the original deferred scenario.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
