### PR TITLE
docs: fix typo pool_echo -> echo_pool

### DIFF
--- a/doc/build/core/engines.rst
+++ b/doc/build/core/engines.rst
@@ -514,7 +514,7 @@ namespace of SA loggers that can be turned on is as follows:
 * ``sqlalchemy.pool`` - controls connection pool logging.  Set to
   ``logging.INFO`` to log connection invalidation and recycle events; set to
   ``logging.DEBUG`` to additionally log all pool checkins and checkouts.
-  These settings are equivalent to ``pool_echo=True`` and ``pool_echo="debug"``
+  These settings are equivalent to ``echo_pool=True`` and ``echo_pool="debug"``
   on :paramref:`_sa.create_engine.echo_pool`, respectively.
 
 * ``sqlalchemy.dialects`` - controls custom logging for SQL dialects, to the


### PR DESCRIPTION
### Description

:x: `pool_echo`
:white_check_mark:  `echo_pool`

### Checklist

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
