### PR TITLE
Mysql ddl compiler fall back to default index args

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2215,7 +2215,7 @@ class MySQLDDLCompiler(
         if index.unique:
             text += "UNIQUE "
 
-        index_prefix = index.kwargs.get("%s_prefix" % self.dialect.name, None)
+        index_prefix = index.get_dialect_option(self.dialect, "prefix")
         if index_prefix:
             text += index_prefix + " "
 
@@ -2224,7 +2224,7 @@ class MySQLDDLCompiler(
             text += "IF NOT EXISTS "
         text += "%s ON %s " % (name, table)
 
-        length = index.dialect_options[self.dialect.name]["length"]
+        length = index.get_dialect_option(self.dialect, "length")
         if length is not None:
             if isinstance(length, dict):
                 # length value can be a (column_name --> integer value)
@@ -2252,11 +2252,11 @@ class MySQLDDLCompiler(
             columns_str = ", ".join(columns)
         text += "(%s)" % columns_str
 
-        parser = index.dialect_options["mysql"]["with_parser"]
+        parser = index.get_dialect_option(self.dialect, "with_parser")
         if parser is not None:
             text += " WITH PARSER %s" % (parser,)
 
-        using = index.dialect_options["mysql"]["using"]
+        using = index.get_dialect_option(self.dialect, "using")
         if using is not None:
             text += " USING %s" % (preparer.quote(using))
 
@@ -2266,7 +2266,7 @@ class MySQLDDLCompiler(
         self, constraint: sa_schema.PrimaryKeyConstraint, **kw: Any
     ) -> str:
         text = super().visit_primary_key_constraint(constraint)
-        using = constraint.dialect_options["mysql"]["using"]
+        using = constraint.get_dialect_option(self.dialect, "using")
         if using:
             text += " USING %s" % (self.preparer.quote(using))
         return text

--- a/lib/sqlalchemy/sql/base.py
+++ b/lib/sqlalchemy/sql/base.py
@@ -495,6 +495,27 @@ class DialectKWArgs:
         ("dialect_options", InternalTraversal.dp_dialect_options)
     ]
 
+    def get_dialect_option(
+        self, dialect: Dialect, argument_name: str, *, else_: Any = None
+    ) -> Any:
+        """Return the value of a dialect-specific option, or *else_* if
+        this dialect does not register the given argument.
+
+        This is useful for DDL compilers that may be inherited by
+        third-party dialects whose ``construct_arguments`` do not
+        include the same set of keys as the parent dialect.
+
+        """
+
+        registry = DialectKWArgs._kw_registry[dialect.name]
+        if registry is None:
+            return else_
+
+        if argument_name in registry.get(self.__class__, {}):
+            return self.dialect_options[dialect.name][argument_name]
+        else:
+            return else_
+
     @classmethod
     def argument_for(
         cls, dialect_name: str, argument_name: str, default: Any

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -269,12 +269,8 @@ class CompileTest(ReservedWordFixture, fixtures.TestBase, AssertsCompiledSQL):
     def test_create_index_with_length(self, dialect_name):
         m = MetaData()
         tbl = Table("testtbl", m, Column("data", String(255)))
-        idx1 = Index(
-            "test_idx1", tbl.c.data, **{f"{dialect_name}_length": 10}
-        )
-        idx2 = Index(
-            "test_idx2", tbl.c.data, **{f"{dialect_name}_length": 5}
-        )
+        idx1 = Index("test_idx1", tbl.c.data, **{f"{dialect_name}_length": 10})
+        idx2 = Index("test_idx2", tbl.c.data, **{f"{dialect_name}_length": 5})
 
         self.assert_compile(
             schema.CreateIndex(idx1),

--- a/test/sql/test_metadata.py
+++ b/test/sql/test_metadata.py
@@ -5724,6 +5724,46 @@ class DialectKWArgTest(fixtures.TestBase):
                 5,
             )
 
+    def test_get_dialect_option_participating(self):
+        with self._fixture():
+            idx = Index("a", "b", "c", participating_x=7)
+            dialect = mock.Mock()
+            dialect.name = "participating"
+            eq_(idx.get_dialect_option(dialect, "x"), 7)
+            eq_(idx.get_dialect_option(dialect, "y"), False)
+
+    def test_get_dialect_option_participating_default(self):
+        with self._fixture():
+            idx = Index("a", "b", "c")
+            dialect = mock.Mock()
+            dialect.name = "participating"
+            eq_(idx.get_dialect_option(dialect, "x"), 5)
+            eq_(idx.get_dialect_option(dialect, "z_one"), None)
+
+    def test_get_dialect_option_participating_unregistered_arg(self):
+        with self._fixture():
+            idx = Index("a", "b", "c", participating_x=7)
+            dialect = mock.Mock()
+            dialect.name = "participating"
+            eq_(idx.get_dialect_option(dialect, "nonexistent"), None)
+            eq_(
+                idx.get_dialect_option(
+                    dialect, "nonexistent", else_="fallback"
+                ),
+                "fallback",
+            )
+
+    def test_get_dialect_option_nonparticipating(self):
+        with self._fixture():
+            idx = Index("a", "b", "c")
+            dialect = mock.Mock()
+            dialect.name = "nonparticipating"
+            eq_(idx.get_dialect_option(dialect, "x"), None)
+            eq_(
+                idx.get_dialect_option(dialect, "x", else_="fallback"),
+                "fallback",
+            )
+
 
 class NamingConventionTest(fixtures.TestBase, AssertsCompiledSQL):
     __dialect__ = "default"


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
Fixes: #13134 

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
