### PR TITLE
docs: fix incorrect execution context class reference

### DIFF
--- a/doc/build/core/defaults.rst
+++ b/doc/build/core/defaults.rst
@@ -164,7 +164,7 @@ is also called once for each set of parameters.
 
 When the function is invoked, the special method
 :meth:`.DefaultExecutionContext.get_current_parameters` is available from
-the context object (an subclass of :class:`.DefaultExecutionContext`).  This
+the context object (a subclass of :class:`.ExecutionContext`).  This
 method returns a dictionary of column-key to values that represents the
 full set of values for the INSERT or UPDATE statement.   In the case of a
 multi-valued INSERT construct, the subset of parameters that corresponds to


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description

Fixes an incorrect execution context class reference in the documentation and corrects a minor grammatical issue in the same paragraph.

### Checklist

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.