### PR TITLE
omit_join optimization for selectinload on many-to-many relationships

### DIFF
--- a/doc/build/changelog/unreleased_21/5987.rst
+++ b/doc/build/changelog/unreleased_21/5987.rst
@@ -6,6 +6,9 @@
   optimization for many-to-many non-self-referential relationships,
   reducing the number of joins in the secondary SELECT by selecting from
   the secondary table directly rather than joining back to the parent entity.
-  ``omit_join`` is enabled automatically and can be disabled by setting
-  :paramref:`.relationship.omit_join` to ``False``.
+  ``omit_join`` is enabled automatically when the join condition determines
+  that the secondary table's foreign keys fully cover the parent's primary key,
+  via the ``secondary_covers_parent_primary_key`` flag on the join condition.
+  ``omit_join`` can be disabled by setting :paramref:`.relationship.omit_join`
+  to ``False``.
   Pull request courtesy bekapono.

--- a/doc/build/changelog/unreleased_21/5987.rst
+++ b/doc/build/changelog/unreleased_21/5987.rst
@@ -1,0 +1,11 @@
+.. change::
+  :tags: use case, orm, loader options, performance
+  :tickets: 5987
+
+  The :func:`.selectinload` loader strategy now supports the ``omit_join``
+  optimization for many-to-many non-self-referential relationships,
+  reducing the number of joins in the secondary SELECT by selecting from
+  the secondary table directly rather than joining back to the parent entity.
+  ``omit_join`` is enabled automatically and can be disabled by setting
+  :paramref:`.relationship.omit_join` to ``False``.
+  Pull request courtesy bekapono.

--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -93,6 +93,7 @@ from ..sql.util import ClauseAdapter
 from ..sql.util import join_condition
 from ..sql.util import selectables_overlap
 from ..sql.util import visit_binary_product
+from ..util import memoized_property
 from ..util.typing import de_optionalize_union_types
 from ..util.typing import resolve_name_to_real_class_name
 
@@ -2413,6 +2414,21 @@ class _JoinCondition:
         self._determine_direction()
         self._check_remote_side()
         self._log_joins()
+        self.secondary_covers_parent_primary_key
+
+    @memoized_property
+    def secondary_covers_parent_primary_key(self) -> bool:
+        if self.secondary is None:
+            return False
+
+        parent_pk_cols = util.column_set(
+            col for col in self.parent_local_selectable.c if col.primary_key
+        )
+
+        secondary_synced_parent_cols = util.column_set(
+            l for (l, r) in self.synchronize_pairs
+        )
+        return parent_pk_cols.issubset(secondary_synced_parent_cols)
 
     def _log_joins(self) -> None:
         log = self.prop.logger

--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -3007,7 +3007,8 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
             if is_m2o:
                 self.omit_join = lazyloader.use_get
             elif is_m2m and not self.parent_property._is_self_referential:
-                self.omit_join = True
+                join_cond = self.parent_property._join_condition
+                self.omit_join = join_cond.secondary_covers_parent_primary_key
             else:
                 self.omit_join = self.parent._get_clause[0].compare(
                     lazyloader._rev_lazywhere,

--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -2996,6 +2996,7 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
         super().__init__(parent, strategy_key)
         self.join_depth = self.parent_property.join_depth
         is_m2o = self.parent_property.direction is interfaces.MANYTOONE
+        is_m2m = self.parent_property.direction is interfaces.MANYTOMANY
 
         if self.parent_property.omit_join is not None:
             self.omit_join = self.parent_property.omit_join
@@ -3005,6 +3006,8 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
             )
             if is_m2o:
                 self.omit_join = lazyloader.use_get
+            elif is_m2m and not self.parent_property._is_self_referential:
+                self.omit_join = True
             else:
                 self.omit_join = self.parent._get_clause[0].compare(
                     lazyloader._rev_lazywhere,
@@ -3253,7 +3256,18 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
             },
         )
 
-        if not query_info.load_with_join:
+        if (
+            self.parent_property.secondary is not None
+            and self.omit_join is True
+        ):
+            # The secondaryjoin condition is used to connect the
+            # secondary table to the related entity,
+            # and is required for composite foreign keys where SQLAlchemy
+            # cannot determine the join condition.
+            q = q.select_from(self.parent_property.secondary).join(
+                entity_sql, self.parent_property._join_condition.secondaryjoin
+            )
+        elif not query_info.load_with_join:
             # the Bundle we have in the "omit_join" case is against raw, non
             # annotated columns, so to ensure the Query knows its primary
             # entity, we add it explicitly.  If we made the Bundle against

--- a/test/orm/test_relationships.py
+++ b/test/orm/test_relationships.py
@@ -1,4 +1,6 @@
 import datetime
+from typing import List
+from typing import Optional
 
 import sqlalchemy as sa
 from sqlalchemy import and_
@@ -23,6 +25,8 @@ from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import exc as orm_exc
 from sqlalchemy.orm import foreign
 from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm import remote
 from sqlalchemy.orm import selectinload
@@ -5634,6 +5638,454 @@ class InvalidRelationshipEscalationTestM2M(
             "Foo.bars",
             "secondary",
         )
+
+
+class SecondaryCoversParentFlagTestM2M(fixtures.DeclarativeMappedTest):
+    def test_false_no_secondary(self):
+        Base = declarative_base()
+
+        class A(Base):
+            __tablename__ = "a"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            bs: Mapped[list["B"]] = relationship("B", back_populates="a")
+
+        class B(Base):
+            __tablename__ = "b"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            a_id: Mapped[int] = mapped_column(ForeignKey("a.id"))
+            a: Mapped["A"] = relationship("A", back_populates="bs")
+
+        join_cond = A.bs.property._join_condition
+        flag = join_cond.secondary_covers_parent_primary_key
+
+        assert flag is False
+
+    def test_false_secondary_joins_on_non_pk(self):
+        Base = declarative_base()
+
+        atob = Table(
+            "atob",
+            Base.metadata,
+            Column("a_code", ForeignKey("a.code")),
+            Column("b_id", ForeignKey("b.id")),
+        )
+
+        class A(Base):
+            __tablename__ = "a"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            code: Mapped[str] = mapped_column(unique=True)
+            bs: Mapped[list["B"]] = relationship("B", secondary=atob)
+
+        class B(Base):
+            __tablename__ = "b"
+            id: Mapped[int] = mapped_column(primary_key=True)
+
+        join_cond = A.bs.property._join_condition
+        flag = join_cond.secondary_covers_parent_primary_key
+
+        assert flag is False
+
+    def test_true_with_composite(self):
+        Base = declarative_base()
+
+        association_table = Table(
+            "a_b",
+            Base.metadata,
+            Column("a_id1", Integer, ForeignKey("a.id1")),
+            Column("a_id2", Integer, ForeignKey("a.id2")),
+            Column("b_id1", Integer, ForeignKey("b.id1")),
+            Column("b_id2", Integer, ForeignKey("b.id2")),
+        )
+
+        class A(Base):
+            __tablename__ = "a"
+            id1: Mapped[int] = mapped_column(primary_key=True)
+            id2: Mapped[int] = mapped_column(primary_key=True)
+            bs = relationship(
+                "B",
+                secondary=association_table,
+                primaryjoin=lambda: and_(
+                    A.id1 == association_table.c.a_id1,
+                    A.id2 == association_table.c.a_id2,
+                ),
+                secondaryjoin=lambda: and_(
+                    B.id1 == association_table.c.b_id1,
+                    B.id2 == association_table.c.b_id2,
+                ),
+            )
+
+        class B(Base):
+            __tablename__ = "b"
+            id1: Mapped[int] = mapped_column(primary_key=True)
+            id2: Mapped[int] = mapped_column(primary_key=True)
+
+        join_cond = A.bs.property._join_condition
+        flag = join_cond.secondary_covers_parent_primary_key
+
+        assert flag is True
+
+    def test_false_with_inheritance(self):
+        Base = declarative_base()
+
+        a_b = Table(
+            "a_b",
+            Base.metadata,
+            Column(
+                "a_code", String, ForeignKey("a_child.code"), primary_key=True
+            ),
+            Column("b_id", Integer, ForeignKey("b.id"), primary_key=True),
+        )
+
+        class A(Base):
+            __tablename__ = "a"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            type: Mapped[str]
+            __mapper_args__ = {
+                "polymorphic_on": "type",
+                "polymorphic_identity": "a",
+            }
+
+        class AChild(A):
+            __tablename__ = "a_child"
+            id: Mapped[int] = mapped_column(
+                ForeignKey("a.id"), primary_key=True
+            )
+            code: Mapped[str] = mapped_column(unique=True)
+            bs: Mapped[list["B"]] = relationship(secondary=a_b)
+            __mapper_args__ = {"polymorphic_identity": "a_child"}
+
+        class B(Base):
+            __tablename__ = "b"
+            id: Mapped[int] = mapped_column(primary_key=True)
+
+        join_cond = AChild.bs.property._join_condition
+        flag = join_cond.secondary_covers_parent_primary_key
+
+        assert flag is False
+
+    def test_true_inheritance_on_child(self):
+        Base = self.DeclarativeBasic
+
+        a_b = Table(
+            "a_b",
+            Base.metadata,
+            Column(
+                "a_child_id",
+                String,
+                ForeignKey("a_child.id"),
+                primary_key=True,
+            ),
+            Column("b_id", Integer, ForeignKey("b.id"), primary_key=True),
+        )
+
+        class A(Base):
+            __tablename__ = "a"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            type: Mapped[str]
+            __mapper_args__ = {
+                "polymorphic_on": "type",
+                "polymorphic_identity": "a",
+            }
+
+        class AChild(A):
+            __tablename__ = "a_child"
+            id: Mapped[int] = mapped_column(
+                ForeignKey("a.id"), primary_key=True
+            )
+            code: Mapped[str] = mapped_column(unique=True)
+            bs: Mapped[list["B"]] = relationship(secondary=a_b)
+            __mapper_args__ = {"polymorphic_identity": "a_child"}
+
+        class B(Base):
+            __tablename__ = "b"
+            id: Mapped[int] = mapped_column(primary_key=True)
+
+        join_cond = AChild.bs.property._join_condition
+        flag = join_cond.secondary_covers_parent_primary_key
+
+        assert flag is True
+
+    def test_true_with_inheritance_on_parent(self):
+        Base = declarative_base()
+
+        a_b = Table(
+            "a_b",
+            Base.metadata,
+            Column("a_id", Integer, ForeignKey("a.id"), primary_key=True),
+            Column("b_id", Integer, ForeignKey("b.id"), primary_key=True),
+        )
+
+        class A(Base):
+            __tablename__ = "a"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            type: Mapped[str] = mapped_column()
+            bs = relationship("B", secondary=a_b)
+            __mapper_args__ = {
+                "polymorphic_on": type,
+                "polymorphic_identity": "parent",
+            }
+
+        class AChild(A):
+            __tablename__ = "a_child"
+            id: Mapped[int] = mapped_column(
+                ForeignKey("a.id"), primary_key=True
+            )
+            code: Mapped[str] = mapped_column(unique=True)
+            __mapper_args__ = {"polymorphic_identity": "child"}
+
+        class B(Base):
+            __tablename__ = "b"
+            id: Mapped[int] = mapped_column(primary_key=True)
+
+        join_cond = A.bs.property._join_condition
+        flag = join_cond.secondary_covers_parent_primary_key
+
+        assert flag is True
+
+    def test_false_special_case_with_inheritance(self):
+        """
+        This is a special case where relationship bs is for
+        AChild, and AChild's pk is a fk from parent A. But
+        for table a_b the keys come from parent A and B.
+
+        We are expecting the results to be False since
+        it should fail the `issubset` evaluation between AChild
+        and B.
+
+        When forcing True to allow omit_join=True for this example,
+        the IN statement still works and gets optimized since
+        AChild.id = A.id
+        """
+        Base = declarative_base()
+
+        a_b = Table(
+            "a_b",
+            Base.metadata,
+            Column("a_id", Integer, ForeignKey("a.id"), primary_key=True),
+            Column("b_id", Integer, ForeignKey("b.id"), primary_key=True),
+        )
+
+        class A(Base):
+            __tablename__ = "a"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            type: Mapped[str] = mapped_column()
+            __mapper_args__ = {
+                "polymorphic_on": type,
+                "polymorphic_identity": "parent",
+            }
+
+        class AChild(A):
+            __tablename__ = "a_child"
+            id: Mapped[int] = mapped_column(
+                ForeignKey("a.id"), primary_key=True
+            )
+            code: Mapped[str] = mapped_column(unique=True)
+            bs = relationship("B", secondary=a_b)
+            __mapper_args__ = {"polymorphic_identity": "child"}
+
+        class B(Base):
+            __tablename__ = "b"
+            id: Mapped[int] = mapped_column(primary_key=True)
+
+        join_cond = AChild.bs.property._join_condition
+        flag = join_cond.secondary_covers_parent_primary_key
+
+        assert flag is False
+
+    def test_true_asymmetric_composite(self):
+        Base = declarative_base()
+
+        association_table = Table(
+            "a_b",
+            Base.metadata,
+            Column("a_id1", Integer, ForeignKey("a.id1")),
+            Column("a_id2", Integer, ForeignKey("a.id2")),
+            Column("b_id", Integer, ForeignKey("b.id")),
+        )
+
+        class A(Base):
+            __tablename__ = "a"
+            id1: Mapped[int] = mapped_column(primary_key=True)
+            id2: Mapped[int] = mapped_column(primary_key=True)
+            bs = relationship(
+                "B",
+                secondary=association_table,
+                primaryjoin=lambda: and_(
+                    A.id1 == association_table.c.a_id1,
+                    A.id2 == association_table.c.a_id2,
+                ),
+                secondaryjoin=lambda: B.id == association_table.c.b_id,
+            )
+
+        class B(Base):
+            __tablename__ = "b"
+            id: Mapped[int] = mapped_column(primary_key=True)
+
+        join_cond = A.bs.property._join_condition
+        flag = join_cond.secondary_covers_parent_primary_key
+
+        assert flag is True
+
+    def test_false_asymmetric_composite_secondary_joins_on_partial_pk(self):
+        Base = declarative_base()
+
+        association_table = Table(
+            "a_b",
+            Base.metadata,
+            Column("a_id1", Integer, ForeignKey("a.id1")),
+            Column("b_id", Integer, ForeignKey("b.id")),
+        )
+
+        class A(Base):
+            __tablename__ = "a"
+            id1: Mapped[int] = mapped_column(primary_key=True)
+            id2: Mapped[int] = mapped_column(primary_key=True)
+            bs = relationship(
+                "B",
+                secondary=association_table,
+                primaryjoin=lambda: A.id1 == association_table.c.a_id1,
+                secondaryjoin=lambda: B.id == association_table.c.b_id,
+            )
+
+        class B(Base):
+            __tablename__ = "b"
+            id: Mapped[int] = mapped_column(primary_key=True)
+
+        join_cond = A.bs.property._join_condition
+        flag = join_cond.secondary_covers_parent_primary_key
+
+        assert flag is False
+
+    def test_true_simple_secondary_joins_on_pk(self):
+        Base = declarative_base()
+
+        atob = Table(
+            "atob",
+            Base.metadata,
+            Column("a_id", ForeignKey("a.id")),
+            Column("b_id", ForeignKey("b.id")),
+        )
+
+        class A(Base):
+            __tablename__ = "a"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            bs: Mapped[list["B"]] = relationship("B", secondary=atob)
+
+        class B(Base):
+            __tablename__ = "b"
+            id: Mapped[int] = mapped_column(primary_key=True)
+
+        join_cond = A.bs.property._join_condition
+        flag = join_cond.secondary_covers_parent_primary_key
+
+        assert flag is True
+
+    def test_true_bi_directional(self):
+        Base = declarative_base()
+
+        atob = Table(
+            "atob",
+            Base.metadata,
+            Column("a_id", ForeignKey("a.id")),
+            Column("b_id", ForeignKey("b.id")),
+        )
+
+        class A(Base):
+            __tablename__ = "a"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            bs: Mapped[list["B"]] = relationship(
+                "B", secondary=atob, back_populates="as_"
+            )
+
+        class B(Base):
+            __tablename__ = "b"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            as_: Mapped[list["A"]] = relationship(
+                "A", secondary=atob, back_populates="bs"
+            )
+
+        join_cond = A.bs.property._join_condition
+        a_flag = join_cond.secondary_covers_parent_primary_key
+
+        join_cond = B.as_.property._join_condition
+        b_flag = join_cond.secondary_covers_parent_primary_key
+
+        assert a_flag is True
+        assert b_flag is True
+
+    def test_true_association_table_with_m2m_access_pattern(self):
+        """
+        Example pulled from Sqlalchemy documentation, with the only
+        changes was to include "viewonly=True" to the secondary
+        relationship.
+        """
+        Base = declarative_base()
+
+        class Association(Base):
+            __tablename__ = "association_table"
+
+            left_id: Mapped[int] = mapped_column(
+                ForeignKey("left_table.id"), primary_key=True
+            )
+            right_id: Mapped[int] = mapped_column(
+                ForeignKey("right_table.id"), primary_key=True
+            )
+            extra_data: Mapped[Optional[str]]
+
+            # association between Association -> Child
+            child: Mapped["Child"] = relationship(
+                back_populates="parent_associations"
+            )
+
+            # association between Association -> Parent
+            parent: Mapped["Parent"] = relationship(
+                back_populates="child_associations"
+            )
+
+        class Parent(Base):
+            __tablename__ = "left_table"
+
+            id: Mapped[int] = mapped_column(primary_key=True)
+
+            # many-to-many relationship to Child,
+            # bypassing the `Association` class
+            children: Mapped[List["Child"]] = relationship(
+                secondary="association_table",
+                back_populates="parents",
+                viewonly=True,
+            )
+
+            # association between Parent -> Association -> Child
+            child_associations: Mapped[List["Association"]] = relationship(
+                back_populates="parent"
+            )
+
+        class Child(Base):
+            __tablename__ = "right_table"
+
+            id: Mapped[int] = mapped_column(primary_key=True)
+
+            # many-to-many relationship to Parent,
+            # bypassing the `Association` class
+            parents: Mapped[List["Parent"]] = relationship(
+                secondary="association_table",
+                back_populates="children",
+                viewonly=True,
+            )
+
+            # association between Child -> Association -> Parent
+            parent_associations: Mapped[List["Association"]] = relationship(
+                back_populates="child"
+            )
+
+        join_cond = Parent.children.property._join_condition
+        parent_child_flag = join_cond.secondary_covers_parent_primary_key
+
+        join_cond = Child.parents.property._join_condition
+        child_parent_flag = join_cond.secondary_covers_parent_primary_key
+
+        assert parent_child_flag is True
+        assert child_parent_flag is True
 
 
 class ActiveHistoryFlagTest(_fixtures.FixtureTest):

--- a/test/orm/test_relationships.py
+++ b/test/orm/test_relationships.py
@@ -6674,11 +6674,11 @@ class SecondaryIncludesLocalColsTest(fixtures.MappedTest):
                 params=[{"id_1": 2}],
             ),
             CompiledSQL(
-                "SELECT a_1.id, b.id FROM a AS a_1 JOIN "
+                "SELECT anon_1.aid, b.id FROM "
                 "(SELECT a.id AS aid, b.id AS id FROM a JOIN b ON a.b_ids "
                 "LIKE (:id_1 || b.id || :param_1)) AS anon_1 "
-                "ON a_1.id = anon_1.aid JOIN b ON b.id = anon_1.id "
-                "WHERE a_1.id IN (__[POSTCOMPILE_primary_keys])",
+                "JOIN b ON b.id = anon_1.id "
+                "WHERE anon_1.aid IN (__[POSTCOMPILE_primary_keys])",
                 params=[{"id_1": "%", "param_1": "%", "primary_keys": [2]}],
             ),
         )

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -1,5 +1,7 @@
 import sqlalchemy as sa
+from sqlalchemy import and_
 from sqlalchemy import bindparam
+from sqlalchemy import Boolean
 from sqlalchemy import ForeignKey
 from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy import Integer
@@ -3636,6 +3638,562 @@ class M2OWDegradeTest(
                 A(id=5, b=b1),
             ],
         )
+
+
+class M2MSimpleOmitTest(fixtures.DeclarativeMappedTest):
+    @classmethod
+    def setup_classes(cls):
+        Base = cls.DeclarativeBasic
+
+        association_table = Table(
+            "a_b",
+            Base.metadata,
+            Column("a_id", Integer, ForeignKey("a.id")),
+            Column("b_id", Integer, ForeignKey("b.id")),
+        )
+
+        class A(Base):
+            __tablename__ = "a"
+            id = Column(Integer, primary_key=True)
+            bs = relationship("B", secondary=association_table)
+            bs_no_omit_join = relationship(
+                "B",
+                secondary=association_table,
+                omit_join=False,
+                overlaps="bs",
+            )
+
+        class B(Base):
+            __tablename__ = "b"
+            id = Column(Integer, primary_key=True)
+
+    @classmethod
+    def insert_data(cls, connection):
+        A, B = cls.classes("A", "B")
+        session = Session(connection)
+        a1 = A(id=1)
+        a2 = A(id=2)
+        b1 = B(id=1)
+        b2 = B(id=2)
+
+        a1.bs = [b1, b2]
+        a2.bs = [b1]
+
+        session.add_all([a1, a2, b1, b2])
+        session.commit()
+
+    def test_m2m_omit_join_true(self):
+        A = self.classes.A
+        session = fixture_session()
+
+        def go():
+            statement = select(A).options(selectinload(A.bs)).order_by(A.id)
+            session.execute(statement).scalars().all()
+
+        self.assert_sql_execution(
+            testing.db,
+            go,
+            CompiledSQL("SELECT a.id FROM a ORDER BY a.id", {}),
+            CompiledSQL(
+                "SELECT a_b.a_id, b.id "
+                "FROM a_b JOIN b ON b.id = a_b.b_id "
+                "WHERE a_b.a_id IN "
+                "(__[POSTCOMPILE_primary_keys])",
+                {"primary_keys": [1, 2]},
+            ),
+        )
+
+    def test_m2m_omit_join_false(self):
+        A = self.classes.A
+        session = fixture_session()
+
+        def go():
+            statement = (
+                select(A)
+                .options(selectinload(A.bs_no_omit_join))
+                .order_by(A.id)
+            )
+            session.execute(statement).scalars().all()
+
+        self.assert_sql_execution(
+            testing.db,
+            go,
+            CompiledSQL("SELECT a.id FROM a ORDER BY a.id", {}),
+            CompiledSQL(
+                "SELECT a_1.id, b.id "
+                "FROM a AS a_1 JOIN a_b AS a_b_1 ON a_1.id = a_b_1.a_id "
+                "JOIN b ON b.id = a_b_1.b_id "
+                "WHERE a_1.id IN "
+                "(__[POSTCOMPILE_primary_keys])",
+                {"primary_keys": [1, 2]},
+            ),
+        )
+
+
+class M2MSymmetricCompositeKeyOmitTest(fixtures.DeclarativeMappedTest):
+    @classmethod
+    def setup_classes(cls):
+        Base = cls.DeclarativeBasic
+
+        association_table = Table(
+            "a_b",
+            Base.metadata,
+            Column("a_id1", Integer, ForeignKey("a.id1")),
+            Column("a_id2", Integer, ForeignKey("a.id2")),
+            Column("b_id1", Integer, ForeignKey("b.id1")),
+            Column("b_id2", Integer, ForeignKey("b.id2")),
+        )
+
+        class B(Base):
+            __tablename__ = "b"
+            id1 = Column(Integer, primary_key=True)
+            id2 = Column(Integer, primary_key=True)
+
+        class A(Base):
+            __tablename__ = "a"
+            id1 = Column(Integer, primary_key=True)
+            id2 = Column(Integer, primary_key=True)
+            bs = relationship(
+                "B",
+                secondary=association_table,
+                primaryjoin=lambda: and_(
+                    A.id1 == association_table.c.a_id1,
+                    A.id2 == association_table.c.a_id2,
+                ),
+                secondaryjoin=lambda: and_(
+                    B.id1 == association_table.c.b_id1,
+                    B.id2 == association_table.c.b_id2,
+                ),
+            )
+            bs_no_omit_join = relationship(
+                "B",
+                secondary=association_table,
+                omit_join=False,
+                overlaps="bs",
+                primaryjoin=lambda: and_(
+                    A.id1 == association_table.c.a_id1,
+                    A.id2 == association_table.c.a_id2,
+                ),
+                secondaryjoin=lambda: and_(
+                    B.id1 == association_table.c.b_id1,
+                    B.id2 == association_table.c.b_id2,
+                ),
+            )
+
+    @classmethod
+    def insert_data(cls, connection):
+        A, B = cls.classes("A", "B")
+        session = Session(connection)
+        a1 = A(id1=1, id2=1)
+        a2 = A(id1=1, id2=2)
+        b1 = B(id1=1, id2=1)
+        b2 = B(id1=1, id2=2)
+
+        a1.bs = [b1, b2]
+        a2.bs = [b1]
+
+        session.add_all([a1, a2, b1, b2])
+        session.commit()
+
+    def test_m2m_omit_join_true(self):
+        A = self.classes.A
+        session = fixture_session()
+
+        def go():
+            statement = (
+                select(A).options(selectinload(A.bs)).order_by(A.id1, A.id2)
+            )
+            session.execute(statement).scalars().all()
+
+        self.assert_sql_execution(
+            testing.db,
+            go,
+            CompiledSQL(
+                "SELECT a.id1, a.id2 FROM a ORDER BY a.id1, a.id2",
+                {},
+            ),
+            CompiledSQL(
+                "SELECT a_b.a_id1, a_b.a_id2, b.id1, b.id2 "
+                "FROM a_b JOIN b ON b.id1 = a_b.b_id1 AND b.id2 = a_b.b_id2 "
+                "WHERE (a_b.a_id1, a_b.a_id2) IN "
+                "(__[POSTCOMPILE_primary_keys])",
+                {"primary_keys": [(1, 1), (1, 2)]},
+            ),
+        )
+
+    def test_m2m_omit_join_false(self):
+        A = self.classes.A
+        session = fixture_session()
+
+        def go():
+            statement = (
+                select(A)
+                .options(selectinload(A.bs_no_omit_join))
+                .order_by(A.id1, A.id2)
+            )
+            session.execute(statement).scalars().all()
+
+        self.assert_sql_execution(
+            testing.db,
+            go,
+            CompiledSQL(
+                "SELECT a.id1, a.id2 FROM a ORDER BY a.id1, a.id2",
+                {},
+            ),
+            CompiledSQL(
+                "SELECT a_1.id1, a_1.id2, b.id1, b.id2 "
+                "FROM a AS a_1 JOIN a_b AS a_b_1 ON "
+                "a_1.id1 = a_b_1.a_id1 AND a_1.id2 = a_b_1.a_id2 "
+                "JOIN b ON b.id1 = a_b_1.b_id1 AND b.id2 = a_b_1.b_id2 "
+                "WHERE (a_1.id1, a_1.id2) IN "
+                "(__[POSTCOMPILE_primary_keys])",
+                {"primary_keys": [(1, 1), (1, 2)]},
+            ),
+        )
+
+
+class M2MAsymmetricCompositeKeyOmitTest(fixtures.DeclarativeMappedTest):
+    @classmethod
+    def setup_classes(cls):
+        Base = cls.DeclarativeBasic
+
+        association_table = Table(
+            "a_b",
+            Base.metadata,
+            Column("a_id1", Integer, ForeignKey("a.id1")),
+            Column("a_id2", Integer, ForeignKey("a.id2")),
+            Column("b_id", Integer, ForeignKey("b.id")),
+        )
+
+        class A(Base):
+            __tablename__ = "a"
+            id1 = Column(Integer, primary_key=True)
+            id2 = Column(Integer, primary_key=True)
+            bs = relationship(
+                "B",
+                secondary=association_table,
+                primaryjoin=lambda: and_(
+                    A.id1 == association_table.c.a_id1,
+                    A.id2 == association_table.c.a_id2,
+                ),
+                secondaryjoin=lambda: B.id == association_table.c.b_id,
+            )
+            bs_no_omit_join = relationship(
+                "B",
+                secondary=association_table,
+                omit_join=False,
+                overlaps="bs",
+                primaryjoin=lambda: and_(
+                    A.id1 == association_table.c.a_id1,
+                    A.id2 == association_table.c.a_id2,
+                ),
+                secondaryjoin=lambda: B.id == association_table.c.b_id,
+            )
+
+        class B(Base):
+            __tablename__ = "b"
+            id = Column(Integer, primary_key=True)
+
+    @classmethod
+    def insert_data(cls, connection):
+        A, B = cls.classes("A", "B")
+        session = Session(connection)
+        a1 = A(id1=1, id2=1)
+        a2 = A(id1=1, id2=2)
+        b1 = B(id=1)
+        b2 = B(id=2)
+        b3 = B(id=3)
+
+        a1.bs = [b1, b2, b3]
+        a2.bs = [b2, b3]
+
+        session.add_all([a1, a2, b1, b2, b3])
+        session.commit()
+
+    def test_m2m_omit_join_true(self):
+        A = self.classes.A
+        session = fixture_session()
+
+        def go():
+            statement = (
+                select(A).options(selectinload(A.bs)).order_by(A.id1, A.id2)
+            )
+            session.execute(statement).scalars().all()
+
+        self.assert_sql_execution(
+            testing.db,
+            go,
+            CompiledSQL(
+                "SELECT a.id1, a.id2 " "FROM a ORDER BY a.id1, a.id2",
+                {},
+            ),
+            CompiledSQL(
+                "SELECT a_b.a_id1, a_b.a_id2, b.id "
+                "FROM a_b JOIN b ON b.id = a_b.b_id "
+                "WHERE (a_b.a_id1, a_b.a_id2) IN "
+                "(__[POSTCOMPILE_primary_keys])",
+                {"primary_keys": [(1, 1), (1, 2)]},
+            ),
+        )
+
+    def test_m2m_omit_join_false(self):
+        A = self.classes.A
+        session = fixture_session()
+
+        def go():
+            statement = (
+                select(A)
+                .options(selectinload(A.bs_no_omit_join))
+                .order_by(A.id1, A.id2)
+            )
+            session.execute(statement).scalars().all()
+
+        self.assert_sql_execution(
+            testing.db,
+            go,
+            CompiledSQL(
+                "SELECT a.id1, a.id2 FROM a ORDER BY a.id1, a.id2",
+                {},
+            ),
+            CompiledSQL(
+                "SELECT a_1.id1, a_1.id2, b.id "
+                "FROM a AS a_1 JOIN a_b AS a_b_1 "
+                "ON a_1.id1 = a_b_1.a_id1 AND a_1.id2 = a_b_1.a_id2 "
+                "JOIN b ON b.id = a_b_1.b_id "
+                "WHERE (a_1.id1, a_1.id2) IN "
+                "(__[POSTCOMPILE_primary_keys])",
+                {"primary_keys": [(1, 1), (1, 2)]},
+            ),
+        )
+
+
+class M2MReverseAsymmetricCompositeKeyOmitTest(fixtures.DeclarativeMappedTest):
+    @classmethod
+    def setup_classes(cls):
+        Base = cls.DeclarativeBasic
+
+        association_table = Table(
+            "a_b",
+            Base.metadata,
+            Column("a_id", Integer, ForeignKey("a.id")),
+            Column("b_id1", Integer, ForeignKey("b.id1")),
+            Column("b_id2", Integer, ForeignKey("b.id2")),
+        )
+
+        class A(Base):
+            __tablename__ = "a"
+            id = Column(Integer, primary_key=True)
+            bs = relationship(
+                "B",
+                secondary=association_table,
+                primaryjoin=lambda: A.id == association_table.c.a_id,
+                secondaryjoin=lambda: and_(
+                    B.id1 == association_table.c.b_id1,
+                    B.id2 == association_table.c.b_id2,
+                ),
+            )
+            bs_no_omit_join = relationship(
+                "B",
+                secondary=association_table,
+                omit_join=False,
+                overlaps="bs",
+                primaryjoin=lambda: A.id == association_table.c.a_id,
+                secondaryjoin=lambda: and_(
+                    B.id1 == association_table.c.b_id1,
+                    B.id2 == association_table.c.b_id2,
+                ),
+            )
+
+        class B(Base):
+            __tablename__ = "b"
+            id1 = Column(Integer, primary_key=True)
+            id2 = Column(Integer, primary_key=True)
+
+    @classmethod
+    def insert_data(cls, connection):
+        A, B = cls.classes("A", "B")
+        session = Session(connection)
+        a1 = A(id=1)
+        a2 = A(id=2)
+        b1 = B(id1=1, id2=1)
+        b2 = B(id1=1, id2=2)
+        b3 = B(id1=2, id2=1)
+
+        a1.bs = [b1, b2, b3]
+        a2.bs = [b2, b3]
+
+        session.add_all([a1, a2, b1, b2, b3])
+        session.commit()
+
+    def test_m2m_omit_join_true(self):
+        A = self.classes.A
+        session = fixture_session()
+
+        def go():
+            statement = select(A).options(selectinload(A.bs)).order_by(A.id)
+            session.execute(statement).scalars().all()
+
+        self.assert_sql_execution(
+            testing.db,
+            go,
+            CompiledSQL(
+                "SELECT a.id FROM a ORDER BY a.id",
+                {},
+            ),
+            CompiledSQL(
+                "SELECT a_b.a_id, b.id1, b.id2 "
+                "FROM a_b JOIN b ON b.id1 = a_b.b_id1 AND b.id2 = a_b.b_id2 "
+                "WHERE a_b.a_id IN "
+                "(__[POSTCOMPILE_primary_keys])",
+                {"primary_keys": [1, 2]},
+            ),
+        )
+
+    def test_m2m_omit_join_false(self):
+        A = self.classes.A
+        session = fixture_session()
+
+        def go():
+            statement = (
+                select(A)
+                .options(selectinload(A.bs_no_omit_join))
+                .order_by(A.id)
+            )
+            session.execute(statement).scalars().all()
+
+        self.assert_sql_execution(
+            testing.db,
+            go,
+            CompiledSQL(
+                "SELECT a.id FROM a ORDER BY a.id",
+                {},
+            ),
+            CompiledSQL(
+                "SELECT a_1.id, b.id1, b.id2 "
+                "FROM a AS a_1 JOIN a_b AS a_b_1 ON a_1.id = a_b_1.a_id "
+                "JOIN b ON b.id1 = a_b_1.b_id1 AND b.id2 = a_b_1.b_id2 "
+                "WHERE a_1.id IN "
+                "(__[POSTCOMPILE_primary_keys])",
+                {"primary_keys": [1, 2]},
+            ),
+        )
+
+
+class M2MFilteredSecondaryjoinOmitTest(fixtures.DeclarativeMappedTest):
+    @classmethod
+    def setup_classes(cls):
+        Base = cls.DeclarativeBasic
+
+        association_table = Table(
+            "a_b",
+            Base.metadata,
+            Column("a_id", Integer, ForeignKey("a.id")),
+            Column("b_id", Integer, ForeignKey("b.id")),
+        )
+
+        class A(Base):
+            __tablename__ = "a"
+            id = Column(Integer, primary_key=True)
+            bs = relationship(
+                "B",
+                secondary=association_table,
+                primaryjoin=lambda: A.id == association_table.c.a_id,
+                secondaryjoin=lambda: and_(
+                    B.id == association_table.c.b_id,
+                    B.active == True,
+                ),
+            )
+            bs_no_omit_join = relationship(
+                "B",
+                secondary=association_table,
+                omit_join=False,
+                overlaps="bs",
+                primaryjoin=lambda: A.id == association_table.c.a_id,
+                secondaryjoin=lambda: and_(
+                    B.id == association_table.c.b_id,
+                    B.active == True,
+                ),
+            )
+
+        class B(Base):
+            __tablename__ = "b"
+            id = Column(Integer, primary_key=True)
+            active = Column(Boolean, default=True)
+
+    @classmethod
+    def insert_data(cls, connection):
+        A, B = cls.classes("A", "B")
+        session = Session(connection)
+        a1 = A(id=1)
+        a2 = A(id=2)
+        b1 = B(id=1, active=True)
+        b2 = B(id=2, active=False)  # inactive - should be filtered out
+        b3 = B(id=3, active=True)
+
+        a1.bs = [b1, b2, b3]
+        a2.bs = [b2, b3]
+
+        session.add_all([a1, a2, b1, b2, b3])
+        session.commit()
+
+    def test_m2m_omit_join_true(self):
+        A = self.classes.A
+        session = fixture_session()
+
+        def go():
+            statement = select(A).options(selectinload(A.bs)).order_by(A.id)
+            return session.execute(statement).scalars().all()
+
+        results = self.assert_sql_execution(
+            testing.db,
+            go,
+            CompiledSQL(
+                "SELECT a.id FROM a ORDER BY a.id",
+                {},
+            ),
+            CompiledSQL(
+                "SELECT a_b.a_id, b.id, b.active "
+                "FROM a_b JOIN b ON b.id = a_b.b_id AND b.active = 1 "
+                "WHERE a_b.a_id IN "
+                "(__[POSTCOMPILE_primary_keys])",
+                {"primary_keys": [1, 2]},
+            ),
+        )
+
+        eq_(sorted(b.id for b in results[0].bs), [1, 3])
+        eq_(sorted(b.id for b in results[1].bs), [3])
+
+    def test_m2m_omit_join_false(self):
+        A = self.classes.A
+        session = fixture_session()
+
+        def go():
+            statement = (
+                select(A)
+                .options(selectinload(A.bs_no_omit_join))
+                .order_by(A.id)
+            )
+            return session.execute(statement).scalars().all()
+
+        results = self.assert_sql_execution(
+            testing.db,
+            go,
+            CompiledSQL(
+                "SELECT a.id FROM a ORDER BY a.id",
+                {},
+            ),
+            CompiledSQL(
+                "SELECT a_1.id, b.id, b.active "
+                "FROM a AS a_1 JOIN a_b AS a_b_1 ON a_1.id = a_b_1.a_id "
+                "JOIN b ON b.id = a_b_1.b_id AND b.active = 1 "
+                "WHERE a_1.id IN "
+                "(__[POSTCOMPILE_primary_keys])",
+                {"primary_keys": [1, 2]},
+            ),
+        )
+
+        eq_(sorted(b.id for b in results[0].bs_no_omit_join), [1, 3])
+        eq_(sorted(b.id for b in results[1].bs_no_omit_join), [3])
 
 
 class SameNamePolymorphicTest(fixtures.DeclarativeMappedTest):


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->
The :func:`.selectinload` loader strategy now supports the `omit_join` optimization for many-to-many non-self-referential relationships, reducing the number of joins in the secondary SELECT by selecting from the secondary table directly rather than joining back to the parent entity. `omit_join` is enabled automatically and can be disabled by setting :paramref:`.relationship.omit_join` to `False`.

Before this implementation, many-to-many relationships would utilize `init_for_join()` since `omit_join` would not pass the `.compare()` strategy evaluation, as `.compare()` is not designed to handle many-to-many relationships.

The changes build on `init_for_omit_join()` with new logic implemented in `_load_for_path()`, specifically involving `load_with_join`. Previously, `init_for_omit_join()` sets `load_with_join` to `False`, leading to `q=q.select_from(effective_entity)`. These changes do not modify the `load_with_join` flag but instead set the association table as the starting point of the query and join from it to the related entity. For many-to-many relationships with composite foreign keys, `secondaryjoin` is included to explicitly define the join condition.

Fixes #5987
### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
