### PR TITLE
ci: add riscv64 wheel builds

### DIFF
--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -35,6 +35,7 @@ jobs:
           # this is only meaningful on linux. windows and macos ignore exclude all but one arch
           - "aarch64"
           - "x86_64"
+          - "riscv64"
 
         include:
           # create pure python build
@@ -54,11 +55,25 @@ jobs:
             linux_archs: "aarch64"
           - os: "ubuntu-22.04-arm"
             linux_archs: "x86_64"
+          - os: "windows-2022"
+            linux_archs: "riscv64"
+          - os: "windows-11-arm"
+            linux_archs: "riscv64"
+          - os: "macos-15"
+            linux_archs: "riscv64"
+          - os: "ubuntu-22.04-arm"
+            linux_archs: "riscv64"
 
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        if: matrix.linux_archs == 'riscv64'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: riscv64
 
       - name: Remove tag-build from pyproject.toml
         # sqlalchemy has `tag-build` set to `dev` in pyproject.toml. It needs to be removed before creating the wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -364,4 +364,4 @@ archs = ["arm64"]
 # On an Linux Intel runner with qemu installed, build Intel and ARM wheels
 # NOTE: this is overridden in the pipeline using the CIBW_ARCHS_LINUX env variable to speed up the build
 [tool.cibuildwheel.linux]
-archs = ["x86_64", "aarch64"]
+archs = ["x86_64", "aarch64", "riscv64"]


### PR DESCRIPTION
Add riscv64 to the wheel build matrix using QEMU emulation on ubuntu-22.04.

## Changes

- Add `riscv64` to `linux_archs` matrix in `create-wheels.yaml`
- Exclude riscv64 from non-Linux runners (Windows, macOS, ARM)
- Add QEMU setup step for riscv64
- Add `riscv64` to `archs` in `pyproject.toml` cibuildwheel config

Built successfully from source on native riscv64 hardware (BananaPi F3, SpacemiT K1).