### PR TITLE
fix: MySQLDDLCompiler create index falls back to default compiler args

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2215,7 +2215,9 @@ class MySQLDDLCompiler(
         if index.unique:
             text += "UNIQUE "
 
-        index_prefix = index.kwargs.get("%s_prefix" % self.dialect.name, None)
+        index_prefix = index.kwargs.get(
+            "%s_prefix" % self.dialect.name) or index.kwargs.get("mysql_prefix")
+
         if index_prefix:
             text += index_prefix + " "
 
@@ -2224,7 +2226,7 @@ class MySQLDDLCompiler(
             text += "IF NOT EXISTS "
         text += "%s ON %s " % (name, table)
 
-        length = index.dialect_options[self.dialect.name]["length"]
+        length = index.dialect_options[self.dialect.name].get("length") or index.dialect_options["mysql"]["length"]
         if length is not None:
             if isinstance(length, dict):
                 # length value can be a (column_name --> integer value)
@@ -2252,11 +2254,15 @@ class MySQLDDLCompiler(
             columns_str = ", ".join(columns)
         text += "(%s)" % columns_str
 
-        parser = index.dialect_options["mysql"]["with_parser"]
+        parser = index.dialect_options[self.dialect.name].get(
+            "with_parser") or index.dialect_options["mysql"]["with_parser"]
+
         if parser is not None:
             text += " WITH PARSER %s" % (parser,)
 
-        using = index.dialect_options["mysql"]["using"]
+        using = index.dialect_options[self.dialect.name].get(
+            "using") or index.dialect_options["mysql"]["using"]
+
         if using is not None:
             text += " USING %s" % (preparer.quote(using))
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Custom DDL compilers that inherit from `MySQLDDLCompiler` (e.g. third-party dialects like StarRocks) cannot use the default `visit_create_index` method when their dialect name differs from `"mysql"`.

The issue is that `visit_create_index` resolves index options — `prefix`, `length`, `using`, `with_parser` — by looking them up exclusively under `{dialect_name}_<arg>` / `dialect_options[dialect_name]`. When a subclass has a different dialect name (e.g. `"starrocks"`), these lookups return `None` even though the user specified them via the standard `mysql_*` kwargs, since the options are stored under the `"mysql"` key.

This change makes each lookup fall back to the `"mysql"` key when the dialect-specific key yields no result, so subclasses of `MySQLDDLCompiler` work out of the box without having to reimplement `visit_create_index` just to fix option resolution.

### Changes

- **`lib/sqlalchemy/dialects/mysql/base.py`** — For `prefix`, `length`, `with_parser`, and `using`, try `dialect_options[self.dialect.name]` first, then fall back to `dialect_options["mysql"]`.
- **`test/dialect/mysql/test_compiler.py`** — Added `MySQLBasedCustomDialectDDLTest` covering `CREATE INDEX` compilation through a simulated custom dialect: simple, length, prefix, using, parser, unique, composite, and expression-based indexes.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
