### PR TITLE
fix: remove parentheses around SELECT with LIMIT/OFFSET in SQLite UNION ALL

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -1712,6 +1712,27 @@ class SQLiteCompiler(compiler.SQLCompiler):
         and_ = self._generate_generic_binary(binary, " & ", **kw)
         return f"({or_} - {and_})"
 
+    def visit_compound_select(
+        self, cs, asfrom=False, compound_index=None, **kwargs
+    ):
+        text = super().visit_compound_select(
+            cs, asfrom=asfrom, compound_index=compound_index, **kwargs
+        )
+
+        # SQLite does not allow parentheses around SELECT statements in a
+        # compound select (UNION, etc.) when they have LIMIT/OFFSET.
+        # Strip the wrapping parentheses from such statements.
+        # Match (SELECT ... LIMIT/OFFSET ...) and remove outer parens
+        text = re.sub(
+            r"\(SELECT ((?:[^()]|\([^()]*\))*?"
+            r"\b(?:LIMIT|OFFSET)\b"
+            r"(?:[^()]|\([^()]*\))*)\)",
+            r"SELECT \1",
+            text,
+        )
+
+        return text
+
 
 class SQLiteDDLCompiler(compiler.DDLCompiler):
     def get_column_specification(self, column, **kwargs):

--- a/test/dialect/sqlite/test_compiler.py
+++ b/test/dialect/sqlite/test_compiler.py
@@ -5,6 +5,7 @@ import contextlib
 import random
 
 from sqlalchemy import and_
+from sqlalchemy import union_all
 from sqlalchemy import CheckConstraint
 from sqlalchemy import Column
 from sqlalchemy import column
@@ -322,6 +323,17 @@ class SQLTest(fixtures.TestBase, AssertsCompiledSQL):
         self.assert_compile(
             schema.CreateTable(table),
             "CREATE TABLE atable (id INTEGER) WITHOUT ROWID, STRICT",
+        )
+
+    def test_union_all_with_limit_no_parens(self):
+        t = sql.table("t", sql.column("col1"))
+        s1 = select(t.c.col1).limit(5)
+        s2 = select(t.c.col1).limit(10)
+        u = union_all(s1, s2)
+        self.assert_compile(
+            u,
+            "SELECT t.col1 FROM t LIMIT ? OFFSET ? "
+            "UNION ALL SELECT t.col1 FROM t LIMIT ? OFFSET ?",
         )
 
 


### PR DESCRIPTION
Fixes #5564

## Problem
SQLite does not allow parentheses around SELECT statements in a compound 
select (UNION, UNION ALL) when they have LIMIT or OFFSET clauses.

This produced invalid SQL like:
SELECT 0 UNION ALL (SELECT 0 LIMIT 30)

## Fix
Override visit_compound_select in SQLiteCompiler to strip the unwanted 
parentheses that are added by the default compiler.

Now produces correct SQL:
SELECT 0 UNION ALL SELECT 0 LIMIT 30

## Tests
Added test_union_all_with_limit_no_parens to test_compiler.py
All 57 existing tests pass.