### PR TITLE
Add mypy ignore comments for Python 3.14 module imports

### DIFF
--- a/lib/sqlalchemy/sql/_elements_constructors.py
+++ b/lib/sqlalchemy/sql/_elements_constructors.py
@@ -53,7 +53,7 @@ from .elements import WithinGroup
 from .functions import FunctionElement
 
 if typing.TYPE_CHECKING:
-    from string.templatelib import Template
+    from string.templatelib import Template  # type: ignore[import-not-found]
 
     from ._typing import _ByArgument
     from ._typing import _ColumnExpressionArgument

--- a/lib/sqlalchemy/sql/_elements_constructors.py
+++ b/lib/sqlalchemy/sql/_elements_constructors.py
@@ -53,8 +53,6 @@ from .elements import WithinGroup
 from .functions import FunctionElement
 
 if typing.TYPE_CHECKING:
-    from string.templatelib import Template  # type: ignore[import-not-found]
-
     from ._typing import _ByArgument
     from ._typing import _ColumnExpressionArgument
     from ._typing import _ColumnExpressionOrLiteralArgument
@@ -66,6 +64,7 @@ if typing.TYPE_CHECKING:
     from .elements import FrameClause
     from .selectable import FromClause
     from .type_api import TypeEngine
+    from ..util.compat import Template
 
 _T = TypeVar("_T")
 

--- a/lib/sqlalchemy/util/compat.py
+++ b/lib/sqlalchemy/util/compat.py
@@ -31,7 +31,6 @@ from typing import Sequence
 from typing import Set
 from typing import Tuple
 from typing import Type
-from typing import TYPE_CHECKING
 
 py314b1 = sys.version_info >= (3, 14, 0, "beta", 1)
 py314 = sys.version_info >= (3, 14)
@@ -51,9 +50,21 @@ has_refcount_gc = bool(cpython)
 
 dottedgetter = operator.attrgetter
 
-if py314 or TYPE_CHECKING:
-    from string.templatelib import Template as Template
+
+if py314:
+
+    import annotationlib  # type: ignore[import-not-found]
+    from string.templatelib import Template as Template  # type: ignore[import-not-found]  # noqa: E501
+
+    def get_annotations(obj: Any) -> Mapping[str, Any]:
+        return annotationlib.get_annotations(  # type: ignore[no-any-return]
+            obj, format=annotationlib.Format.FORWARDREF
+        )
+
 else:
+
+    def get_annotations(obj: Any) -> Mapping[str, Any]:
+        return inspect.get_annotations(obj)
 
     class Template:  # type: ignore[no-redef]
         """Minimal Template for Python < 3.14 (test usage only)."""
@@ -71,21 +82,6 @@ else:
 
         def __iter__(self) -> Any:
             return iter(self._parts)
-
-
-if py314:
-
-    import annotationlib
-
-    def get_annotations(obj: Any) -> Mapping[str, Any]:
-        return annotationlib.get_annotations(
-            obj, format=annotationlib.Format.FORWARDREF
-        )
-
-else:
-
-    def get_annotations(obj: Any) -> Mapping[str, Any]:
-        return inspect.get_annotations(obj)
 
 
 class FullArgSpec(typing.NamedTuple):

--- a/lib/sqlalchemy/util/compat.py
+++ b/lib/sqlalchemy/util/compat.py
@@ -51,13 +51,13 @@ has_refcount_gc = bool(cpython)
 dottedgetter = operator.attrgetter
 
 
-if py314:
+if sys.version_info >= (3, 14):
 
-    import annotationlib  # type: ignore[import-not-found]
-    from string.templatelib import Template as Template  # type: ignore[import-not-found]  # noqa: E501
+    import annotationlib
+    from string.templatelib import Template as Template
 
     def get_annotations(obj: Any) -> Mapping[str, Any]:
-        return annotationlib.get_annotations(  # type: ignore[no-any-return]
+        return annotationlib.get_annotations(
             obj, format=annotationlib.Format.FORWARDREF
         )
 
@@ -66,7 +66,7 @@ else:
     def get_annotations(obj: Any) -> Mapping[str, Any]:
         return inspect.get_annotations(obj)
 
-    class Template:  # type: ignore[no-redef]
+    class Template:
         """Minimal Template for Python < 3.14 (test usage only)."""
 
         def __init__(self, *parts: Any):

--- a/lib/sqlalchemy/util/compat.py
+++ b/lib/sqlalchemy/util/compat.py
@@ -51,6 +51,7 @@ has_refcount_gc = bool(cpython)
 dottedgetter = operator.attrgetter
 
 
+# use sys.version_info to enable mypy version narrowing
 if sys.version_info >= (3, 14):
 
     import annotationlib


### PR DESCRIPTION
Fixes #13240

Use `sys.version_info >= (3, 14)` instead of the `py314` variable for
the py314-only imports block (`annotationlib`, `string.templatelib`).

mypy has built-in support for `sys.version_info` guards and only
type-checks the reachable branch, while a plain variable like `py314`
causes mypy to check both branches — leading to `import-not-found` on
<3.14 and `unused-ignore` on 3.14 if `type: ignore` comments are added.