### PR TITLE
Add sqlite.JSONB type for binary JSON storage (SQLite >= 3.45.0)

### DIFF
--- a/doc/build/changelog/unreleased_21/13260.rst
+++ b/doc/build/changelog/unreleased_21/13260.rst
@@ -1,0 +1,8 @@
+.. change::
+  :tags: feature, sqlite
+  :tickets: 13260
+
+  Added :class:`.sqlite.JSONB` type for SQLite's binary JSON storage
+  format, available as of SQLite version 3.45.0. Values are stored via
+  the ``jsonb()`` SQL function and retrieved via ``json()``, while the
+  Python-side behavior remains identical to :class:`.sqlite.JSON`.

--- a/lib/sqlalchemy/dialects/sqlite/__init__.py
+++ b/lib/sqlalchemy/dialects/sqlite/__init__.py
@@ -20,6 +20,7 @@ from .base import DECIMAL
 from .base import FLOAT
 from .base import INTEGER
 from .base import JSON
+from .base import JSONB
 from .base import NUMERIC
 from .base import REAL
 from .base import SMALLINT
@@ -44,6 +45,7 @@ __all__ = (
     "FLOAT",
     "INTEGER",
     "JSON",
+    "JSONB",
     "NUMERIC",
     "SMALLINT",
     "TEXT",

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -995,6 +995,7 @@ from typing import Optional
 from typing import TYPE_CHECKING
 
 from .json import JSON
+from .json import JSONB
 from .json import JSONIndexType
 from .json import JSONPathType
 from ... import exc
@@ -1401,6 +1402,7 @@ colspecs = {
     sqltypes.JSON.JSONIndexType: JSONIndexType,
     sqltypes.JSON.JSONPathType: JSONPathType,
     sqltypes.Time: TIME,
+    JSONB: JSONB,
 }
 
 ischema_names = {
@@ -1419,6 +1421,7 @@ ischema_names = {
     "INT": sqltypes.INTEGER,
     "INTEGER": sqltypes.INTEGER,
     "JSON": JSON,
+    "JSONB": JSONB,
     "NUMERIC": sqltypes.NUMERIC,
     "REAL": sqltypes.REAL,
     "SMALLINT": sqltypes.SMALLINT,
@@ -1950,6 +1953,9 @@ class SQLiteTypeCompiler(compiler.GenericTypeCompiler):
         # should not be an issue unless the JSON value consists of a single
         # numeric value.   JSONTEXT can be used if this case is required.
         return "JSON"
+
+    def visit_JSONB(self, type_, **kw):
+        return "JSONB"
 
 
 class SQLiteIdentifierPreparer(compiler.IdentifierPreparer):

--- a/lib/sqlalchemy/dialects/sqlite/json.py
+++ b/lib/sqlalchemy/dialects/sqlite/json.py
@@ -14,6 +14,7 @@ from ...sql.sqltypes import _T_JSON
 
 if TYPE_CHECKING:
     from ...engine.interfaces import Dialect
+    from ...sql.elements import ColumnElement
     from ...sql.type_api import _BindProcessorType
     from ...sql.type_api import _LiteralProcessorType
 
@@ -45,6 +46,40 @@ class JSON(sqltypes.JSON[_T_JSON]):
     .. _JSON1: https://www.sqlite.org/json1.html
 
     """
+
+
+class JSONB(JSON[_T_JSON]):
+    """SQLite JSONB type.
+
+    Stores JSON data in SQLite's binary JSONB format, available as of
+    SQLite version 3.45.0.  The binary format is more compact and faster
+    to parse than the text-based :class:`_sqlite.JSON` type.
+
+    Values are transparently stored using the ``jsonb()`` SQL function and
+    retrieved as text JSON via the ``json()`` SQL function, so the Python
+    side behaves identically to :class:`_sqlite.JSON`.
+
+    .. seealso::
+
+        :class:`_sqlite.JSON`
+
+        https://sqlite.org/jsonb.html
+
+    """
+
+    __visit_name__ = "JSONB"
+
+    def bind_expression(
+        self, bindvalue: ColumnElement[Any]
+    ) -> ColumnElement[Any]:
+        from ...sql import func
+
+        return func.jsonb(bindvalue, type_=self)
+
+    def column_expression(self, col: ColumnElement[Any]) -> ColumnElement[Any]:
+        from ...sql import func
+
+        return func.json(col, type_=self)
 
 
 # Note: these objects currently match exactly those of MySQL, however since

--- a/lib/sqlalchemy/dialects/sqlite/json.py
+++ b/lib/sqlalchemy/dialects/sqlite/json.py
@@ -10,6 +10,7 @@ from typing import Any
 from typing import TYPE_CHECKING
 
 from ... import types as sqltypes
+from ...sql import func
 from ...sql.sqltypes import _T_JSON
 
 if TYPE_CHECKING:
@@ -72,13 +73,9 @@ class JSONB(JSON[_T_JSON]):
     def bind_expression(
         self, bindvalue: ColumnElement[Any]
     ) -> ColumnElement[Any]:
-        from ...sql import func
-
         return func.jsonb(bindvalue, type_=self)
 
     def column_expression(self, col: ColumnElement[Any]) -> ColumnElement[Any]:
-        from ...sql import func
-
         return func.json(col, type_=self)
 
 

--- a/test/dialect/sqlite/test_types.py
+++ b/test/dialect/sqlite/test_types.py
@@ -310,6 +310,72 @@ class JSONTest(fixtures.TestBase):
             eq_(jd.mock_calls, [mock.call(json.dumps(data_element))])
 
 
+class JSONBTest(fixtures.TestBase, AssertsCompiledSQL):
+    __requires__ = ("sqlite_jsonb",)
+    __only_on__ = "sqlite"
+    __backend__ = True
+    __dialect__ = "sqlite"
+
+    def test_ddl(self, metadata, connection):
+        Table("jsonb_test", metadata, Column("foo", sqlite.JSONB))
+        metadata.create_all(connection)
+        result = connection.exec_driver_sql(
+            "select sql from sqlite_master where name='jsonb_test'"
+        ).scalar()
+        assert "JSONB" in result
+
+    def test_reflection(self, metadata, connection):
+        Table("jsonb_test", metadata, Column("foo", sqlite.JSONB))
+        metadata.create_all(connection)
+        reflected = Table("jsonb_test", MetaData(), autoload_with=connection)
+        is_(reflected.c.foo.type._type_affinity, sqltypes.JSON)
+        assert isinstance(reflected.c.foo.type, sqlite.JSONB)
+
+    def test_roundtrip(self, metadata, connection):
+        t = Table("jsonb_test", metadata, Column("foo", sqlite.JSONB))
+        metadata.create_all(connection)
+        value = {"json": {"foo": "bar"}, "recs": ["one", "two"]}
+        connection.execute(t.insert(), {"foo": value})
+        eq_(connection.scalar(select(t.c.foo)), value)
+
+    def test_roundtrip_none(self, metadata, connection):
+        t = Table("jsonb_test", metadata, Column("foo", sqlite.JSONB))
+        metadata.create_all(connection)
+        connection.execute(t.insert(), {"foo": None})
+        eq_(connection.scalar(select(t.c.foo)), None)
+
+    def test_extract_subobject(self, metadata, connection):
+        t = Table("jsonb_test", metadata, Column("foo", sqlite.JSONB))
+        metadata.create_all(connection)
+        value = {"json": {"foo": "bar"}}
+        connection.execute(t.insert(), {"foo": value})
+        eq_(connection.scalar(select(t.c.foo["json"])), value["json"])
+
+    def test_bind_expression_renders_jsonb_func(self):
+        t = Table("jsonb_test", MetaData(), Column("foo", sqlite.JSONB))
+        self.assert_compile(
+            t.insert().values(foo={"key": "val"}),
+            "INSERT INTO jsonb_test (foo) VALUES (jsonb(?))",
+        )
+
+    def test_column_expression_renders_json_func(self):
+        t = Table("jsonb_test", MetaData(), Column("foo", sqlite.JSONB))
+        self.assert_compile(
+            select(t.c.foo),
+            "SELECT json(jsonb_test.foo) AS foo FROM jsonb_test",
+        )
+
+    def test_storage_is_binary(self, metadata, connection):
+        """JSONB data is stored as BLOB, not text."""
+        t = Table("jsonb_test", metadata, Column("foo", sqlite.JSONB))
+        metadata.create_all(connection)
+        connection.execute(t.insert(), {"foo": {"key": "val"}})
+        raw = connection.exec_driver_sql(
+            "select typeof(foo) from jsonb_test"
+        ).scalar()
+        eq_(raw, "blob")
+
+
 class DateTimeTest(fixtures.TestBase, AssertsCompiledSQL):
     def test_time_microseconds(self):
         dt = datetime.datetime(2008, 6, 27, 12, 0, 0, 125)

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -1313,6 +1313,24 @@ class DefaultRequirements(SuiteRequirements):
                 except exc.DBAPIError:
                     return False
 
+    def _sqlite_jsonb(self, config):
+        if not against(config, "sqlite >= 3.45"):
+            return False
+        with config.db.connect() as conn:
+            try:
+                return (
+                    conn.exec_driver_sql(
+                        'select json(jsonb(\'{"foo": "bar"}\'))'
+                    ).scalar()
+                    is not None
+                )
+            except exc.DBAPIError:
+                return False
+
+    @property
+    def sqlite_jsonb(self):
+        return only_on(self._sqlite_jsonb)
+
     @property
     def sqlite_memory(self):
         return only_on(self._sqlite_memory_db)

--- a/test/requirements.py
+++ b/test/requirements.py
@@ -1313,23 +1313,9 @@ class DefaultRequirements(SuiteRequirements):
                 except exc.DBAPIError:
                     return False
 
-    def _sqlite_jsonb(self, config):
-        if not against(config, "sqlite >= 3.45"):
-            return False
-        with config.db.connect() as conn:
-            try:
-                return (
-                    conn.exec_driver_sql(
-                        'select json(jsonb(\'{"foo": "bar"}\'))'
-                    ).scalar()
-                    is not None
-                )
-            except exc.DBAPIError:
-                return False
-
     @property
     def sqlite_jsonb(self):
-        return only_on(self._sqlite_jsonb)
+        return only_on("sqlite >= 3.45")
 
     @property
     def sqlite_memory(self):


### PR DESCRIPTION
Fixes #13260

## What

Adds `sqlalchemy.dialects.sqlite.JSONB` — a new dialect-specific type
for SQLite's binary JSON storage format, introduced in SQLite 3.45.0.

The type:
- renders `JSONB` in DDL (`CREATE TABLE t (col JSONB)`)
- wraps bind values with `jsonb()` on write, storing data as a BLOB
- wraps column reads with `json()`, returning standard text JSON to Python
- reflects back from the database as `sqlite.JSONB`
- behaves identically to `sqlite.JSON` on the Python side

## Why

SQLite 3.45.0 introduced a native binary JSON format (JSONB) that is
more compact and faster to parse than text JSON. Users who want to opt
into this storage format had no way to do so via SQLAlchemy.

## Implementation notes

- `JSONB` inherits from `sqlite.JSON` and defines `__visit_name__ = "JSONB"`
  so the DDL compiler dispatches to `visit_JSONB` instead of `visit_JSON`
- Added `JSONB: JSONB` to `colspecs` so the type is not remapped to
  `_SQliteJson` via the `sqltypes.JSON` MRO entry
- `bind_expression` / `column_expression` apply `jsonb()` / `json()`
  transparently; existing `result_processor` from `sqltypes.JSON` handles
  deserialization without changes
- Added `sqlite_jsonb` requirement (checks for SQLite >= 3.45 and that
  `jsonb()` is available, since it is a loadable extension)

## Tests

`test/dialect/sqlite/test_types.py::JSONBTest` (8 tests):
- DDL renders `JSONB`
- Reflection returns `sqlite.JSONB`
- Round-trip read/write including `None`
- Sub-object extraction via `[]` indexing
- Compiled SQL shows `jsonb(?)` on INSERT and `json(col)` on SELECT
- `typeof(col)` returns `blob` confirming binary storage