### PR TITLE
docs: fix grammar in the metadata tutorial

### DIFF
--- a/doc/build/tutorial/metadata.rst
+++ b/doc/build/tutorial/metadata.rst
@@ -599,7 +599,7 @@ that database.
 .. tip::  There is no requirement that reflection must be used in order to
    use SQLAlchemy with a pre-existing database.  It is entirely typical that
    the SQLAlchemy application declares all metadata explicitly in Python,
-   such that its structure corresponds to that the existing database.
+   such that its structure corresponds to the existing database.
    The metadata structure also need not include tables, columns, or other
    constraints and constructs in the pre-existing database that are not needed
    for the local application to function.


### PR DESCRIPTION
### Description

Fixed a grammatical error in the documentation. I removed the word `that` from the phrase `corresponds to that the existing database`.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
