### PR TITLE
Change annotation of `Column.table` to `Optional[Table]` to indicate the attribute can be null

### DIFF
--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -2447,7 +2447,7 @@ class Column(DialectKWArgs, SchemaItem, ColumnClause[_T], Named[_T]):
 
         self._extra_kwargs(**dialect_kwargs)
 
-    table: Table
+    table: Optional[Table]
 
     constraints: Set[Constraint]
 


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

The `table` attribute is initialized to `None` in

https://github.com/sqlalchemy/sqlalchemy/blob/38e0fc2dd095e2710ffcc20fd7eccebb2fa25048/lib/sqlalchemy/sql/elements.py#L5412-L5420

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
