### PR TITLE
Add overload for `CursorResult` return type for `Session.execute`

### DIFF
--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -130,6 +130,7 @@ if typing.TYPE_CHECKING:
     from ..sql._typing import _TypedColumnClauseArgument as _TCCA
     from ..sql.base import Executable
     from ..sql.base import ExecutableOption
+    from ..sql.dml import UpdateBase
     from ..sql.elements import ClauseElement
     from ..sql.roles import TypedColumnsClauseRole
     from ..sql.selectable import ForUpdateParameter
@@ -2136,6 +2137,19 @@ class Session(_SessionClassMethods, EventTarget):
     @overload
     def _execute_internal(
         self,
+        statement: UpdateBase,
+        params: Optional[_CoreAnyExecuteParams] = None,
+        *,
+        execution_options: OrmExecuteOptionsParameter = util.EMPTY_DICT,
+        bind_arguments: Optional[_BindArguments] = None,
+        _parent_execute_state: Optional[Any] = None,
+        _add_event: Optional[Any] = None,
+        _scalar_result: bool = ...,
+    ) -> CursorResult[Unpack[TupleAny]]: ...
+
+    @overload
+    def _execute_internal(
+        self,
         statement: Executable,
         params: Optional[_CoreAnyExecuteParams] = None,
         *,
@@ -2321,6 +2335,18 @@ class Session(_SessionClassMethods, EventTarget):
         _parent_execute_state: Optional[Any] = None,
         _add_event: Optional[Any] = None,
     ) -> Result[Unpack[_Ts]]: ...
+
+    @overload
+    def execute(
+        self,
+        statement: UpdateBase,
+        params: Optional[_CoreAnyExecuteParams] = None,
+        *,
+        execution_options: OrmExecuteOptionsParameter = util.EMPTY_DICT,
+        bind_arguments: Optional[_BindArguments] = None,
+        _parent_execute_state: Optional[Any] = None,
+        _add_event: Optional[Any] = None,
+    ) -> CursorResult[Unpack[TupleAny]]: ...
 
     @overload
     def execute(


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

When running update/delete statements without `returning` clauses using `Session.execute()`, developers are typically validating success by accessing `rowcount` on the returned result, which causes type checkers to complain.

This change intends to add an overload to `Session.execute()` to return `CursorResult` in these situations, which includes rowcount.

### Description
<!-- Describe your changes in detail -->

My understanding from debugging this at runtime / exploring code is that:
1. Any `UpdateBase` derived statement with a `returning` clause, will not be impacted by this change. They will fall under the previous overload for `execute` by matching `statement: TypedReturnsRows[Unpack[_Ts]]` and as a result will continue to return a type of `Result[Unpack[_Ts]]`.
2. All other `UpdateBase` derived statements should actually return `CursorResult[Unpack[TupleAny]]` (and possibly even this could be more explicitly typed as `CursorResult[None]`). This assumption is based on observations at runtime, as opposed to any concrete guarantees observed in code (as `_execute_internal` is quite dynamic here).

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
