### PR TITLE
feature - implemented configurable chunksize parameter for selectinload

### DIFF
--- a/doc/build/changelog/unreleased_21/11450.rst
+++ b/doc/build/changelog/unreleased_21/11450.rst
@@ -1,0 +1,8 @@
+. change::
+  :tags: orm, loader options, feature
+  :tickets: 11450
+
+  Added `chunksize` parameter to :func`.selectinload` allowing users
+  to configure the number of primary keys sent per IN clause when loading
+  reltaionships. 
+  Pull request courtesy bekapono

--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -2972,6 +2972,21 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
 
     _chunksize = 500
 
+    @classmethod
+    def _set_chunksize(cls, loadopt) -> int:
+        if loadopt is None or hasattr(loadopt, "local_opts") is None:
+            return cls._chunksize
+
+        user_input = loadopt.local_opts.get("chunksize", None)
+        if user_input is None:
+            return cls._chunksize
+        elif not isinstance(user_input, int) or user_input < 1:
+            raise ValueError(
+                f"'{user_input}' is not an appropriate input, "
+                f"please use a positive non-zero integer."
+            )
+        return user_input
+
     def __init__(self, parent, strategy_key):
         super().__init__(parent, strategy_key)
         self.join_depth = self.parent_property.join_depth
@@ -3335,6 +3350,8 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
                     _setup_outermost_orderby, self.parent_property
                 )
 
+        chunksize = self._set_chunksize(loadopt)
+
         if query_info.load_only_child:
             self._load_via_child(
                 our_states,
@@ -3343,10 +3360,16 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
                 q,
                 context,
                 execution_options,
+                chunksize,
             )
         else:
             self._load_via_parent(
-                our_states, query_info, q, context, execution_options
+                our_states,
+                query_info,
+                q,
+                context,
+                execution_options,
+                chunksize,
             )
 
     def _load_via_child(
@@ -3357,14 +3380,15 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
         q,
         context,
         execution_options,
+        chunksize,
     ):
         uselist = self.uselist
 
         # this sort is really for the benefit of the unit tests
         our_keys = sorted(our_states)
         while our_keys:
-            chunk = our_keys[0 : self._chunksize]
-            our_keys = our_keys[self._chunksize :]
+            chunk = our_keys[0:chunksize]
+            our_keys = our_keys[chunksize:]
             data = {
                 k: v
                 for k, v in context.session.execute(
@@ -3405,14 +3429,14 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
             state.get_impl(self.key).set_committed_value(state, dict_, None)
 
     def _load_via_parent(
-        self, our_states, query_info, q, context, execution_options
+        self, our_states, query_info, q, context, execution_options, chunksize
     ):
         uselist = self.uselist
         _empty_result = () if uselist else None
 
         while our_states:
-            chunk = our_states[0 : self._chunksize]
-            our_states = our_states[self._chunksize :]
+            chunk = our_states[0:chunksize]
+            our_states = our_states[chunksize:]
 
             primary_keys = [
                 key[0] if query_info.zero_idx else key

--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -2981,8 +2981,8 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
         if user_input is None:
             return cls._chunksize
         elif not isinstance(user_input, int) or user_input < 1:
-            raise ValueError(
-                f"'{user_input}' is not an appropriate input, "
+            raise sa_exc.InvalidRequestError(
+                f"'chunksize={user_input}' is not an appropriate input, "
                 f"please use a positive non-zero integer."
             )
         return user_input

--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -2981,7 +2981,7 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
         if user_input is None:
             return cls._chunksize
         elif not isinstance(user_input, int) or user_input < 1:
-            raise sa_exc.InvalidRequestError(
+            raise sa_exc.ArgumentError(
                 f"'chunksize={user_input}' is not an appropriate input, "
                 f"please use a positive non-zero integer."
             )

--- a/lib/sqlalchemy/orm/strategy_options.py
+++ b/lib/sqlalchemy/orm/strategy_options.py
@@ -402,11 +402,6 @@ class _AbstractLoad(traversals.GenerativeOnTraversal, LoaderOption):
          integer, the keys from the IN statement will be chunked relative
          to the passed parameter
 
-         .. note:: The :paramref:`_orm.selectinload.chunksize` only allows
-            configurability for use with selectinload() in strategies.py and
-            not for `_SelectInLoader._chunksize` use in loader.py
-
-
         .. seealso::
 
             :ref:`loading_toplevel`

--- a/lib/sqlalchemy/orm/strategy_options.py
+++ b/lib/sqlalchemy/orm/strategy_options.py
@@ -359,6 +359,7 @@ class _AbstractLoad(traversals.GenerativeOnTraversal, LoaderOption):
         self,
         attr: _AttrType,
         recursion_depth: Optional[int] = None,
+        chunksize: Optional[int] = None,
     ) -> Self:
         """Indicate that the given attribute should be loaded using
         SELECT IN eager loading.
@@ -397,6 +398,14 @@ class _AbstractLoad(traversals.GenerativeOnTraversal, LoaderOption):
          .. versionadded:: 2.0 added
             :paramref:`_orm.selectinload.recursion_depth`
 
+        :param chunksize: optional int; when set to a positive non-zero
+         integer, the keys from the IN statement will be chunked relative
+         to the passed parameter
+
+         .. note:: The :paramref:`_orm.selectinload.chunksize` only allows
+            configurability for use with selectinload() in strategies.py and
+            not for `_SelectInLoader._chunksize` use in loader.py
+
 
         .. seealso::
 
@@ -408,7 +417,7 @@ class _AbstractLoad(traversals.GenerativeOnTraversal, LoaderOption):
         return self._set_relationship_strategy(
             attr,
             {"lazy": "selectin"},
-            opts={"recursion_depth": recursion_depth},
+            opts={"recursion_depth": recursion_depth, "chunksize": chunksize},
         )
 
     def lazyload(self, attr: _AttrType) -> Self:
@@ -2435,10 +2444,15 @@ def subqueryload(*keys: _AttrType) -> _AbstractLoad:
 
 @loader_unbound_fn
 def selectinload(
-    *keys: _AttrType, recursion_depth: Optional[int] = None
+    *keys: _AttrType,
+    recursion_depth: Optional[int] = None,
+    chunksize: Optional[int] = None,
 ) -> _AbstractLoad:
     return _generate_from_keys(
-        Load.selectinload, keys, False, {"recursion_depth": recursion_depth}
+        Load.selectinload,
+        keys,
+        False,
+        {"recursion_depth": recursion_depth, "chunksize": chunksize},
     )
 
 

--- a/lib/sqlalchemy/orm/strategy_options.py
+++ b/lib/sqlalchemy/orm/strategy_options.py
@@ -402,6 +402,9 @@ class _AbstractLoad(traversals.GenerativeOnTraversal, LoaderOption):
          integer, the keys from the IN statement will be chunked relative
          to the passed parameter
 
+         .. versionadded:: 2.1rc1 added
+            :paramref:`_orm.selectinload.chunksize`
+
         .. seealso::
 
             :ref:`loading_toplevel`

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -2379,24 +2379,43 @@ class ChunkingTest(fixtures.DeclarativeMappedTest):
         )
         session.commit()
 
-    def test_odd_number_chunks(self):
+    @testing.combinations(True, False)
+    def test_odd_number_chunks(self, legacy):
         A, B = self.classes("A", "B")
 
         session = fixture_session()
 
         def go():
-            with mock.patch(
-                "sqlalchemy.orm.strategies._SelectInLoader._chunksize", 47
-            ):
-                q = session.query(A).options(selectinload(A.bs)).order_by(A.id)
+            if legacy:
+                with mock.patch(
+                    "sqlalchemy.orm.strategies._SelectInLoader._chunksize", 47
+                ):
+                    q = (
+                        session.query(A)
+                        .options(selectinload(A.bs))
+                        .order_by(A.id)
+                    )
 
-                for a in q:
-                    a.bs
+                    for a in q:
+                        a.bs
+            else:
+                statement = (
+                    select(A)
+                    .options(selectinload(A.bs, chunksize=47))
+                    .order_by(A.id)
+                )
+
+                q = session.scalars(statement).all()
+
+        if legacy:
+            initial_sql = "SELECT a.id AS a_id FROM a ORDER BY a.id"
+        else:
+            initial_sql = "SELECT a.id FROM a ORDER BY a.id"
 
         self.assert_sql_execution(
             testing.db,
             go,
-            CompiledSQL("SELECT a.id AS a_id FROM a ORDER BY a.id", {}),
+            CompiledSQL(initial_sql, {}),
             CompiledSQL(
                 "SELECT b.a_id, b.id "
                 "FROM b WHERE b.a_id IN "
@@ -2416,6 +2435,25 @@ class ChunkingTest(fixtures.DeclarativeMappedTest):
                 {"primary_keys": list(range(95, 101))},
             ),
         )
+
+    @testing.combinations(-250, "a", 0)
+    def test_chunksize_value_error(self, chunksize):
+        A, B = self.classes("A", "B")
+
+        session = fixture_session()
+
+        def go():
+            with testing.expect_raises_message(
+               ValueError,
+               ".*please use a positive non-zero integer.*"
+            ):
+                statement = (
+                    select(A)
+                    .options(selectinload(A.bs, chunksize=chunksize))
+                    .order_by(A.id)
+                )
+
+                q = session.scalars(statement).all()
 
     @testing.requires.independent_cursors
     def test_yield_per(self):
@@ -2489,6 +2527,152 @@ class ChunkingTest(fixtures.DeclarativeMappedTest):
                 "SELECT a.id FROM a WHERE a.id IN "
                 "(__[POSTCOMPILE_primary_keys])",
                 {"primary_keys": list(range(95, 101))},
+            ),
+        )
+
+
+class ChainedChunkingTest(fixtures.DeclarativeMappedTest):
+    @classmethod
+    def setup_mappers(cls):
+        Base = cls.DeclarativeBasic
+
+        class A(ComparableEntity, Base):
+            __tablename__ = "a"
+            id = Column(Integer, primary_key=True)
+            bs = relationship("B", order_by="B.id", back_populates="a")
+
+        class B(ComparableEntity, Base):
+            __tablename__ = "b"
+            id = Column(Integer, primary_key=True)
+            a_id = Column(ForeignKey("a.id"))
+            a = relationship("A", back_populates="bs")
+            cs = relationship("C", order_by="C.id", back_populates="b")
+
+        class C(ComparableEntity, Base):
+            __tablename__ = "c"
+            id = Column(Integer, primary_key=True)
+            b_id = Column(ForeignKey("b.id"))
+            b = relationship("B", back_populates="cs")
+
+    @classmethod
+    def insert_data(cls, connection):
+        A, B, C = cls.classes("A", "B", "C")
+
+        session = Session(connection)
+
+        for i in range(1, 6):
+            b_list = []
+            for j in range(1, 4):
+                b_id = (i * 6) + j
+                c_id = b_id + 1
+
+                b_list.append(B(id=b_id, cs=[C(id=c_id)]))
+            session.add(A(id=i, bs=b_list))
+        session.commit()
+
+    def test_chained_selectinload_with_two_custom_chunksize(self):
+        A, B, C = self.classes("A", "B", "C")
+
+        b_list = [7, 8, 9, 13, 14, 15, 19, 20, 21, 25, 26, 27, 31, 32, 33]
+
+        session = fixture_session()
+
+        def go():
+            statement = (
+                select(A)
+                .options(
+                    selectinload(A.bs, chunksize=3).selectinload(
+                        B.cs, chunksize=4
+                    )
+                )
+                .order_by(A.id)
+            )
+            q = session.scalars(statement).all()
+
+        self.assert_sql_execution(
+            testing.db,
+            go,
+            CompiledSQL("SELECT a.id FROM a ORDER BY a.id", {}),
+            CompiledSQL(
+                "SELECT b.a_id, b.id "
+                "FROM b WHERE b.a_id IN "
+                "(__[POSTCOMPILE_primary_keys]) ORDER BY b.id",
+                {"primary_keys": list(range(1, 4))},
+            ),
+            CompiledSQL(
+                "SELECT b.a_id, b.id "
+                "FROM b WHERE b.a_id IN "
+                "(__[POSTCOMPILE_primary_keys]) ORDER BY b.id",
+                {"primary_keys": list(range(4, 6))},
+            ),
+            CompiledSQL(
+                "SELECT c.b_id, c.id "
+                "FROM c WHERE c.b_id IN "
+                "(__[POSTCOMPILE_primary_keys]) ORDER BY c.id",
+                {"primary_keys": b_list[0:4]},
+            ),
+            CompiledSQL(
+                "SELECT c.b_id, c.id "
+                "FROM c WHERE c.b_id IN "
+                "(__[POSTCOMPILE_primary_keys]) ORDER BY c.id",
+                {"primary_keys": b_list[4:8]},
+            ),
+            CompiledSQL(
+                "SELECT c.b_id, c.id "
+                "FROM c WHERE c.b_id IN "
+                "(__[POSTCOMPILE_primary_keys]) ORDER BY c.id",
+                {"primary_keys": b_list[8:12]},
+            ),
+            CompiledSQL(
+                "SELECT c.b_id, c.id "
+                "FROM c WHERE c.b_id IN "
+                "(__[POSTCOMPILE_primary_keys]) ORDER BY c.id",
+                {"primary_keys": b_list[12:]},
+            ),
+        )
+
+    def test_chained_selectinload_with_one_chunksize(self):
+        """
+        This test is to make sure that a previous custom chunksize doesn't
+        effect chunksize in remaining selectinload
+        """
+
+        A, B, C = self.classes("A", "B", "C")
+
+        b_list = [7, 8, 9, 13, 14, 15, 19, 20, 21, 25, 26, 27, 31, 32, 33]
+
+        session = fixture_session()
+
+        def go():
+            statement = (
+                select(A)
+                .options(selectinload(A.bs, chunksize=3).selectinload(B.cs))
+                .order_by(A.id)
+            )
+
+            q = session.scalars(statement).all()
+
+        self.assert_sql_execution(
+            testing.db,
+            go,
+            CompiledSQL("SELECT a.id FROM a ORDER BY a.id", {}),
+            CompiledSQL(
+                "SELECT b.a_id, b.id "
+                "FROM b WHERE b.a_id IN "
+                "(__[POSTCOMPILE_primary_keys]) ORDER BY b.id",
+                {"primary_keys": list(range(1, 4))},
+            ),
+            CompiledSQL(
+                "SELECT b.a_id, b.id "
+                "FROM b WHERE b.a_id IN "
+                "(__[POSTCOMPILE_primary_keys]) ORDER BY b.id",
+                {"primary_keys": list(range(4, 6))},
+            ),
+            CompiledSQL(
+                "SELECT c.b_id, c.id "
+                "FROM c WHERE c.b_id IN "
+                "(__[POSTCOMPILE_primary_keys]) ORDER BY c.id",
+                {"primary_keys": b_list},
             ),
         )
 

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -2442,7 +2442,8 @@ class ChunkingTest(fixtures.DeclarativeMappedTest):
 
         def go():
             with testing.expect_raises_message(
-                ValueError, ".*please use a positive non-zero integer.*"
+                sa.exc.InvalidRequestError,
+                ".*please use a positive non-zero integer.*",
             ):
                 select(A).options(
                     selectinload(A.bs, chunksize=chunksize)

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -2405,7 +2405,7 @@ class ChunkingTest(fixtures.DeclarativeMappedTest):
                     .order_by(A.id)
                 )
 
-                q = session.scalars(statement).all()
+                session.scalars(statement).all()
 
         if legacy:
             initial_sql = "SELECT a.id AS a_id FROM a ORDER BY a.id"
@@ -2440,20 +2440,13 @@ class ChunkingTest(fixtures.DeclarativeMappedTest):
     def test_chunksize_value_error(self, chunksize):
         A, B = self.classes("A", "B")
 
-        session = fixture_session()
-
         def go():
             with testing.expect_raises_message(
-               ValueError,
-               ".*please use a positive non-zero integer.*"
+                ValueError, ".*please use a positive non-zero integer.*"
             ):
-                statement = (
-                    select(A)
-                    .options(selectinload(A.bs, chunksize=chunksize))
-                    .order_by(A.id)
-                )
-
-                q = session.scalars(statement).all()
+                select(A).options(
+                    selectinload(A.bs, chunksize=chunksize)
+                ).order_by(A.id)
 
     @testing.requires.independent_cursors
     def test_yield_per(self):
@@ -2587,7 +2580,8 @@ class ChainedChunkingTest(fixtures.DeclarativeMappedTest):
                 )
                 .order_by(A.id)
             )
-            q = session.scalars(statement).all()
+
+            session.scalars(statement).all()
 
         self.assert_sql_execution(
             testing.db,
@@ -2650,7 +2644,7 @@ class ChainedChunkingTest(fixtures.DeclarativeMappedTest):
                 .order_by(A.id)
             )
 
-            q = session.scalars(statement).all()
+            session.scalars(statement).all()
 
         self.assert_sql_execution(
             testing.db,

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -2379,61 +2379,41 @@ class ChunkingTest(fixtures.DeclarativeMappedTest):
         )
         session.commit()
 
-    @testing.combinations(True, False)
-    def test_odd_number_chunks(self, legacy):
+    @testing.combinations(
+        (None, (1, 101)),
+        (47, (1, 48, 95, 101)),
+        (50, (1, 51, 101)),
+        (99, (1, 100, 101)),
+        (108, (1, 101)),
+        argnames="chunksize, expected_range",
+    )
+    def test_odd_number_chunks(self, chunksize, expected_range):
         A, B = self.classes("A", "B")
 
         session = fixture_session()
 
         def go():
-            if legacy:
-                with mock.patch(
-                    "sqlalchemy.orm.strategies._SelectInLoader._chunksize", 47
-                ):
-                    q = (
-                        session.query(A)
-                        .options(selectinload(A.bs))
-                        .order_by(A.id)
-                    )
+            statement = (
+                select(A)
+                .options(selectinload(A.bs, chunksize=chunksize))
+                .order_by(A.id)
+            )
 
-                    for a in q:
-                        a.bs
-            else:
-                statement = (
-                    select(A)
-                    .options(selectinload(A.bs, chunksize=47))
-                    .order_by(A.id)
-                )
-
-                session.scalars(statement).all()
-
-        if legacy:
-            initial_sql = "SELECT a.id AS a_id FROM a ORDER BY a.id"
-        else:
-            initial_sql = "SELECT a.id FROM a ORDER BY a.id"
+            session.scalars(statement).all()
 
         self.assert_sql_execution(
             testing.db,
             go,
-            CompiledSQL(initial_sql, {}),
-            CompiledSQL(
-                "SELECT b.a_id, b.id "
-                "FROM b WHERE b.a_id IN "
-                "(__[POSTCOMPILE_primary_keys]) ORDER BY b.id",
-                {"primary_keys": list(range(1, 48))},
-            ),
-            CompiledSQL(
-                "SELECT b.a_id, b.id "
-                "FROM b WHERE b.a_id IN "
-                "(__[POSTCOMPILE_primary_keys]) ORDER BY b.id",
-                {"primary_keys": list(range(48, 95))},
-            ),
-            CompiledSQL(
-                "SELECT b.a_id, b.id "
-                "FROM b WHERE b.a_id IN "
-                "(__[POSTCOMPILE_primary_keys]) ORDER BY b.id",
-                {"primary_keys": list(range(95, 101))},
-            ),
+            CompiledSQL("SELECT a.id FROM a ORDER BY a.id", {}),
+            *[
+                CompiledSQL(
+                    "SELECT b.a_id, b.id "
+                    "FROM b WHERE b.a_id IN "
+                    "(__[POSTCOMPILE_primary_keys]) ORDER BY b.id",
+                    {"primary_keys": list(range(a, b))},
+                )
+                for a, b in zip(expected_range, expected_range[1:])
+            ],
         )
 
     @testing.combinations(-250, "a", 0)
@@ -2442,7 +2422,7 @@ class ChunkingTest(fixtures.DeclarativeMappedTest):
 
         def go():
             with testing.expect_raises_message(
-                sa.exc.InvalidRequestError,
+                sa.exc.ArgumentError,
                 ".*please use a positive non-zero integer.*",
             ):
                 select(A).options(


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
This change adds a chunksize parameter to `selectinload()` that allows users to configure the number of primary keys sent per IN clause when loading relationships.

Previously, chunksize was a fixed class variable (500) used in `load_via_child` and `load_via_parent` within `_SelectInLoader` in `strategies.py`, and `_load_via_subclass_in` in `loading.py`. This change replaces direct calls to the class variable within `_SelectInLoader` with a configurable parameter passed through the existing `opts`/`local_opts` dictionary, following the same pattern as `recursion_depth`. The chunksize logic in `loading.py`, which is outside of `_SelectInLoader`, is unchanged and NOT configurable.

The parameter is validated in `set_chunksize` to verify the input is a positive non-zero integer. If `local_opts` or `loadopts` is not present the fixed class variable default is used. For cases where validation fails a `ValueError` is raised.

These changes DO NOT impose a maximum chunksize limit. Since maximum chunksize is dialect dependent, we rely on each dialect to detect and handle cases where the provided chunksize exceeds its supported limit.

Fixes #11450
### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
