### PR TITLE
fix: PostgreSQL check constraint reflection strips brackets naively

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1831,6 +1831,30 @@ from ...types import TEXT
 from ...types import UUID as UUID
 from ...types import VARCHAR
 
+
+def _strip_outer_parens(text):
+    """Strip only balanced outer parentheses from constraint text.
+
+    Unlike a naive greedy regex, this correctly handles expressions
+    like '(a > 1) AND (b < 2)' where inner parens must be preserved.
+    """
+    text = text.strip()
+    if not text.startswith("(") or not text.endswith(")"):
+        return text
+    depth = 0
+    for i, ch in enumerate(text):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        if depth == 0:
+            # Found the closing paren matching the first opening paren
+            if i == len(text) - 1:
+                return text[1:-1].strip()
+            return text
+    return text
+
+
 IDX_USING = re.compile(r"^(?:btree|hash|gist|gin|[\w_]+)$", re.I)
 
 RESERVED_WORDS = {
@@ -5503,9 +5527,7 @@ class PGDialect(default.DefaultDialect):
                 util.warn("Could not parse CHECK constraint text: %r" % src)
                 sqltext = ""
             else:
-                sqltext = re.compile(
-                    r"^[\s\n]*\((.+)\)[\s\n]*$", flags=re.DOTALL
-                ).sub(r"\1", m.group(1))
+                sqltext = _strip_outer_parens(m.group(1))
             entry = {
                 "name": check_name,
                 "sqltext": sqltext,


### PR DESCRIPTION
## Description
Fix PostgreSQL CHECK constraint reflection that naively strips brackets from constraint expressions, producing syntactically invalid SQL.

## Problem
When reflecting CHECK constraints from PostgreSQL, the code uses a greedy regex `(.+)` to strip outer parentheses. This regex naively matches the first `(` and last `)` in the expression, ignoring balanced inner parentheses.

For a constraint like `(x IS NULL OR y IS NULL) AND (x IS NULL OR y IS NULL)`, the regex strips the first `(` and last `)`, producing `x IS NULL OR y IS NULL) AND (x IS NULL OR y IS NULL` — syntactically invalid SQL.

## Solution
Replace the greedy regex with a proper balanced-parenthesis stripping function (`_strip_outer_parens`) that:
1. Only removes outer parentheses when the closing paren at depth 0 matches the opening paren
2. Preserves inner parenthesized subexpressions intact

## Tests
Verified with the exact case from the issue:
- Input: `(x IS NULL OR y IS NULL) AND (x IS NULL OR y IS NULL)`
- Before (buggy): `x IS NULL OR y IS NULL) AND (x IS NULL OR y IS NULL`
- After (fixed): `(x IS NULL OR y IS NULL) AND (x IS NULL OR y IS NULL)` ✅

Also verified:
- `((a > 1) AND (a < 5))` → `(a > 1) AND (a < 5)` ✅
- `(a > 1)` → `a > 1` ✅
- `a > 1` → `a > 1` (no parens, unchanged) ✅

Closes: #13157
