### PR TITLE
Oracle dialect reflection of RAW length

### DIFF
--- a/lib/sqlalchemy/dialects/oracle/base.py
+++ b/lib/sqlalchemy/dialects/oracle/base.py
@@ -2847,6 +2847,7 @@ class OracleDialect(default.DefaultDialect):
                 all_cols.c.column_name,
                 all_cols.c.data_type,
                 all_cols.c.char_length,
+                all_cols.c.data_length,
                 all_cols.c.data_precision,
                 all_cols.c.data_scale,
                 all_cols.c.nullable,
@@ -2965,6 +2966,9 @@ class OracleDialect(default.DefaultDialect):
             elif coltype in ("VARCHAR2", "NVARCHAR2", "CHAR", "NCHAR"):
                 char_length = maybe_int(row_dict["char_length"])
                 coltype = self.ischema_names.get(coltype)(char_length)
+            elif coltype == "RAW":
+                data_length = maybe_int(row_dict["data_length"])
+                coltype = RAW(data_length)
             elif "WITH TIME ZONE" in coltype:
                 coltype = TIMESTAMP(timezone=True)
             elif "WITH LOCAL TIME ZONE" in coltype:

--- a/test/dialect/oracle/test_reflection.py
+++ b/test/dialect/oracle/test_reflection.py
@@ -1384,16 +1384,19 @@ class TypeReflectionTest(fixtures.TestBase):
         ]
         self._run_test(metadata, connection, specs, ["length"])
 
-    @testing.combinations(ROWID(), RAW(1), argnames="type_")
+    @testing.combinations(ROWID(), RAW(1), RAW(50), argnames="type_")
     def test_misc_types(self, metadata, connection, type_):
         t = Table("t1", metadata, Column("x", type_))
 
         t.create(connection)
-
+        reflected_type = inspect(connection).get_columns("t1")[0]["type"]
         eq_(
-            inspect(connection).get_columns("t1")[0]["type"]._type_affinity,
+            reflected_type._type_affinity,
             type_._type_affinity,
         )
+
+        if hasattr(type_, "length"):
+            eq_(type_.length, reflected_type.length)
 
     def test_raw_type(self, metadata, connection):
         """Test that RAW columns preserve data_length on reflection."""

--- a/test/dialect/oracle/test_reflection.py
+++ b/test/dialect/oracle/test_reflection.py
@@ -1395,6 +1395,14 @@ class TypeReflectionTest(fixtures.TestBase):
             type_._type_affinity,
         )
 
+    def test_raw_type(self, metadata, connection):
+        """Test that RAW columns preserve data_length on reflection."""
+        specs = [
+            (RAW(50), RAW(50)),
+            (RAW(128), RAW(128)),
+        ]
+        self._run_test(metadata, connection, specs, ["length"])
+
 
 class IdentityReflectionTest(fixtures.TablesTest):
     __only_on__ = "oracle"


### PR DESCRIPTION
### Description
Adds reflection of RAW type length for Oracle. Includes tests for length of data type. Discussed in [13147](https://github.com/sqlalchemy/sqlalchemy/discussions/13147)

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [X] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
