### PR TITLE
Remove redundant deserializer assignment from asyncpg dialect

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/asyncpg.py
+++ b/lib/sqlalchemy/dialects/postgresql/asyncpg.py
@@ -1255,7 +1255,6 @@ class PGDialect_asyncpg(PGDialect):
         """
 
         asyncpg_connection = conn._connection
-        deserializer = self._json_deserializer or _py_json.loads
 
         def _jsonb_encoder(str_value):
             # \x01 is the prefix for jsonb used by PostgreSQL.


### PR DESCRIPTION
### Description
asyncpg JSONB deserializer is assigned in both 

https://github.com/sqlalchemy/sqlalchemy/blob/1e1c0084b1804eaae8b7f089435241a2b8f4be60/lib/sqlalchemy/dialects/postgresql/asyncpg.py#L1258

and

https://github.com/sqlalchemy/sqlalchemy/blob/1e1c0084b1804eaae8b7f089435241a2b8f4be60/lib/sqlalchemy/dialects/postgresql/asyncpg.py#L1265

Remove the first one as it is redundant.

### Checklist

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

### Tests done
`pytest --db asyncpg test/dialect/postgresql/test_async_pg.py`
