### PR TITLE
Fix return type hint for `Query.get()`

### DIFF
--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -1060,7 +1060,7 @@ class Query(
         ":meth:`_orm.Query.get`",
         alternative="The method is now available as :meth:`_orm.Session.get`",
     )
-    def get(self, ident: _PKIdentityArgument) -> Optional[Any]:
+    def get(self, ident: _PKIdentityArgument) -> Optional[_T]:
         """Return an instance based on the given primary key identifier,
         or ``None`` if not found.
 

--- a/test/typing/plain_files/orm/typed_queries.py
+++ b/test/typing/plain_files/orm/typed_queries.py
@@ -135,6 +135,8 @@ def t_legacy_query_single_entity() -> None:
 
     assert_type(q1, Query[User])
 
+    assert_type(q1.get(5), Optional[User])
+
     assert_type(q1.one(), User)
 
     assert_type(q1.all(), list[User])


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

`Query[_T].get(...)` should return `Optional[_T]` instead of `Optional[Any]`. This is typed correctly when migrating to  `Session.get(_T, ...)`. By typing the legacy `Query.get(...)` call first, it should make migrations easier on developers, as it splits up the type checking improvements (and subsequent errors which may be discovered) from the `Query.get()`
 to `Session.get()` migration.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
