### PR TITLE
Drop the mutable default in inspect_formatargspec

### DIFF
--- a/lib/sqlalchemy/util/compat.py
+++ b/lib/sqlalchemy/util/compat.py
@@ -193,8 +193,8 @@ def inspect_formatargspec(
     varkw: Optional[str] = None,
     defaults: Optional[Sequence[Any]] = None,
     kwonlyargs: Optional[Sequence[str]] = (),
-    kwonlydefaults: Optional[Mapping[str, Any]] = {},
-    annotations: Mapping[str, Any] = {},
+    kwonlydefaults: Optional[Mapping[str, Any]] = None,
+    annotations: Mapping[str, Any] = None,
     formatarg: Callable[[str], str] = str,
     formatvarargs: Callable[[str], str] = lambda name: "*" + name,
     formatvarkw: Callable[[str], str] = lambda name: "**" + name,
@@ -215,6 +215,10 @@ def inspect_formatargspec(
     is dropped.
 
     """
+    if kwonlydefaults is None:
+        kwonlydefaults = {}
+    if annotations is None:
+        annotations = {}
 
     kwonlydefaults = kwonlydefaults or {}
     annotations = annotations or {}


### PR DESCRIPTION
Upon reviewing lib/sqlalchemy/util/compat.py, I noticed an opportunity for improvement. Drop the mutable default in inspect_formatargspec. Mutable defaults are shared across calls and usually turn into state leaks. I kept the patch small and re-ran syntax checks after applying it.

Backward-compat note: This changes a public function signature by replacing mutable defaults with None guards. Call sites stay source-compatible, but callers introspecting defaults will see None now.