### PR TITLE
Use _effective_decimal_return_scale in Numeric.result_processor

### DIFF
--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -638,11 +638,7 @@ class Numeric(NumericCommon[_N], TypeEngine[_N]):
                 # we're a "numeric", DBAPI returns floats, convert.
                 return processors.to_decimal_processor_factory(
                     decimal.Decimal,
-                    (
-                        self.scale
-                        if self.scale is not None
-                        else self._default_decimal_return_scale
-                    ),
+                    self._effective_decimal_return_scale,
                 )
         else:
             if dialect.supports_native_decimal:


### PR DESCRIPTION
### Description

`Numeric.result_processor` computes the decimal return scale inline, bypassing the `decimal_return_scale` parameter, while `Float.result_processor` correctly uses `_effective_decimal_return_scale`.

### Current behavior

```python
# Numeric.result_processor - ignores decimal_return_scale
return processors.to_decimal_processor_factory(
    decimal.Decimal,
    (
        self.scale
        if self.scale is not None
        else self._default_decimal_return_scale
    ),
)
```

The `_effective_decimal_return_scale` property (from `NumericCommon`) checks `self.decimal_return_scale` first, then falls back to `self.scale`, then `_default_decimal_return_scale`. The inline logic in `Numeric` skips the `decimal_return_scale` check entirely.

This means `Numeric(precision=10, scale=2, decimal_return_scale=5)` would use scale 2 instead of 5 when the DBAPI doesn't support native decimals.

### Fix

Use `self._effective_decimal_return_scale`, same as `Float.result_processor` already does.

```python
# After fix - consistent with Float
return processors.to_decimal_processor_factory(
    decimal.Decimal,
    self._effective_decimal_return_scale,
)
```
