### PR TITLE
Added implementations for avg & abs

### DIFF
--- a/doc/build/core/functions.rst
+++ b/doc/build/core/functions.rst
@@ -52,10 +52,16 @@ unknown to SQLAlchemy, built-in or user defined. The section here only
 describes those functions where SQLAlchemy already knows what argument and
 return types are in use.
 
+.. autoclass:: abs
+    :no-members:
+
 .. autoclass:: aggregate_strings
     :no-members:
 
 .. autoclass:: array_agg
+    :no-members:
+
+.. autoclass:: avg
     :no-members:
 
 .. autoclass:: char_length

--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -1018,6 +1018,42 @@ class _FunctionGenerator:
         # code within this block is **programmatically,
         # statically generated** by tools/generate_sql_functions.py
 
+        # set ColumnElement[_T] as a separate overload, to appease
+        # mypy which seems to not want to accept _T from
+        # _ColumnExpressionArgument. Seems somewhat related to the covariant
+        # _HasClauseElement as of mypy 1.15
+
+        @overload
+        def abs(  # noqa: A001
+            self,
+            col: ColumnElement[_T],
+            *args: _ColumnExpressionOrLiteralArgument[Any],
+            **kwargs: Any,
+        ) -> abs[_T]: ...
+
+        @overload
+        def abs(  # noqa: A001
+            self,
+            col: _ColumnExpressionArgument[_T],
+            *args: _ColumnExpressionOrLiteralArgument[Any],
+            **kwargs: Any,
+        ) -> abs[_T]: ...
+
+        @overload
+        def abs(  # noqa: A001
+            self,
+            col: _T,
+            *args: _ColumnExpressionOrLiteralArgument[Any],
+            **kwargs: Any,
+        ) -> abs[_T]: ...
+
+        def abs(  # noqa: A001
+            self,
+            col: _ColumnExpressionOrLiteralArgument[_T],
+            *args: _ColumnExpressionOrLiteralArgument[Any],
+            **kwargs: Any,
+        ) -> abs[_T]: ...
+
         @property
         def aggregate_strings(self) -> Type[aggregate_strings]: ...
 
@@ -1059,6 +1095,9 @@ class _FunctionGenerator:
             *args: _ColumnExpressionOrLiteralArgument[Any],
             **kwargs: Any,
         ) -> array_agg[_T]: ...
+
+        @property
+        def avg(self) -> Type[avg]: ...
 
         @property
         def cast(self) -> Type[Cast[Any]]: ...
@@ -1770,6 +1809,13 @@ class coalesce(ReturnTypeFromOptionalArgs[_T]):
     inherit_cache = True
 
 
+class avg(GenericFunction[decimal.Decimal]):
+    """The SQL AVG() aggregate function."""
+
+    type: sqltypes.Numeric[decimal.Decimal] = sqltypes.Numeric()
+    inherit_cache = True
+
+
 class max(ReturnTypeFromArgs[_T]):  # noqa:  A001
     """The SQL MAX() aggregate function."""
 
@@ -1784,6 +1830,12 @@ class min(ReturnTypeFromArgs[_T]):  # noqa: A001
 
 class sum(ReturnTypeFromArgs[_T]):  # noqa: A001
     """The SQL SUM() aggregate function."""
+
+    inherit_cache = True
+
+
+class abs(ReturnTypeFromArgs[_T]):  # noqa: A001
+    """The SQL ABS() aggregate function."""
 
     inherit_cache = True
 

--- a/test/sql/test_functions.py
+++ b/test/sql/test_functions.py
@@ -552,7 +552,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         assert_raises(TypeError, func.char_length)
 
     def test_return_type_detection(self):
-        for fn in [func.coalesce, func.max, func.min, func.sum]:
+        for fn in [func.abs, func.coalesce, func.max, func.min, func.sum]:
             for args, type_ in [
                 (
                     (datetime.date(2007, 10, 5), datetime.date(2005, 10, 15)),

--- a/test/typing/plain_files/sql/functions.py
+++ b/test/typing/plain_files/sql/functions.py
@@ -20,129 +20,139 @@ from sqlalchemy import String
 # code within this block is **programmatically,
 # statically generated** by tools/generate_sql_functions.py
 
-stmt1 = select(func.aggregate_strings(column("x", String), ","))
+stmt1 = select(func.abs(column("x", Integer)))
 
-assert_type(stmt1, Select[str])
-
-
-stmt2 = select(func.array_agg(column("x", Integer)))
-
-assert_type(stmt2, Select[Sequence[int]])
+assert_type(stmt1, Select[int])
 
 
-stmt3 = select(func.char_length(column("x")))
+stmt2 = select(func.aggregate_strings(column("x", String), ","))
 
-assert_type(stmt3, Select[int])
-
-
-stmt4 = select(func.coalesce(column("x", Integer)))
-
-assert_type(stmt4, Select[int])
+assert_type(stmt2, Select[str])
 
 
-stmt5 = select(func.concat())
+stmt3 = select(func.array_agg(column("x", Integer)))
 
-assert_type(stmt5, Select[str])
+assert_type(stmt3, Select[Sequence[int]])
 
 
-stmt6 = select(func.count(column("x")))
+stmt4 = select(func.avg())
+
+assert_type(stmt4, Select[Decimal])
+
+
+stmt5 = select(func.char_length(column("x")))
+
+assert_type(stmt5, Select[int])
+
+
+stmt6 = select(func.coalesce(column("x", Integer)))
 
 assert_type(stmt6, Select[int])
 
 
-stmt7 = select(func.cume_dist())
+stmt7 = select(func.concat())
 
-assert_type(stmt7, Select[Decimal])
-
-
-stmt8 = select(func.current_date())
-
-assert_type(stmt8, Select[date])
+assert_type(stmt7, Select[str])
 
 
-stmt9 = select(func.current_time())
+stmt8 = select(func.count(column("x")))
 
-assert_type(stmt9, Select[time])
-
-
-stmt10 = select(func.current_timestamp())
-
-assert_type(stmt10, Select[datetime])
+assert_type(stmt8, Select[int])
 
 
-stmt11 = select(func.current_user())
+stmt9 = select(func.cume_dist())
 
-assert_type(stmt11, Select[str])
-
-
-stmt12 = select(func.dense_rank())
-
-assert_type(stmt12, Select[int])
+assert_type(stmt9, Select[Decimal])
 
 
-stmt13 = select(func.localtime())
+stmt10 = select(func.current_date())
 
-assert_type(stmt13, Select[datetime])
-
-
-stmt14 = select(func.localtimestamp())
-
-assert_type(stmt14, Select[datetime])
+assert_type(stmt10, Select[date])
 
 
-stmt15 = select(func.max(column("x", Integer)))
+stmt11 = select(func.current_time())
 
-assert_type(stmt15, Select[int])
-
-
-stmt16 = select(func.min(column("x", Integer)))
-
-assert_type(stmt16, Select[int])
+assert_type(stmt11, Select[time])
 
 
-stmt17 = select(func.next_value(SqlAlchemySequence("x_seq")))
+stmt12 = select(func.current_timestamp())
+
+assert_type(stmt12, Select[datetime])
+
+
+stmt13 = select(func.current_user())
+
+assert_type(stmt13, Select[str])
+
+
+stmt14 = select(func.dense_rank())
+
+assert_type(stmt14, Select[int])
+
+
+stmt15 = select(func.localtime())
+
+assert_type(stmt15, Select[datetime])
+
+
+stmt16 = select(func.localtimestamp())
+
+assert_type(stmt16, Select[datetime])
+
+
+stmt17 = select(func.max(column("x", Integer)))
 
 assert_type(stmt17, Select[int])
 
 
-stmt18 = select(func.now())
+stmt18 = select(func.min(column("x", Integer)))
 
-assert_type(stmt18, Select[datetime])
-
-
-stmt19 = select(func.percent_rank())
-
-assert_type(stmt19, Select[Decimal])
+assert_type(stmt18, Select[int])
 
 
-stmt20 = select(func.pow(column("x", Integer)))
+stmt19 = select(func.next_value(SqlAlchemySequence("x_seq")))
 
-assert_type(stmt20, Select[int])
-
-
-stmt21 = select(func.rank())
-
-assert_type(stmt21, Select[int])
+assert_type(stmt19, Select[int])
 
 
-stmt22 = select(func.session_user())
+stmt20 = select(func.now())
 
-assert_type(stmt22, Select[str])
+assert_type(stmt20, Select[datetime])
 
 
-stmt23 = select(func.sum(column("x", Integer)))
+stmt21 = select(func.percent_rank())
+
+assert_type(stmt21, Select[Decimal])
+
+
+stmt22 = select(func.pow(column("x", Integer)))
+
+assert_type(stmt22, Select[int])
+
+
+stmt23 = select(func.rank())
 
 assert_type(stmt23, Select[int])
 
 
-stmt24 = select(func.sysdate())
+stmt24 = select(func.session_user())
 
-assert_type(stmt24, Select[datetime])
+assert_type(stmt24, Select[str])
 
 
-stmt25 = select(func.user())
+stmt25 = select(func.sum(column("x", Integer)))
 
-assert_type(stmt25, Select[str])
+assert_type(stmt25, Select[int])
+
+
+stmt26 = select(func.sysdate())
+
+assert_type(stmt26, Select[datetime])
+
+
+stmt27 = select(func.user())
+
+assert_type(stmt27, Select[str])
 
 # END GENERATED FUNCTION TYPING TESTS
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Added the implementations for `func.avg()` and `func.abs()`.
Fixes: #13049

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
