### PR TITLE
Accept OrderByLists in order_by 

### DIFF
--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -4503,9 +4503,12 @@ class GenerativeSelect(DialectKWArgs, SelectBase, Generative):
         __first: Union[
             Literal[None, _NoArg.NO_ARG],
             _ColumnExpressionOrStrLabelArgument[Any],
+            roles.OrderByRole,
         ] = _NoArg.NO_ARG,
         /,
-        *clauses: _ColumnExpressionOrStrLabelArgument[Any],
+        *clauses: Union[
+            _ColumnExpressionOrStrLabelArgument[Any], roles.OrderByRole
+        ],
     ) -> Self:
         r"""Return a new selectable with the given list of ORDER BY
         criteria applied.

--- a/test/typing/plain_files/sql/common_sql_element.py
+++ b/test/typing/plain_files/sql/common_sql_element.py
@@ -172,6 +172,11 @@ s12730_3 = select(A, B).with_for_update(of=[A, B])
 s12730_4 = select(A, B).with_for_update(of=[A, B])
 s12730_5 = select(a_table, b_table).with_for_update(of=[a_table, b_table])
 
+# test 13248 - freestanding asc/desc in order_by
+s13248_1 = select(User.id).order_by(asc(User.id))
+s13248_2 = select(User.id).order_by(desc(User.id))
+s13248_3 = select(User.id).order_by(User.id, asc(User.id))
+
 
 # with_for_update but for query
 session = Session()


### PR DESCRIPTION
Add OrderByRole to acceptable arguments for order_by

Fixes: #13248

### Description
Add OrderByRole to acceptable arguments for order_by to solve typing regression

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
