### PR TITLE
fix: treat with_for_update=False same as None in Session.get

### DIFF
--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -3907,7 +3907,7 @@ class Session(_SessionClassMethods, EventTarget):
         if (
             not populate_existing
             and not mapper.always_refresh
-            and with_for_update is None
+            and not with_for_update
         ):
             instance = self._identity_lookup(
                 mapper,


### PR DESCRIPTION
## Summary
Fixes #13176.
**Root cause:** `Session.get()` bypassed the identity map when `with_for_update=False` was passed, because the check was `is not None` instead of a truthiness check. This caused unnecessary SQL queries.
**Fix:** Changed the condition to use truthiness check so `False` is treated the same as `None`.
## Changes
- `lib/sqlalchemy/orm/session.py`: Updated `with_for_update` check to use truthiness
## Testing
- Verified fix prevents unnecessary SQL when with_for_update=False
- Change is minimal and follows existing code patterns

Made with [Cursor](https://cursor.com)