### PR TITLE
Fix floordiv (//) for float/numeric by int with div_is_floordiv dialects

### DIFF
--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -3318,6 +3318,7 @@ class SQLCompiler(Compiled):
         if (
             self.dialect.div_is_floordiv
             and binary.right.type._type_affinity is sqltypes.Integer
+            and binary.left.type._type_affinity is sqltypes.Integer
         ):
             return (
                 self.process(binary.left, **kw)

--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -2825,6 +2825,33 @@ class MathOperatorTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     def test_floordiv_op_numeric(self):
         self.assert_compile(5.10 // literal(5.5), "FLOOR(:param_1 / :param_2)")
 
+    def test_floordiv_float_by_int(self):
+        """float // int must include FLOOR even with div_is_floordiv dialect"""
+        expr = column("a", Float()) // column("b", Integer())
+        self.assert_compile(
+            expr,
+            "FLOOR(a / b)",
+            dialect=postgresql.dialect(),
+        )
+
+    def test_floordiv_numeric_by_int(self):
+        """numeric // int must include FLOOR even with div_is_floordiv dialect"""
+        expr = column("a", Numeric()) // column("b", Integer())
+        self.assert_compile(
+            expr,
+            "FLOOR(a / b)",
+            dialect=postgresql.dialect(),
+        )
+
+    def test_floordiv_int_by_int_pg(self):
+        """int // int can skip FLOOR when dialect has div_is_floordiv"""
+        expr = column("a", Integer()) // column("b", Integer())
+        self.assert_compile(
+            expr,
+            "a / b",
+            dialect=postgresql.dialect(),
+        )
+
     @testing.combinations(
         ("format", "mytable.myid %% %s"),
         ("qmark", "mytable.myid % ?"),


### PR DESCRIPTION
When a dialect has `div_is_floordiv=True` (e.g. PostgreSQL), integer `/` already truncates toward zero. However, `visit_floordiv_binary` was skipping the `FLOOR()` wrapper whenever the **right** operand was `Integer`, even if the **left** operand was `Float` or `Numeric`. This produced incorrect SQL like `foo.float_col / foo.int_col` instead of `FLOOR(foo.float_col / foo.int_col)`.

**Fix:** only skip `FLOOR()` when **both** operands are `Integer`.

**Before** (PostgreSQL dialect):
```
float_col // int_col:    foo.float_col / foo.int_col       (WRONG - no floor)
numeric_col // int_col:  foo.numeric_col / foo.int_col     (WRONG - no floor)
int_col // int_col2:     foo.int_col / foo.int_col2         (correct)
```

**After:**
```
float_col // int_col:    FLOOR(foo.float_col / foo.int_col)  (CORRECT)
numeric_col // int_col:  FLOOR(foo.numeric_col / foo.int_col) (CORRECT)
int_col // int_col2:     foo.int_col / foo.int_col2           (still correct)
```

Fixes: #10528

cc @zzzeek