### PR TITLE
Allow opting specific mapped classes out of bind config for Session

### DIFF
--- a/test/orm/test_bind.py
+++ b/test/orm/test_bind.py
@@ -826,6 +826,24 @@ class GetBindTest(fixtures.MappedTest):
         is_(session.get_bind(self.classes.BaseClass), base_class_bind)
         is_(session.get_bind(self.classes.ConcreteSubClass), concrete_sub_bind)
 
+    def test_bind_base_class_none(self):
+        concrete_sub_bind = Mock(name="concrete")
+
+        session = self._fixture(
+            {
+                self.classes.BaseClass: None,
+                self.classes.ConcreteSubClass: concrete_sub_bind
+            }
+        )
+
+        assert_raises_message(
+            sa.exc.UnboundExecutionError,
+            "Could not locate a bind configured on mapper ",
+            session.get_bind,
+            self.classes.BaseClass
+        )
+        is_(session.get_bind(self.classes.ConcreteSubClass), concrete_sub_bind)
+
     @testing.fixture
     def two_table_fixture(self):
         base_class_bind = Mock(name="base")


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->
Draft status while working on updating tests.

### Description
<!-- Describe your changes in detail -->

We have a use case where we want to set our sessionmaker as follows:
```python3
class M1(DeclarativeBase):
    pass

class M2(DeclarativeBase):
    pass

Session = sessionmaker(
    bind=engine,
    binds={M1: engine, M2: None}
)
session = Session()
```

The goal is:
1. Custom non-ORM statements (e.g. for controlling custom scoped extended session timeout values) will continue to work by accessing underlying bind.
2. ORM statements accessing models created by subclassing M1 will work with these sessions.
3. ORM statements accessing models created by subclassing M2 will not work with these sessions.

This kind of works today - attempting to use an M2 based ORM model with this session will result in an AttributeError once `conn = bind.connect()` is called in [_connection_for_bind](https://github.com/soceanainn/sqlalchemy/blob/9314ab0a5bdde1b8407134cc676b176f73689a60/lib/sqlalchemy/orm/session.py#L1188).

I think the behaviour is more consistent to raise `UnboundExecutionError`  if we encounter a value of `None` within binds - this is consistent with encountering an explicit `None` value for `bind`.



### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

This prompts me to create an issue, but when I try to create an issue it prompts me to open a discussion instead.

Started a discussion here:
https://github.com/sqlalchemy/sqlalchemy/discussions/13122

**Have a nice day!**
