### PR TITLE
fix: use balanced parenthesis check in PG check constraint reflection

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -5503,9 +5503,27 @@ class PGDialect(default.DefaultDialect):
                 util.warn("Could not parse CHECK constraint text: %r" % src)
                 sqltext = ""
             else:
-                sqltext = re.compile(
-                    r"^[\s\n]*\((.+)\)[\s\n]*$", flags=re.DOTALL
-                ).sub(r"\1", m.group(1))
+                sqltext = m.group(1).strip()
+                # Only strip outer parens if they wrap the entire expression
+                # (balanced). Naive regex strips first ( and last ), corrupting
+                # compound expressions like (a) AND (b).
+                if (
+                    sqltext.startswith("(")
+                    and sqltext.endswith(")")
+                    and len(sqltext) >= 2
+                ):
+                    inner = sqltext[1:-1]
+                    depth = 0
+                    for ch in inner:
+                        if ch == "(":
+                            depth += 1
+                        elif ch == ")":
+                            depth -= 1
+                            if depth < 0:
+                                break
+                    else:
+                        if depth == 0:
+                            sqltext = inner
             entry = {
                 "name": check_name,
                 "sqltext": sqltext,

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -2713,6 +2713,36 @@ class ReflectionTest(
         ):
             testing.db.dialect.get_check_constraints(conn, "foo")
 
+    def test_reflect_check_constraint_compound_expr_no_strip(self):
+        # Compound expressions like (a) AND (b) must not have outer parens
+        # stripped, as first ( and last ) are not a matching pair.
+        rows = [
+            (
+                "foo",
+                "broken",
+                "CHECK ((x IS NULL OR y IS NULL) AND (x IS NULL OR y IS NULL))",
+                None,
+            ),
+        ]
+        conn = mock.Mock(
+            execute=lambda *arg, **kw: mock.MagicMock(
+                fetchall=lambda: rows, __iter__=lambda self: iter(rows)
+            )
+        )
+        check_constraints = testing.db.dialect.get_check_constraints(
+            conn, "foo"
+        )
+        eq_(
+            check_constraints,
+            [
+                {
+                    "name": "broken",
+                    "sqltext": "(x IS NULL OR y IS NULL) AND (x IS NULL OR y IS NULL)",
+                    "comment": None,
+                }
+            ],
+        )
+
     def test_reflect_extra_newlines(self):
         rows = [
             (


### PR DESCRIPTION
## Summary
Fixes #13157.
**Root cause:** Check constraint reflection naively stripped one pair of outer parentheses, corrupting compound expressions where the first opening paren did not match the last closing paren.
**Fix:** Added balanced parenthesis validation before stripping outer parens.
## Changes
- `lib/sqlalchemy/dialects/postgresql/base.py`: Replaced naive regex with balanced parenthesis check
- `test/dialect/postgresql/test_reflection.py`: Added test for compound expression case
## Testing
- Verified compound expressions are preserved correctly
- Change is minimal and follows existing code patterns

Made with [Cursor](https://cursor.com)