### PR TITLE
limit pypy to one build, fix typo

### DIFF
--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -38,7 +38,6 @@ jobs:
           - "3.13"
           - "3.14"
           - "3.14t"
-          - "pypy-3.11"
         build-type:
           # builds greenlet, runs asyncio tests.  includes aiosqlite driver
           - "cext-greenlet"
@@ -56,6 +55,9 @@ jobs:
           # autocommit tests fail on the ci for some reason
           - python-version: "pypy-3.11"
             pytest-args: "-k 'not test_autocommit_on and not test_turn_autocommit_off_via_default_iso_level and not test_autocommit_isolation_level'"
+            architecture: x64
+            build-type: "nocext"
+            os: "ubuntu-22.04"
 
         exclude:
           # linux do not have x86 / arm64 python
@@ -76,17 +78,6 @@ jobs:
             architecture: x86
           - os: "macos-latest"
             architecture: x64
-          # pypy does not have cext or x86 or arm on linux
-          - python-version: "pypy-3.11"
-            build-type: "cext"
-          - os: "ubuntu-22.04-arm"
-            python-version: "pypy-3.11"
-          - os: "windows-latest"
-            python-version: "pypy-3.11"
-            architecture: x86
-          # Setup-python does not support any versions before 3.11 for arm64 windows
-          - os: "windows-11-arm"
-            python-version: "pypy-3.11"
           - os: "windows-11-arm"
             python-version: "3.10"
           - os: "windows-11-arm"

--- a/noxfile.py
+++ b/noxfile.py
@@ -187,7 +187,7 @@ def github_cext(session: nox.Session) -> None:
 def github_nocext(session: nox.Session) -> None:
     """run tests for github actions"""
 
-    _tests(session, "sqlite", "cext", greenlet=False)
+    _tests(session, "sqlite", "nocext", greenlet=False)
 
 
 def _tests(


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

github actions were failing fast with PyPy. There were jobs defined with cext-greenlet, and even the nocext job suffered from a typo that made nox run it as cext.

Toward https://github.com/sqlalchemy/sqlalchemy/discussions/13274, should I open an issue or continue with the discussion topic?

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
