### PR TITLE
Fix PostgreSQL check constraint reflection stripping parentheses incorrectly

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -5505,44 +5505,36 @@ class PGDialect(default.DefaultDialect):
             # "CHECK (((a\n < 1)\n OR\n (a\n >= 5))\n)"
             # "CHECK (a NOT NULL) NO INHERIT"
             # "CHECK (a NOT NULL) NO INHERIT NOT VALID"
+            # "CHECK (c != 'hi')"
 
-            m = re.match(
-                r"^CHECK *\((.+)\)( NO INHERIT)?( NOT VALID)?$",
-                src,
-                flags=re.DOTALL,
-            )
-            if not m:
+            _suffix = ""
+            if not src.startswith("CHECK ("):
                 util.warn("Could not parse CHECK constraint text: %r" % src)
                 sqltext = ""
             else:
-                sqltext = m.group(1)
-                # Strip outer parens iteratively; regex greedy match
-                # breaks on nested expressions like ((a) AND (b)).
-                while True:
-                    s = sqltext.strip()
-                    if len(s) >= 2 and s[0] == "(" and s[-1] == ")":
-                        depth = matched = 0
-                        for i, c in enumerate(s):
-                            depth += (c == "(") - (c == ")")
-                            if depth == 0:
-                                if i == len(s) - 1:
-                                    sqltext = s[1:-1]
-                                    matched = 1
-                                break
-                        if not matched:
-                            break
-                    else:
-                        break
+                try:
+                    end = util.find_parentheses_end(src, len("CHECK (") - 1)
+                except ValueError:
+                    util.warn(
+                        "Could not parse CHECK constraint text: %r" % src
+                    )
+                    sqltext = ""
+                else:
+                    sqltext = util.strip_parentheses(
+                        src[len("CHECK (") : end - 1]
+                    )
+                    # Remaining text after the closing paren
+                    _suffix = src[end:].strip()
             entry = {
                 "name": check_name,
                 "sqltext": sqltext,
                 "comment": comment,
             }
-            if m:
+            if sqltext != "":
                 do = {}
-                if " NOT VALID" in m.groups():
+                if " NOT VALID" in _suffix:
                     do["not_valid"] = True
-                if " NO INHERIT" in m.groups():
+                if " NO INHERIT" in _suffix:
                     do["no_inherit"] = True
                 if do:
                     entry["dialect_options"] = do

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -5515,9 +5515,24 @@ class PGDialect(default.DefaultDialect):
                 util.warn("Could not parse CHECK constraint text: %r" % src)
                 sqltext = ""
             else:
-                sqltext = re.compile(
-                    r"^[\s\n]*\((.+)\)[\s\n]*$", flags=re.DOTALL
-                ).sub(r"\1", m.group(1))
+                sqltext = m.group(1)
+                # Strip outer parens iteratively; regex greedy match
+                # breaks on nested expressions like ((a) AND (b)).
+                while True:
+                    s = sqltext.strip()
+                    if len(s) >= 2 and s[0] == "(" and s[-1] == ")":
+                        depth = matched = 0
+                        for i, c in enumerate(s):
+                            depth += (c == "(") - (c == ")")
+                            if depth == 0:
+                                if i == len(s) - 1:
+                                    sqltext = s[1:-1]
+                                    matched = 1
+                                break
+                        if not matched:
+                            break
+                    else:
+                        break
             entry = {
                 "name": check_name,
                 "sqltext": sqltext,

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -5506,25 +5506,21 @@ class PGDialect(default.DefaultDialect):
             # "CHECK (a NOT NULL) NO INHERIT"
             # "CHECK (a NOT NULL) NO INHERIT NOT VALID"
             # "CHECK (c != 'hi')"
-
             _suffix = ""
             if not src.startswith("CHECK ("):
                 util.warn("Could not parse CHECK constraint text: %r" % src)
                 sqltext = ""
             else:
                 try:
-                    end = util.find_parentheses_end(src, len("CHECK (") - 1)
+                    sqltext, after_paren = util.consume_parenthesized_expression(
+                        src, len("CHECK (") - 1
+                    )
+                    _suffix = after_paren.strip()
                 except ValueError:
                     util.warn(
                         "Could not parse CHECK constraint text: %r" % src
                     )
                     sqltext = ""
-                else:
-                    sqltext = util.strip_parentheses(
-                        src[len("CHECK (") : end - 1]
-                    )
-                    # Remaining text after the closing paren
-                    _suffix = src[end:].strip()
             entry = {
                 "name": check_name,
                 "sqltext": sqltext,

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2876,31 +2876,21 @@ class SQLiteDialect(default.DefaultDialect):
                 )
 
             # Find the matching closing parenthesis by counting balanced parens
-            # Must track string context to ignore parens inside string literals
+            # Use the shared utility to find the matching closing paren,
+            # accounting for string literals
             start = match.end()  # Position after 'CHECK ('
-            paren_count = 1
-            in_single_quote = False
-            in_double_quote = False
 
-            for pos, char in enumerate(table_data[start:], start):
-                # Track string literal context
-                if char == "'" and not in_double_quote:
-                    in_single_quote = not in_single_quote
-                elif char == '"' and not in_single_quote:
-                    in_double_quote = not in_double_quote
-                # Only count parens when not inside a string literal
-                elif not in_single_quote and not in_double_quote:
-                    if char == "(":
-                        paren_count += 1
-                    elif char == ")":
-                        paren_count -= 1
-                        if paren_count == 0:
-                            # Successfully found matching closing parenthesis
-                            sqltext = table_data[start:pos].strip()
-                            cks.append(
-                                {"sqltext": sqltext, "name": constraint_name}
-                            )
-                            break
+            try:
+                close_end = util.find_parentheses_end(
+                    table_data, start - 1
+                )
+            except ValueError:
+                continue
+
+            sqltext = table_data[start : close_end - 1].strip()
+            cks.append(
+                {"sqltext": sqltext, "name": constraint_name}
+            )
 
         cks.sort(key=lambda d: d["name"] or "~")  # sort None as last
         if cks:

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2885,6 +2885,7 @@ class SQLiteDialect(default.DefaultDialect):
                     table_data, start - 1
                 )
             except ValueError:
+                # Unbalanced parentheses — skip this constraint
                 continue
 
             sqltext = table_data[start : close_end - 1].strip()

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2875,20 +2875,18 @@ class SQLiteDialect(default.DefaultDialect):
                     flags=re.DOTALL,
                 )
 
-            # Find the matching closing parenthesis by counting balanced parens
-            # Use the shared utility to find the matching closing paren,
-            # accounting for string literals
+            # Use the shared utility to extract the CHECK expression,
+            # accounting for string literals and nested parentheses
             start = match.end()  # Position after 'CHECK ('
 
             try:
-                close_end = util.find_parentheses_end(
+                sqltext, _end = util.consume_parenthesized_expression(
                     table_data, start - 1
                 )
+                sqltext = sqltext.strip()
             except ValueError:
                 # Unbalanced parentheses — skip this constraint
                 continue
-
-            sqltext = table_data[start : close_end - 1].strip()
             cks.append(
                 {"sqltext": sqltext, "name": constraint_name}
             )

--- a/lib/sqlalchemy/util/__init__.py
+++ b/lib/sqlalchemy/util/__init__.py
@@ -154,5 +154,7 @@ from .langhelpers import warn as warn
 from .langhelpers import warn_exception as warn_exception
 from .langhelpers import warn_limited as warn_limited
 from .langhelpers import wrap_callable as wrap_callable
+from .langhelpers import strip_parentheses as strip_parentheses
+from .langhelpers import find_parentheses_end as find_parentheses_end
 from .preloaded import preload_module as preload_module
 from .typing import is_non_string_iterable as is_non_string_iterable

--- a/lib/sqlalchemy/util/__init__.py
+++ b/lib/sqlalchemy/util/__init__.py
@@ -154,8 +154,6 @@ from .langhelpers import warn as warn
 from .langhelpers import warn_exception as warn_exception
 from .langhelpers import warn_limited as warn_limited
 from .langhelpers import wrap_callable as wrap_callable
-from .langhelpers import strip_parentheses as strip_parentheses
 from .langhelpers import consume_parenthesized_expression as consume_parenthesized_expression
-from .langhelpers import find_parentheses_end as find_parentheses_end
 from .preloaded import preload_module as preload_module
 from .typing import is_non_string_iterable as is_non_string_iterable

--- a/lib/sqlalchemy/util/__init__.py
+++ b/lib/sqlalchemy/util/__init__.py
@@ -155,6 +155,7 @@ from .langhelpers import warn_exception as warn_exception
 from .langhelpers import warn_limited as warn_limited
 from .langhelpers import wrap_callable as wrap_callable
 from .langhelpers import strip_parentheses as strip_parentheses
+from .langhelpers import consume_parenthesized_expression as consume_parenthesized_expression
 from .langhelpers import find_parentheses_end as find_parentheses_end
 from .preloaded import preload_module as preload_module
 from .typing import is_non_string_iterable as is_non_string_iterable

--- a/lib/sqlalchemy/util/langhelpers.py
+++ b/lib/sqlalchemy/util/langhelpers.py
@@ -2274,79 +2274,36 @@ def repr_tuple_names(names: List[str]) -> Optional[str]:
         return "%s, ..., %s" % (", ".join(res[0:3]), res[-1])
 
 
-def strip_parentheses(text: str) -> str:
-    """Strip outer balanced parentheses from *text*, taking string literals
-    into account.
+def consume_parenthesized_expression(text: str, start: int) -> tuple[str, int]:
+    """Extract a parenthesized expression starting at *start*.
 
-    This is used when reflecting CHECK constraint expressions, where
-    databases wrap the expression in parentheses (possibly multiple
-    levels).  The function walks the string character-by-character,
-    tracking parenthesis depth **and** whether we are inside a single- or
-    double-quoted string literal so that parentheses inside literals are
-    not counted.
+    Given *text* and the position of an opening ``(`` at *start*,
+    return a tuple of ``(inner_text, end_pos)`` where *inner_text* is
+    the content inside the parentheses (with redundant outer balanced
+    parentheses stripped) and *end_pos* is the position **after** the
+    matching closing ``)``.
 
-    The stripping is applied iteratively: if after one strip the result
-    is again wrapped in balanced parentheses, another round is performed.
+    The scan correctly handles nested parentheses, single- and
+    double-quoted string literals, and SQL-style escaped quotes
+    (``''`` and ``""``).
+
+    This is the single entry-point for parsing CHECK constraint
+    expression bodies from the raw SQL returned by the database.
+    Databases typically wrap the expression in parentheses, sometimes
+    with multiple nesting levels, e.g. ``(((a > 1) AND (a < 5)))``.
+
+    Raises :exc:`ValueError` when the input text has no balanced
+    closing parenthesis for the opening ``(`` at *start*.  This
+    indicates malformed or unexpected constraint text that cannot be
+    parsed; callers should catch this and fall back to returning the
+    raw/unparsed text.
     """
-    while True:
-        s = text.strip()
-        if len(s) < 2 or s[0] != "(" or s[-1] != ")":
-            break
 
-        depth = 0
-        in_single_quote = False
-        in_double_quote = False
-        matched = False
-
-        for i, c in enumerate(s):
-            if c == "'" and not in_double_quote:
-                # Handle escaped quotes ('')
-                if (
-                    i + 1 < len(s)
-                    and s[i + 1] == "'"
-                    and not in_single_quote
-                ):
-                    # Skip past escaped quote – stay in same quote state
-                    continue
-                in_single_quote = not in_single_quote
-            elif c == '"' and not in_single_quote:
-                if (
-                    i + 1 < len(s)
-                    and s[i + 1] == '"'
-                    and not in_double_quote
-                ):
-                    continue
-                in_double_quote = not in_double_quote
-            elif not in_single_quote and not in_double_quote:
-                if c == "(":
-                    depth += 1
-                elif c == ")":
-                    depth -= 1
-                    if depth == 0:
-                        if i == len(s) - 1:
-                            text = s[1:-1]
-                            matched = True
-                        break
-
-        if not matched:
-            break
-
-    return text
-
-
-def find_parentheses_end(text: str, start: int = 0) -> int:
-    """Return the index of the character **after** the closing ``)`` that
-    balances the opening ``(`` at position *start*.
-
-    The scan tracks single- and double-quoted string literals so that
-    parentheses inside strings are ignored.  Escaped quotes (``''`` for
-    single, ``""`` for double) are handled.
-
-    Raises :exc:`ValueError` if no balanced closing paren is found.
-    """
+    # --- Phase 1: find the matching closing parenthesis ---
     depth = 0
     in_single_quote = False
     in_double_quote = False
+    close_end = -1
 
     for i in range(start, len(text)):
         c = text[i]
@@ -2356,7 +2313,7 @@ def find_parentheses_end(text: str, start: int = 0) -> int:
                 and text[i + 1] == "'"
                 and not in_single_quote
             ):
-                continue  # escaped quote
+                continue  # escaped single quote
             in_single_quote = not in_single_quote
         elif c == '"' and not in_single_quote:
             if (
@@ -2364,7 +2321,7 @@ def find_parentheses_end(text: str, start: int = 0) -> int:
                 and text[i + 1] == '"'
                 and not in_double_quote
             ):
-                continue  # escaped quote
+                continue  # escaped double quote
             in_double_quote = not in_double_quote
         elif not in_single_quote and not in_double_quote:
             if c == "(":
@@ -2372,9 +2329,59 @@ def find_parentheses_end(text: str, start: int = 0) -> int:
             elif c == ")":
                 depth -= 1
                 if depth == 0:
-                    return i + 1  # position *after* the closing )
+                    close_end = i + 1  # position *after* the closing )
+                    break
 
-    raise ValueError("Could not find matching closing parenthesis")
+    if close_end == -1:
+        raise ValueError(
+            "Could not find matching closing parenthesis "
+            "for '(' at position %d" % start
+        )
+
+    # --- Phase 2: strip redundant outer parentheses from inner content ---
+    inner = text[start + 1 : close_end - 1]
+    while True:
+        s = inner.strip()
+        if len(s) < 2 or s[0] != "(" or s[-1] != ")":
+            break
+
+        _depth = 0
+        _in_sq = False
+        _in_dq = False
+        _matched = False
+
+        for j, c in enumerate(s):
+            if c == "'" and not _in_dq:
+                if (
+                    j + 1 < len(s)
+                    and s[j + 1] == "'"
+                    and not _in_sq
+                ):
+                    continue
+                _in_sq = not _in_sq
+            elif c == '"' and not _in_sq:
+                if (
+                    j + 1 < len(s)
+                    and s[j + 1] == '"'
+                    and not _in_dq
+                ):
+                    continue
+                _in_dq = not _in_dq
+            elif not _in_sq and not _in_dq:
+                if c == "(":
+                    _depth += 1
+                elif c == ")":
+                    _depth -= 1
+                    if _depth == 0:
+                        if j == len(s) - 1:
+                            inner = s[1:-1]
+                            _matched = True
+                        break
+
+        if not _matched:
+            break
+
+    return inner, close_end
 
 
 def has_compiled_ext(raise_=False):
@@ -2422,22 +2429,3 @@ class _Missing(enum.Enum):
 Missing = _Missing.Missing
 MissingOr = Union[_T, Literal[_Missing.Missing]]
 
-
-def consume_parenthesized_expression(text: str, start: int) -> tuple[str, int]:
-    """Extract a parenthesized expression starting at *start*.
-
-    Given *text* and the position of an opening ``(`` at *start*,
-    return a tuple of ``(inner_text, end_pos)`` where *inner_text* is
-    the content inside the parentheses (with outer balanced parentheses
-    stripped) and *end_pos* is the position **after** the matching
-    closing ``)``.
-
-    The scan correctly handles nested parentheses, single- and
-    double-quoted string literals, and SQL-style escaped quotes
-    (``''`` and ``""``).
-
-    Raises :exc:`ValueError` if no balanced closing parenthesis is found.
-    """
-    end = find_parentheses_end(text, start)
-    inner = strip_parentheses(text[start + 1 : end - 1])
-    return inner, end

--- a/lib/sqlalchemy/util/langhelpers.py
+++ b/lib/sqlalchemy/util/langhelpers.py
@@ -2274,6 +2274,109 @@ def repr_tuple_names(names: List[str]) -> Optional[str]:
         return "%s, ..., %s" % (", ".join(res[0:3]), res[-1])
 
 
+def strip_parentheses(text: str) -> str:
+    """Strip outer balanced parentheses from *text*, taking string literals
+    into account.
+
+    This is used when reflecting CHECK constraint expressions, where
+    databases wrap the expression in parentheses (possibly multiple
+    levels).  The function walks the string character-by-character,
+    tracking parenthesis depth **and** whether we are inside a single- or
+    double-quoted string literal so that parentheses inside literals are
+    not counted.
+
+    The stripping is applied iteratively: if after one strip the result
+    is again wrapped in balanced parentheses, another round is performed.
+    """
+    while True:
+        s = text.strip()
+        if len(s) < 2 or s[0] != "(" or s[-1] != ")":
+            break
+
+        depth = 0
+        in_single_quote = False
+        in_double_quote = False
+        matched = False
+
+        for i, c in enumerate(s):
+            if c == "'" and not in_double_quote:
+                # Handle escaped quotes ('')
+                if (
+                    i + 1 < len(s)
+                    and s[i + 1] == "'"
+                    and not in_single_quote
+                ):
+                    # Skip past escaped quote – stay in same quote state
+                    continue
+                in_single_quote = not in_single_quote
+            elif c == '"' and not in_single_quote:
+                if (
+                    i + 1 < len(s)
+                    and s[i + 1] == '"'
+                    and not in_double_quote
+                ):
+                    continue
+                in_double_quote = not in_double_quote
+            elif not in_single_quote and not in_double_quote:
+                if c == "(":
+                    depth += 1
+                elif c == ")":
+                    depth -= 1
+                    if depth == 0:
+                        if i == len(s) - 1:
+                            text = s[1:-1]
+                            matched = True
+                        break
+
+        if not matched:
+            break
+
+    return text
+
+
+def find_parentheses_end(text: str, start: int = 0) -> int:
+    """Return the index of the character **after** the closing ``)`` that
+    balances the opening ``(`` at position *start*.
+
+    The scan tracks single- and double-quoted string literals so that
+    parentheses inside strings are ignored.  Escaped quotes (``''`` for
+    single, ``""`` for double) are handled.
+
+    Raises :exc:`ValueError` if no balanced closing paren is found.
+    """
+    depth = 0
+    in_single_quote = False
+    in_double_quote = False
+
+    for i in range(start, len(text)):
+        c = text[i]
+        if c == "'" and not in_double_quote:
+            if (
+                i + 1 < len(text)
+                and text[i + 1] == "'"
+                and not in_single_quote
+            ):
+                continue  # escaped quote
+            in_single_quote = not in_single_quote
+        elif c == '"' and not in_single_quote:
+            if (
+                i + 1 < len(text)
+                and text[i + 1] == '"'
+                and not in_double_quote
+            ):
+                continue  # escaped quote
+            in_double_quote = not in_double_quote
+        elif not in_single_quote and not in_double_quote:
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0:
+                    return i + 1  # position *after* the closing )
+
+    raise ValueError("Could not find matching closing parenthesis")
+
+
 def has_compiled_ext(raise_=False):
     from ._has_cython import HAS_CYEXTENSION
 

--- a/lib/sqlalchemy/util/langhelpers.py
+++ b/lib/sqlalchemy/util/langhelpers.py
@@ -2421,3 +2421,23 @@ class _Missing(enum.Enum):
 
 Missing = _Missing.Missing
 MissingOr = Union[_T, Literal[_Missing.Missing]]
+
+
+def consume_parenthesized_expression(text: str, start: int) -> tuple[str, int]:
+    """Extract a parenthesized expression starting at *start*.
+
+    Given *text* and the position of an opening ``(`` at *start*,
+    return a tuple of ``(inner_text, end_pos)`` where *inner_text* is
+    the content inside the parentheses (with outer balanced parentheses
+    stripped) and *end_pos* is the position **after** the matching
+    closing ``)``.
+
+    The scan correctly handles nested parentheses, single- and
+    double-quoted string literals, and SQL-style escaped quotes
+    (``''`` and ``""``).
+
+    Raises :exc:`ValueError` if no balanced closing parenthesis is found.
+    """
+    end = find_parentheses_end(text, start)
+    inner = strip_parentheses(text[start + 1 : end - 1])
+    return inner, end

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -3787,3 +3787,90 @@ class TestTest(fixtures.TestBase):
                 is_false(foo.foo)
             case _:
                 foo.fail()
+
+
+class StripParenthesesTest(fixtures.TestBase):
+    def test_strip_no_parens(self):
+        eq_(util.strip_parentheses("a > 1"), "a > 1")
+
+    def test_strip_single_level(self):
+        eq_(util.strip_parentheses("(a > 1)"), "a > 1")
+
+    def test_strip_multiple_levels(self):
+        eq_(util.strip_parentheses("((a > 1))"), "a > 1")
+        eq_(util.strip_parentheses("(((a > 1)))"), "a > 1")
+
+    def test_strip_nested_expression(self):
+        eq_(
+            util.strip_parentheses("((a > 1) AND (a < 5))"),
+            "(a > 1) AND (a < 5)",
+        )
+
+    def test_strip_preserves_inner_unbalanced(self):
+        """Outer parens that don't balance should not be stripped."""
+        eq_(util.strip_parentheses("(a > 1) AND (a < 5)"), "(a > 1) AND (a < 5)")
+
+    def test_string_literal_single_quotes(self):
+        """Parens inside single-quoted strings are ignored."""
+        eq_(util.strip_parentheses("(a != '(')"), "a != '('")
+        eq_(util.strip_parentheses("(a != ')')"), "a != ')'")
+        eq_(
+            util.strip_parentheses("(a IN (')', '('))"),
+            "a IN (')', '(')",
+        )
+
+    def test_string_literal_double_quotes(self):
+        """Parens inside double-quoted strings are ignored."""
+        eq_(util.strip_parentheses('(a != "(")'), 'a != "("')
+        eq_(
+            util.strip_parentheses('(a != "say ""(hello)"" ")'),
+            'a != "say ""(hello)"" "',
+        )
+
+    def test_escaped_quotes(self):
+        """Escaped quotes ('' or "") don't toggle quote state."""
+        eq_(
+            util.strip_parentheses("(a != 'it''s (not) valid')"),
+            "a != 'it''s (not) valid'",
+        )
+        eq_(
+            util.strip_parentheses('(a != "say ""(hello)"" ")'),
+            'a != "say ""(hello)"" "',
+        )
+
+    def test_complex_mixed(self):
+        eq_(
+            util.strip_parentheses(
+                "(((a != '((') AND (a = ')))')))"
+            ),
+            "(a != '((') AND (a = ')))')",
+        )
+
+
+class FindParenthesesEndTest(fixtures.TestBase):
+    def test_simple(self):
+        eq_(util.find_parentheses_end("(a > 1)", 0), 7)
+
+    def test_nested(self):
+        eq_(util.find_parentheses_end("((a > 1) AND (a < 5))", 0), 21)
+
+    def test_with_string_literal(self):
+        eq_(util.find_parentheses_end("(a != '(')", 0), 10)
+
+    def test_with_string_literal_closing_paren(self):
+        eq_(util.find_parentheses_end("(a != ')')", 0), 10)
+
+    def test_complex_strings(self):
+        text = "(a != '((' OR a = ')))')"
+        eq_(util.find_parentheses_end(text, 0), len(text))
+
+    def test_escaped_quotes_in_string(self):
+        text = "(a != 'it''s (not) valid')"
+        eq_(util.find_parentheses_end(text, 0), len(text))
+
+    def test_no_match_raises(self):
+        with expect_raises(ValueError):
+            util.find_parentheses_end("(a > 1", 0)
+
+    def test_start_offset(self):
+        eq_(util.find_parentheses_end("CHECK (a > 1)", 6), 13)

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -3874,3 +3874,45 @@ class FindParenthesesEndTest(fixtures.TestBase):
 
     def test_start_offset(self):
         eq_(util.find_parentheses_end("CHECK (a > 1)", 6), 13)
+
+
+class ConsumeParenthesizedExpressionTest(fixtures.TestBase):
+    def test_simple(self):
+        text, end = util.consume_parenthesized_expression("(a > 1)", 0)
+        eq_(text, "a > 1")
+        eq_(end, 7)
+
+    def test_nested(self):
+        text, end = util.consume_parenthesized_expression(
+            "((a > 1) AND (a < 5))", 0
+        )
+        eq_(text, "(a > 1) AND (a < 5)")
+        eq_(end, 21)
+
+    def test_with_suffix(self):
+        text, end = util.consume_parenthesized_expression(
+            "CHECK (a > 1) NOT VALID", 6
+        )
+        eq_(text, "a > 1")
+        eq_(end, 13)
+
+    def test_with_string_literal(self):
+        text, end = util.consume_parenthesized_expression(
+            "(a != '(')", 0
+        )
+        eq_(text, "a != '('")
+        eq_(end, 10)
+
+    def test_multi_level_wrapping(self):
+        """Multiple outer parens are stripped down to the inner expression."""
+        text, end = util.consume_parenthesized_expression(
+            "CHECK (((a > 1) AND (a < 5))) NO INHERIT", 6
+        )
+        eq_(text, "(a > 1) AND (a < 5)")
+        # end points after the closing paren that matches start
+        suffix_after = "CHECK (((a > 1) AND (a < 5))) NO INHERIT"[end:]
+        eq_(suffix_after.strip(), "NO INHERIT")
+
+    def test_no_match_raises(self):
+        with expect_raises(ValueError):
+            util.consume_parenthesized_expression("(a > 1", 0)

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -3789,105 +3789,109 @@ class TestTest(fixtures.TestBase):
                 foo.fail()
 
 
-class StripParenthesesTest(fixtures.TestBase):
-    def test_strip_no_parens(self):
-        eq_(util.strip_parentheses("a > 1"), "a > 1")
-
-    def test_strip_single_level(self):
-        eq_(util.strip_parentheses("(a > 1)"), "a > 1")
-
-    def test_strip_multiple_levels(self):
-        eq_(util.strip_parentheses("((a > 1))"), "a > 1")
-        eq_(util.strip_parentheses("(((a > 1)))"), "a > 1")
-
-    def test_strip_nested_expression(self):
-        eq_(
-            util.strip_parentheses("((a > 1) AND (a < 5))"),
-            "(a > 1) AND (a < 5)",
-        )
-
-    def test_strip_preserves_inner_unbalanced(self):
-        """Outer parens that don't balance should not be stripped."""
-        eq_(util.strip_parentheses("(a > 1) AND (a < 5)"), "(a > 1) AND (a < 5)")
-
-    def test_string_literal_single_quotes(self):
-        """Parens inside single-quoted strings are ignored."""
-        eq_(util.strip_parentheses("(a != '(')"), "a != '('")
-        eq_(util.strip_parentheses("(a != ')')"), "a != ')'")
-        eq_(
-            util.strip_parentheses("(a IN (')', '('))"),
-            "a IN (')', '(')",
-        )
-
-    def test_string_literal_double_quotes(self):
-        """Parens inside double-quoted strings are ignored."""
-        eq_(util.strip_parentheses('(a != "(")'), 'a != "("')
-        eq_(
-            util.strip_parentheses('(a != "say ""(hello)"" ")'),
-            'a != "say ""(hello)"" "',
-        )
-
-    def test_escaped_quotes(self):
-        """Escaped quotes ('' or "") don't toggle quote state."""
-        eq_(
-            util.strip_parentheses("(a != 'it''s (not) valid')"),
-            "a != 'it''s (not) valid'",
-        )
-        eq_(
-            util.strip_parentheses('(a != "say ""(hello)"" ")'),
-            'a != "say ""(hello)"" "',
-        )
-
-    def test_complex_mixed(self):
-        eq_(
-            util.strip_parentheses(
-                "(((a != '((') AND (a = ')))')))"
-            ),
-            "(a != '((') AND (a = ')))')",
-        )
-
-
-class FindParenthesesEndTest(fixtures.TestBase):
-    def test_simple(self):
-        eq_(util.find_parentheses_end("(a > 1)", 0), 7)
-
-    def test_nested(self):
-        eq_(util.find_parentheses_end("((a > 1) AND (a < 5))", 0), 21)
-
-    def test_with_string_literal(self):
-        eq_(util.find_parentheses_end("(a != '(')", 0), 10)
-
-    def test_with_string_literal_closing_paren(self):
-        eq_(util.find_parentheses_end("(a != ')')", 0), 10)
-
-    def test_complex_strings(self):
-        text = "(a != '((' OR a = ')))')"
-        eq_(util.find_parentheses_end(text, 0), len(text))
-
-    def test_escaped_quotes_in_string(self):
-        text = "(a != 'it''s (not) valid')"
-        eq_(util.find_parentheses_end(text, 0), len(text))
-
-    def test_no_match_raises(self):
-        with expect_raises(ValueError):
-            util.find_parentheses_end("(a > 1", 0)
-
-    def test_start_offset(self):
-        eq_(util.find_parentheses_end("CHECK (a > 1)", 6), 13)
-
 
 class ConsumeParenthesizedExpressionTest(fixtures.TestBase):
-    def test_simple(self):
+    # --- strip (phase 2) behaviour ---
+
+    def test_strip_no_parens(self):
         text, end = util.consume_parenthesized_expression("(a > 1)", 0)
         eq_(text, "a > 1")
-        eq_(end, 7)
 
-    def test_nested(self):
+    def test_strip_single_level(self):
+        text, end = util.consume_parenthesized_expression("(a > 1)", 0)
+        eq_(text, "a > 1")
+
+    def test_strip_multiple_levels(self):
+        text, end = util.consume_parenthesized_expression("((a > 1))", 0)
+        eq_(text, "a > 1")
+        text, end = util.consume_parenthesized_expression("(((a > 1)))", 0)
+        eq_(text, "a > 1")
+
+    def test_strip_nested_expression(self):
         text, end = util.consume_parenthesized_expression(
             "((a > 1) AND (a < 5))", 0
         )
         eq_(text, "(a > 1) AND (a < 5)")
+
+    def test_strip_preserves_inner_unbalanced(self):
+        """Only the first balanced paren group is consumed; trailing text is ignored."""
+        text, end = util.consume_parenthesized_expression(
+            "(a > 1) AND (a < 5)", 0
+        )
+        eq_(text, "a > 1")
+
+    def test_string_literal_single_quotes(self):
+        """Parens inside single-quoted strings are ignored."""
+        text, end = util.consume_parenthesized_expression("(a != '(')", 0)
+        eq_(text, "a != '('")
+        text, end = util.consume_parenthesized_expression("(a != ')')", 0)
+        eq_(text, "a != ')'")
+        text, end = util.consume_parenthesized_expression(
+            "(a IN (')', '('))", 0
+        )
+        eq_(text, "a IN (')', '(')")
+
+    def test_string_literal_double_quotes(self):
+        """Parens inside double-quoted strings are ignored."""
+        text, end = util.consume_parenthesized_expression('(a != "(")', 0)
+        eq_(text, 'a != "("')
+        text, end = util.consume_parenthesized_expression(
+            '(a != "say ""(hello)"" ")', 0
+        )
+        eq_(text, 'a != "say ""(hello)"" "')
+
+    def test_escaped_quotes(self):
+        """Escaped quotes ('' or "") don't toggle quote state."""
+        text, end = util.consume_parenthesized_expression(
+            "(a != 'it''s (not) valid')", 0
+        )
+        eq_(text, "a != 'it''s (not) valid'")
+        text, end = util.consume_parenthesized_expression(
+            '(a != "say ""(hello)"" ")', 0
+        )
+        eq_(text, 'a != "say ""(hello)"" "')
+
+    def test_complex_mixed(self):
+        text, end = util.consume_parenthesized_expression(
+            "(((a != '((') AND (a = ')))')))", 0
+        )
+        eq_(text, "(a != '((') AND (a = ')))')")
+
+    # --- find-end (phase 1) behaviour ---
+
+    def test_simple_end(self):
+        text, end = util.consume_parenthesized_expression("(a > 1)", 0)
+        eq_(end, 7)
+
+    def test_nested_end(self):
+        text, end = util.consume_parenthesized_expression(
+            "((a > 1) AND (a < 5))", 0
+        )
         eq_(end, 21)
+
+    def test_with_string_literal_end(self):
+        text, end = util.consume_parenthesized_expression("(a != '(')", 0)
+        eq_(end, 10)
+
+    def test_with_string_literal_closing_paren_end(self):
+        text, end = util.consume_parenthesized_expression("(a != ')')", 0)
+        eq_(end, 10)
+
+    def test_complex_strings_end(self):
+        text = "(a != '((' OR a = ')))')"
+        _text, end = util.consume_parenthesized_expression(text, 0)
+        eq_(end, len(text))
+
+    def test_escaped_quotes_in_string_end(self):
+        text = "(a != 'it''s (not) valid')"
+        _text, end = util.consume_parenthesized_expression(text, 0)
+        eq_(end, len(text))
+
+    def test_start_offset(self):
+        text, end = util.consume_parenthesized_expression("CHECK (a > 1)", 6)
+        eq_(end, 13)
+
+    # --- combined / integration ---
 
     def test_with_suffix(self):
         text, end = util.consume_parenthesized_expression(
@@ -3895,13 +3899,6 @@ class ConsumeParenthesizedExpressionTest(fixtures.TestBase):
         )
         eq_(text, "a > 1")
         eq_(end, 13)
-
-    def test_with_string_literal(self):
-        text, end = util.consume_parenthesized_expression(
-            "(a != '(')", 0
-        )
-        eq_(text, "a != '('")
-        eq_(end, 10)
 
     def test_multi_level_wrapping(self):
         """Multiple outer parens are stripped down to the inner expression."""
@@ -3913,6 +3910,16 @@ class ConsumeParenthesizedExpressionTest(fixtures.TestBase):
         suffix_after = "CHECK (((a > 1) AND (a < 5))) NO INHERIT"[end:]
         eq_(suffix_after.strip(), "NO INHERIT")
 
-    def test_no_match_raises(self):
+    # --- error cases ---
+
+    def test_no_match_raises_valueerror(self):
+        """Unbalanced input raises ValueError with a descriptive message."""
         with expect_raises(ValueError):
             util.consume_parenthesized_expression("(a > 1", 0)
+
+    def test_error_message_includes_position(self):
+        """The ValueError message tells which opening paren is unmatched."""
+        try:
+            util.consume_parenthesized_expression("CHECK (a > 1", 6)
+        except ValueError as ve:
+            assert "position 6" in str(ve)

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -2847,6 +2847,127 @@ class ReflectionTest(
             ],
         )
 
+    def test_reflect_check_constraint_with_parens_in_strings(self):
+        """Test CHECK constraints that contain parentheses inside string
+        literals.
+
+        Parentheses inside quoted strings must not be counted when
+        matching balanced parentheses in the constraint expression.
+        """
+        rows = [
+            ("foo", None, "CHECK (a != '(')", None),
+            ("foo", None, "CHECK (a != ')')", None),
+            ("foo", None, "CHECK (a NOT LIKE '%(')", None),
+            ("foo", None, "CHECK (a IN (')', '(', 'test'))", None),
+            (
+                "foo",
+                None,
+                "CHECK (a != 'it''s (not) valid')",
+                None,
+            ),
+            ('foo', None, 'CHECK (a != "say ""(hello)"" ")', None),
+            (
+                "foo",
+                None,
+                "CHECK (a NOT IN ('()', 'a''b''c', ')'))",
+                None,
+            ),
+            (
+                "foo",
+                None,
+                "CHECK (a != '((' OR a = ')))')",
+                None,
+            ),
+            (
+                "foo",
+                None,
+                "CHECK (((a != '(') AND (a != ')')))",
+                None,
+            ),
+            (
+                "foo",
+                "cc1",
+                "CHECK ((a > 1) AND (a < 5)) NOT VALID",
+                None,
+            ),
+            (
+                "foo",
+                "cc2",
+                "CHECK ((a = 1) OR ((a > 2) AND (a < 5))) NO INHERIT",
+                None,
+            ),
+        ]
+        conn = mock.Mock(
+            execute=lambda *arg, **kw: mock.MagicMock(
+                fetchall=lambda: rows, __iter__=lambda self: iter(rows)
+            )
+        )
+        check_constraints = testing.db.dialect.get_multi_check_constraints(
+            conn, "foo", None, None, None
+        )
+        eq_(
+            list(check_constraints)[0][1],
+            [
+                {
+                    "name": None,
+                    "sqltext": "a != '('",
+                    "comment": None,
+                },
+                {
+                    "name": None,
+                    "sqltext": "a != ')'",
+                    "comment": None,
+                },
+                {
+                    "name": None,
+                    "sqltext": "a NOT LIKE '%('",
+                    "comment": None,
+                },
+                {
+                    "name": None,
+                    "sqltext": "a IN (')', '(', 'test')",
+                    "comment": None,
+                },
+                {
+                    "name": None,
+                    "sqltext": "a != 'it''s (not) valid'",
+                    "comment": None,
+                },
+                {
+                    "name": None,
+                    'sqltext': 'a != "say ""(hello)"" "',
+                    "comment": None,
+                },
+                {
+                    "name": None,
+                    "sqltext": "a NOT IN ('()', 'a''b''c', ')')",
+                    "comment": None,
+                },
+                {
+                    "name": None,
+                    "sqltext": "a != '((' OR a = ')))'",
+                    "comment": None,
+                },
+                {
+                    "name": None,
+                    "sqltext": "(a != '(') AND (a != ')')",
+                    "comment": None,
+                },
+                {
+                    "name": "cc1",
+                    "sqltext": "a > 1 AND a < 5",
+                    "dialect_options": {"not_valid": True},
+                    "comment": None,
+                },
+                {
+                    "name": "cc2",
+                    "sqltext": "(a = 1) OR ((a > 2) AND (a < 5))",
+                    "dialect_options": {"no_inherit": True},
+                    "comment": None,
+                },
+            ],
+        )
+
     def _apply_stm(self, connection, use_map):
         if use_map:
             return connection.execution_options(

--- a/test/dialect/sqlite/test_reflection.py
+++ b/test/dialect/sqlite/test_reflection.py
@@ -960,8 +960,8 @@ class ConstraintReflectionTest(fixtures.TestBase):
                 # Triple-quote multi-line definition should have added a
                 # newline and whitespace:
                 {
-                    "sqltext": "((value > 0) AND \n\t(value < 100) AND \n\t\n"
-                    "                      (value != 50))",
+                    "sqltext": "(value > 0) AND \n\t(value < 100) AND \n\t\n"
+                    "                      (value != 50)",
                     "name": "ck_r_value_multiline",
                 },
                 {"sqltext": "id > 0", "name": None},


### PR DESCRIPTION
## Problem

In `PGDialect.get_multi_check_constraints()`, the regex used to strip outer parentheses from CHECK constraint text uses a greedy match that corrupts nested expressions.

For example, a constraint defined as:
```sql
CHECK (((x IS NULL OR y IS NULL) AND (x IS NULL OR y IS NULL)))
```

gets reflected as:
```
x IS NULL OR y IS NULL) AND (x IS NULL OR y IS_NULL
```

The leading `(` and trailing content are dropped because the greedy `(.+)` captures from the first inner `(` to the last inner `)`, not the actual outer delimiters.

## Fix

Replace the single regex substitution with a depth-tracking loop that walks the string character-by-character. It only strips outer parens when they genuinely balance around the entire expression, and repeats to handle multiple wrapping levels (e.g. `((a > 1))` → `a > 1`).

Fixes #13157