### PR TITLE
postgresql: harden two-phase xid SQL literal quoting

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -3687,19 +3687,21 @@ class PGDialect(default.DefaultDialect):
         self.do_begin(connection.connection)
 
     def do_prepare_twophase(self, connection, xid):
-        connection.exec_driver_sql("PREPARE TRANSACTION '%s'" % xid)
+        xid_literal = self._twophase_xid_literal(xid)
+        connection.exec_driver_sql(f"PREPARE TRANSACTION {xid_literal}")
 
     def do_rollback_twophase(
         self, connection, xid, is_prepared=True, recover=False
     ):
         if is_prepared:
+            xid_literal = self._twophase_xid_literal(xid)
             if recover:
                 # FIXME: ugly hack to get out of transaction
                 # context when committing recoverable transactions
                 # Must find out a way how to make the dbapi not
                 # open a transaction.
                 connection.exec_driver_sql("ROLLBACK")
-            connection.exec_driver_sql("ROLLBACK PREPARED '%s'" % xid)
+            connection.exec_driver_sql(f"ROLLBACK PREPARED {xid_literal}")
             connection.exec_driver_sql("BEGIN")
             self.do_rollback(connection.connection)
         else:
@@ -3709,13 +3711,17 @@ class PGDialect(default.DefaultDialect):
         self, connection, xid, is_prepared=True, recover=False
     ):
         if is_prepared:
+            xid_literal = self._twophase_xid_literal(xid)
             if recover:
                 connection.exec_driver_sql("ROLLBACK")
-            connection.exec_driver_sql("COMMIT PREPARED '%s'" % xid)
+            connection.exec_driver_sql(f"COMMIT PREPARED {xid_literal}")
             connection.exec_driver_sql("BEGIN")
             self.do_rollback(connection.connection)
         else:
             self.do_commit(connection.connection)
+
+    def _twophase_xid_literal(self, xid):
+        return sql_util._quote_ddl_expr(xid)
 
     def do_recover_twophase(self, connection):
         return connection.scalars(

--- a/lib/sqlalchemy/dialects/postgresql/provision.py
+++ b/lib/sqlalchemy/dialects/postgresql/provision.py
@@ -11,6 +11,7 @@ import time
 from ... import exc
 from ... import inspect
 from ... import text
+from ...sql import util as sql_util
 from ...testing import warn_test_suite
 from ...testing.provision import create_db
 from ...testing.provision import drop_all_schema_objects_post_tables
@@ -97,7 +98,8 @@ def drop_all_schema_objects_pre_tables(cfg, eng):
         for xid in conn.exec_driver_sql(
             "select gid from pg_prepared_xacts"
         ).scalars():
-            conn.exec_driver_sql("ROLLBACK PREPARED '%s'" % xid)
+            xid_literal = sql_util._quote_ddl_expr(xid)
+            conn.exec_driver_sql(f"ROLLBACK PREPARED {xid_literal}")
 
 
 @drop_all_schema_objects_post_tables.for_db("postgresql")

--- a/lib/sqlalchemy/dialects/postgresql/psycopg.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg.py
@@ -622,8 +622,9 @@ class PGDialect_psycopg(_PGDialect_common_psycopg):
         self, connection, xid, is_prepared=True, recover=False
     ):
         if is_prepared:
+            xid_literal = self._twophase_xid_literal(xid)
             self._do_prepared_twophase(
-                connection, f"ROLLBACK PREPARED '{xid}'", recover=recover
+                connection, f"ROLLBACK PREPARED {xid_literal}", recover=recover
             )
         else:
             self.do_rollback(connection.connection)
@@ -632,8 +633,9 @@ class PGDialect_psycopg(_PGDialect_common_psycopg):
         self, connection, xid, is_prepared=True, recover=False
     ):
         if is_prepared:
+            xid_literal = self._twophase_xid_literal(xid)
             self._do_prepared_twophase(
-                connection, f"COMMIT PREPARED '{xid}'", recover=recover
+                connection, f"COMMIT PREPARED {xid_literal}", recover=recover
             )
         else:
             self.do_commit(connection.connection)

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -158,6 +158,39 @@ class DialectTest(fixtures.TestBase):
         ]:
             eq_(dialect._get_server_version_info(mock_conn(string)), version)
 
+    def test_twophase_xid_literal_quotes_single_quotes(self):
+        dialect = postgresql.dialect()
+        eq_(dialect._twophase_xid_literal("x'1"), "'x''1'")
+
+    def test_do_prepare_twophase_uses_quoted_xid(self):
+        dialect = postgresql.dialect()
+        conn = mock.Mock(exec_driver_sql=mock.Mock())
+
+        dialect.do_prepare_twophase(conn, "x'1")
+
+        eq_(
+            conn.exec_driver_sql.mock_calls,
+            [mock.call("PREPARE TRANSACTION 'x''1'")],
+        )
+
+    def test_psycopg_twophase_commands_use_quoted_xid(self):
+        dialect = psycopg_dialect.dialect()
+        conn = mock.Mock()
+        dialect._do_prepared_twophase = mock.Mock()
+
+        dialect.do_commit_twophase(conn, "x'1", is_prepared=True, recover=False)
+        dialect.do_rollback_twophase(
+            conn, "x'1", is_prepared=True, recover=False
+        )
+
+        eq_(
+            dialect._do_prepared_twophase.mock_calls,
+            [
+                mock.call(conn, "COMMIT PREPARED 'x''1'", recover=False),
+                mock.call(conn, "ROLLBACK PREPARED 'x''1'", recover=False),
+            ],
+        )
+
     @testing.only_on("postgresql")
     def test_ensure_version_is_qualified(
         self, future_connection, testing_engine, metadata


### PR DESCRIPTION
### Description

  This PR introduces a defensive hardening change for PostgreSQL two-phase transaction SQL string construction.

  It replaces direct %s interpolation of xid in:

  - PREPARE TRANSACTION
  - COMMIT PREPARED
  - ROLLBACK PREPARED

  with SQL-quoted literals using existing internal helpers.

  Updated locations:

  - PostgreSQL base dialect twophase methods
  - PostgreSQL psycopg twophase command composition
  - PostgreSQL provision cleanup path (ROLLBACK PREPARED)

  Tests added:

  - verifies single-quote escaping in twophase xid literal rendering
  - verifies generated SQL command strings for base dialect and psycopg dialect paths

  This is intended as a hardening/defensive coding improvement; no behavior change is expected for normal valid xid
  values.

  ### Checklist

  This pull request is:

  - [x] A short code fix
      - Related to defensive hardening requested by maintainer feedback
      - Includes tests for command construction and quoting behavior
  - [ ] A documentation / typographical / small typing error fix
  - [ ] A new feature implementation
 
