### PR TITLE
Fix mypy error on scalar call with tuple[Any, ...]

### DIFF
--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -47,6 +47,7 @@ from ..sql.base import _generative
 from ..sql.base import InPlaceGenerative
 from ..util import deprecated
 from ..util import NONE_SET
+from ..util.typing import Never
 from ..util.typing import Self
 from ..util.typing import TupleAny
 from ..util.typing import TypeVarTuple
@@ -1063,6 +1064,16 @@ class Result(_WithKeys, ResultInternal[Row[Unpack[_Ts]]]):
         return self._only_one_row(
             raise_for_second_row=True, raise_for_none=True, scalar=False
         )
+
+    # special case to handle mypy issue:
+    # https://github.com/python/mypy/issues/20651
+    @overload
+    def scalar(self: Result[Never, Unpack[TupleAny]]) -> Optional[Any]:
+        pass
+
+    @overload
+    def scalar(self: Result[_T, Unpack[TupleAny]]) -> Optional[_T]:
+        pass
 
     def scalar(self: Result[_T, Unpack[TupleAny]]) -> Optional[_T]:
         """Fetch the first column of the first row, and close the result set.


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
Fixes: #13091

### Description
Fix mypy error on scalar call with tuple[Any, ...]

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.
