### PR TITLE
Fix typo "nad" -> "and" in DefaultDialect.construct_arguments docstring

### DIFF
--- a/lib/sqlalchemy/engine/interfaces.py
+++ b/lib/sqlalchemy/engine/interfaces.py
@@ -1131,7 +1131,7 @@ class Dialect(EventTarget):
 
     If the above construct is established on the PostgreSQL dialect,
     the :class:`.Index` construct will now accept the keyword arguments
-    ``postgresql_using``, ``postgresql_where``, nad ``postgresql_ops``.
+    ``postgresql_using``, ``postgresql_where``, and ``postgresql_ops``.
     Any other argument specified to the constructor of :class:`.Index`
     which is prefixed with ``postgresql_`` will raise :class:`.ArgumentError`.
 


### PR DESCRIPTION

**Repo:** sqlalchemy/sqlalchemy (⭐ 9000)
**Type:** docs
**Files changed:** 1
**Lines:** +1/-1

## What
Corrects a single-character typo (`nad` → `and`) in the docstring of
`DefaultDialect.construct_arguments` in `lib/sqlalchemy/engine/interfaces.py`.
The phrase appeared in an example explaining dialect-prefixed Index keyword
arguments and read "``postgresql_using``, ``postgresql_where``, nad
``postgresql_ops``".

## Why
The docstring is rendered into the public Sphinx docs for the dialect interface,
so the typo is user-visible. Trivial documentation hygiene with no behavior
impact.

## Testing
Pure docstring change; no runtime code path is affected. Verified the surrounding
docstring still reads naturally and that no other instances of "nad" exist in the
`lib/sqlalchemy` tree.

## Risk
Low — docstring-only, single-word fix.
