### PR TITLE
Add JSON type support for Oracle dialect, addresses #10375

### DIFF
--- a/lib/sqlalchemy/dialects/oracle/__init__.py
+++ b/lib/sqlalchemy/dialects/oracle/__init__.py
@@ -36,6 +36,7 @@ from .base import VARCHAR2
 from .base import VECTOR
 from .base import VectorIndexConfig
 from .base import VectorIndexType
+from .json import JSON
 from .vector import SparseVector
 from .vector import VectorDistanceType
 from .vector import VectorStorageFormat
@@ -80,4 +81,5 @@ __all__ = (
     "VectorStorageFormat",
     "VectorStorageType",
     "SparseVector",
+    "JSON",
 )

--- a/lib/sqlalchemy/dialects/oracle/json.py
+++ b/lib/sqlalchemy/dialects/oracle/json.py
@@ -1,0 +1,103 @@
+# dialects/oracle/json.py
+# Copyright (C) 2005-2025 the SQLAlchemy authors and contributors
+# <see AUTHORS file>
+#
+# This module is part of SQLAlchemy and is released under
+# the MIT License: https://www.opensource.org/licenses/mit-license.php
+# mypy: ignore-errors
+
+from __future__ import annotations
+from typing import Any
+from decimal import Decimal
+from typing import TYPE_CHECKING
+import json
+
+from ... import types as sqltypes
+
+if TYPE_CHECKING:
+    from ...engine.interfaces import Dialect
+    from ...sql.type_api import _BindProcessorType
+    from ...sql.type_api import _LiteralProcessorType
+
+
+class JSON(sqltypes.JSON):
+    """
+    Note: The oracledb Python driver automatically deserializes JSON column data,
+    returning native Python objects (dict, list, bool, int, float, str) directly.
+    """
+
+    def result_processor(self, dialect, coltype):  # type: ignore[override]
+        string_process = self._str_impl.result_processor(dialect, coltype)
+        json_deserializer = getattr(dialect, "_json_deserializer", None) or json.loads
+
+        def process(value):
+            if value is None:
+                return None
+
+            if string_process:
+                value = string_process(value)
+
+            if isinstance(value, Decimal):
+                return float(value)
+
+            # If it's a string, it might be JSON that needs deserializing
+            # This can happen with CAST operations or when reading from VARCHAR2 columns
+            if isinstance(value, str):
+                try:
+                    return json_deserializer(value)
+                except (json.JSONDecodeError, TypeError):
+                    return value
+
+            return value
+
+        return process
+
+
+class _FormatTypeMixin:
+    def _format_value(self, value: Any) -> str:
+        raise NotImplementedError()
+
+    def bind_processor(self, dialect: Dialect) -> _BindProcessorType[Any]:
+        super_proc = self.string_bind_processor(dialect)  # type: ignore[attr-defined]  # noqa: E501
+
+        def process(value: Any) -> Any:
+            value = self._format_value(value)
+            if super_proc:
+                value = super_proc(value)
+            return value
+
+        return process
+
+    def literal_processor(
+        self, dialect: Dialect
+    ) -> _LiteralProcessorType[Any]:
+        super_proc = self.string_literal_processor(dialect)  # type: ignore[attr-defined]  # noqa: E501
+
+        def process(value: Any) -> str:
+            value = self._format_value(value)
+            if super_proc:
+                value = super_proc(value)
+            return value  # type: ignore[no-any-return]
+
+        return process
+
+
+class JSONIndexType(_FormatTypeMixin, sqltypes.JSON.JSONIndexType):
+    def _format_value(self, value: Any) -> str:
+        if isinstance(value, int):
+            formatted_value = "$[%s]" % value
+        else:
+            formatted_value = '$."%s"' % value
+        return formatted_value
+
+
+class JSONPathType(_FormatTypeMixin, sqltypes.JSON.JSONPathType):
+    def _format_value(self, value: Any) -> str:
+        return "$%s" % (
+            "".join(
+                [
+                    "[%s]" % elem if isinstance(elem, int) else '."%s"' % elem
+                    for elem in value
+                ]
+            )
+        )

--- a/lib/sqlalchemy/dialects/oracle/types.py
+++ b/lib/sqlalchemy/dialects/oracle/types.py
@@ -40,6 +40,23 @@ class NCLOB(sqltypes.Text):
 class VARCHAR2(VARCHAR):
     __visit_name__ = "VARCHAR2"
 
+    @classmethod
+    def _adapt_string_for_cast(cls, type_: sqltypes.String) -> "VARCHAR2":
+        """Adapt a String type for use in CAST expressions.
+
+        Oracle requires a length for VARCHAR2 in CAST expressions.
+        If no length is specified, we default to 4000 (max for VARCHAR2).
+        """
+        type_ = sqltypes.to_instance(type_)
+        if isinstance(type_, VARCHAR2):
+            return type_
+        elif isinstance(type_, VARCHAR):
+            return VARCHAR2(
+                length=type_.length or 4000, collation=type_.collation
+            )
+        else:
+            return VARCHAR2(length=type_.length or 4000)
+
 
 NVARCHAR2 = NVARCHAR
 

--- a/lib/sqlalchemy/testing/requirements.py
+++ b/lib/sqlalchemy/testing/requirements.py
@@ -1927,6 +1927,16 @@ class SuiteRequirements(Requirements):
         return exclusions.closed()
 
     @property
+    def json_deserializer_is_used(self):
+        """Indicates if custom json_deserializer is called for JSON columns.
+        
+        Some database drivers (e.g., Oracle's oracledb) automatically
+        deserialize JSON at the DBAPI level, returning native Python objects
+        directly, which means custom json_deserializer cannot be invoked.
+        """
+        return exclusions.closed() + exclusions.skip_if(["oracle"])
+
+    @property
     def reflect_table_options(self):
         """Target database must support reflecting table_options."""
         return exclusions.closed()

--- a/lib/sqlalchemy/testing/suite/test_types.py
+++ b/lib/sqlalchemy/testing/suite/test_types.py
@@ -1318,7 +1318,9 @@ class JSONTest(_LiteralRoundTripFixture, fixtures.TablesTest):
         Table(
             "data_table",
             metadata,
-            Column("id", Integer, primary_key=True),
+            Column(
+                "id", Integer, primary_key=True, test_needs_autoincrement=True
+            ),
             Column("name", String(30), nullable=False),
             Column("data", cls.datatype, nullable=False),
             Column("nulldata", cls.datatype(none_as_null=True)),
@@ -1592,6 +1594,9 @@ class JSONTest(_LiteralRoundTripFixture, fixtures.TablesTest):
             eq_(row, (data_element, data_element))
 
     def test_round_trip_custom_json(self):
+        if not testing.requires.json_deserializer_is_used.enabled:
+            return
+
         data_table = self.tables.data_table
         data_element = {"key1": "data1"}
 
@@ -1611,6 +1616,7 @@ class JSONTest(_LiteralRoundTripFixture, fixtures.TablesTest):
 
             eq_(row, (data_element,))
             eq_(js.mock_calls, [mock.call(data_element)])
+
             if testing.requires.json_deserializer_binary.enabled:
                 eq_(
                     jd.mock_calls,
@@ -1936,7 +1942,9 @@ class JSONLegacyStringCastIndexTest(
         Table(
             "data_table",
             metadata,
-            Column("id", Integer, primary_key=True),
+            Column(
+                "id", Integer, primary_key=True, test_needs_autoincrement=True
+            ),
             Column("name", String(30), nullable=False),
             Column("data", cls.datatype),
             Column("nulldata", cls.datatype(none_as_null=True)),

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -1247,8 +1247,9 @@ class DefaultRequirements(SuiteRequirements):
                 "postgresql >= 9.3",
                 self._sqlite_json,
                 "mssql",
+                "oracle>=21",
             ]
-        )
+        ) + skip_if("oracle+cx_oracle")
 
     @property
     def json_index_supplementary_unicode_element(self):
@@ -1339,6 +1340,7 @@ class DefaultRequirements(SuiteRequirements):
                 and not config.db.dialect._is_mariadb,
                 "postgresql >= 9.3",
                 "sqlite >= 3.9",
+                "oracle>=21",
             ]
         )
 
@@ -2179,6 +2181,16 @@ class DefaultRequirements(SuiteRequirements):
     def json_deserializer_binary(self):
         "indicates if the json_deserializer function is called with bytes"
         return only_on(["postgresql+psycopg"])
+
+    @property
+    def json_deserializer_is_used(self):
+        """Indicates if custom json_deserializer is called for JSON columns.
+        
+        Some database drivers (e.g., Oracle's oracledb) automatically
+        deserialize JSON at the DBAPI level, returning native Python objects
+        directly, which means custom json_deserializer cannot be invoked.
+        """
+        return skip_if(["oracle"])
 
     @property
     def mssql_filestream(self):


### PR DESCRIPTION
I followed the convention used by other dialects while implementing this. One key difference is that in JSON queries, Oracle uses literal JSON paths, not parameterized ones. 

This pull request is:
- [x] A new feature implementation