### PR TITLE
fix(pool): use time.monotonic() instead of time.time() for connection timestamps

### DIFF
--- a/lib/sqlalchemy/pool/base.py
+++ b/lib/sqlalchemy/pool/base.py
@@ -404,7 +404,7 @@ class Pool(log.Identified, event.EventTarget):
         """
         rec = getattr(connection, "_connection_record", None)
         if not rec or self._invalidate_time < rec.starttime:
-            self._invalidate_time = time.time()
+            self._invalidate_time = time.monotonic()
         if _checkin and getattr(connection, "is_valid", False):
             connection.invalidate(exception)
 
@@ -809,7 +809,7 @@ class _ConnectionRecord(ConnectionPoolEntry):
             )
 
         if soft:
-            self._soft_invalidate_time = time.time()
+            self._soft_invalidate_time = time.monotonic()
         else:
             self.__close(terminate=True)
             self.dbapi_connection = None
@@ -817,25 +817,20 @@ class _ConnectionRecord(ConnectionPoolEntry):
     def get_connection(self) -> DBAPIConnection:
         recycle = False
 
-        # NOTE: the various comparisons here are assuming that measurable time
-        # passes between these state changes.  however, time.time() is not
-        # guaranteed to have sub-second precision.  comparisons of
-        # "invalidation time" to "starttime" should perhaps use >= so that the
-        # state change can take place assuming no measurable  time has passed,
-        # however this does not guarantee correct behavior here as if time
-        # continues to not pass, it will try to reconnect repeatedly until
-        # these timestamps diverge, so in that sense using > is safer.  Per
-        # https://stackoverflow.com/a/1938096/34549, Windows time.time() may be
-        # within 16 milliseconds accuracy, so unit tests for connection
-        # invalidation need a sleep of at least this long between initial start
-        # time and invalidation for the logic below to work reliably.
+        # NOTE: the various comparisons here compare time.monotonic()
+        # values which are guaranteed to be monotonic and have
+        # sub-millisecond precision across all platforms. This resolves
+        # the issue where time.time() could have ~16 ms granularity
+        # on Windows, causing comparisons like _soft_invalidate_time >
+        # starttime to fail when both timestamps were captured within
+        # the same timer quantum.
 
         if self.dbapi_connection is None:
             self.info.clear()
             self.__connect()
         elif (
             self.__pool._recycle > -1
-            and time.time() - self.starttime > self.__pool._recycle
+            and time.monotonic() - self.starttime > self.__pool._recycle
         ):
             self.__pool.logger.info(
                 "Connection %r exceeded timeout; recycling",
@@ -890,7 +885,7 @@ class _ConnectionRecord(ConnectionPoolEntry):
         # creator fails, this attribute stays None
         self.dbapi_connection = None
         try:
-            self.starttime = time.time()
+            self.starttime = time.monotonic()
             self.dbapi_connection = connection = pool._invoke_creator(self)
             pool.logger.debug("Created new connection %r", connection)
             self.fresh = True


### PR DESCRIPTION
### Description

Replaced all `time.time()` calls in `pool/base.py` with `time.monotonic()` for connection record timestamp tracking. Also updated the comment block that documented the Windows precision caveat.

`time.time()` on Windows has approximately 16 ms granularity, which can cause soft invalidation checks to fail when `_soft_invalidate_time` and `starttime` are captured in the same timer quantum. `time.monotonic()` is monotonic by definition and provides sub-millisecond precision on all platforms, so the `>` comparisons between timestamps work correctly regardless of platform timer resolution.

Four sites changed (all in `lib/sqlalchemy/pool/base.py`):
- `Pool._invalidate_time` assignment (line 407)
- `_ConnectionRecord._soft_invalidate_time` assignment (line 812)
- Connection recycle time check in `get_connection` (line 838)
- `_ConnectionRecord.starttime` assignment in `__connect` (line 893)

All comparisons are relative (timestamp vs timestamp or timestamp delta vs timeout), so switching to `time.monotonic()` preserves existing behavior while fixing the precision issue.

- [x] A short code fix
  - Fixes: #13169
  - Existing pool invalidation tests cover the comparison logic