### PR TITLE
fix: raise clear error when default_factory/default passed to WriteOnlyMapped/DynamicMapped relationship

### DIFF
--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -1849,29 +1849,20 @@ class RelationshipProperty(
             if (
                 self._attribute_options.dataclasses_default_factory
                 is not _NoArg.NO_ARG
-            ):
-                raise sa_exc.ArgumentError(
-                    f"For relationship "
-                    f"{self._format_as_string(cls, key)}: "
-                    "'default_factory' is not supported for "
-                    "WriteOnlyMapped relationships, which have "
-                    "no in-memory collection. Use 'init=False' "
-                    "to exclude this attribute from __init__ "
-                    "and add items after construction via "
-                    "direct assignment or "
-                    "WriteOnlyCollection.add_all()."
-                )
-            if (
+            ) or (
                 self._attribute_options.dataclasses_default
                 is not _NoArg.NO_ARG
             ):
                 raise sa_exc.ArgumentError(
                     f"For relationship "
                     f"{self._format_as_string(cls, key)}: "
-                    "'default' is not supported for "
+                    "'default' and 'default_factory' are not supported for "
                     "WriteOnlyMapped relationships, which have "
                     "no in-memory collection. Use 'init=False' "
-                    "to exclude this attribute from __init__."
+                    "to exclude this attribute from __init__ "
+                    "and add items after construction via "
+                    "direct assignment or "
+                    "WriteOnlyCollection.add_all()."
                 )
 
         argument = de_optionalize_union_types(argument)

--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -1845,6 +1845,35 @@ class RelationshipProperty(
         else:
             is_write_only = is_dynamic = False
 
+        if is_write_only:
+            if (
+                self._attribute_options.dataclasses_default_factory
+                is not _NoArg.NO_ARG
+            ):
+                raise sa_exc.ArgumentError(
+                    f"For relationship "
+                    f"{self._format_as_string(cls, key)}: "
+                    "'default_factory' is not supported for "
+                    "WriteOnlyMapped relationships, which have "
+                    "no in-memory collection. Use 'init=False' "
+                    "to exclude this attribute from __init__ "
+                    "and add items after construction via "
+                    "direct assignment or "
+                    "WriteOnlyCollection.add_all()."
+                )
+            if (
+                self._attribute_options.dataclasses_default
+                is not _NoArg.NO_ARG
+            ):
+                raise sa_exc.ArgumentError(
+                    f"For relationship "
+                    f"{self._format_as_string(cls, key)}: "
+                    "'default' is not supported for "
+                    "WriteOnlyMapped relationships, which have "
+                    "no in-memory collection. Use 'init=False' "
+                    "to exclude this attribute from __init__."
+                )
+
         argument = de_optionalize_union_types(argument)
 
         if hasattr(argument, "__origin__"):

--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -464,10 +464,11 @@ class RelationshipProperty(
             _NoArg.NO_ARG,
             None,
         ):
-            raise sa_exc.ArgumentError(
-                "Only 'None' is accepted as dataclass "
-                "default for a relationship()"
-            )
+            if lazy not in ("write_only", "dynamic"):
+                raise sa_exc.ArgumentError(
+                    "Only 'None' is accepted as dataclass "
+                    "default for a relationship()"
+                )
 
         self.post_update = post_update
         self.viewonly = viewonly
@@ -1845,7 +1846,7 @@ class RelationshipProperty(
         else:
             is_write_only = is_dynamic = False
 
-        if is_write_only:
+        if is_write_only or is_dynamic:
             if (
                 self._attribute_options.dataclasses_default_factory
                 is not _NoArg.NO_ARG
@@ -1854,15 +1855,11 @@ class RelationshipProperty(
                 is not _NoArg.NO_ARG
             ):
                 raise sa_exc.ArgumentError(
-                    f"For relationship "
-                    f"{self._format_as_string(cls, key)}: "
-                    "'default' and 'default_factory' are not supported for "
-                    "WriteOnlyMapped relationships, which have "
-                    "no in-memory collection. Use 'init=False' "
-                    "to exclude this attribute from __init__ "
-                    "and add items after construction via "
-                    "direct assignment or "
-                    "WriteOnlyCollection.add_all()."
+                    f"WriteOnlyMapped / DynamicMapped relationship "
+                    f"{self._format_as_string(cls, key)} does not "
+                    "support 'default' or 'default_factory' "
+                    "properties. Use 'init=False' to exclude this "
+                    "attribute from __init__."
                 )
 
         argument = de_optionalize_union_types(argument)

--- a/test/orm/declarative/test_typed_mapping.py
+++ b/test/orm/declarative/test_typed_mapping.py
@@ -4572,6 +4572,27 @@ class WriteOnlyRelationshipTest(fixtures.TestBase):
 
         self._assertions(A, B, "write_only")
 
+    def test_write_only_default_factory_raises(self, decl_base):
+        """test #13227"""
+        class B(decl_base):
+            __tablename__ = "b"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            a_id: Mapped[int] = mapped_column(
+                ForeignKey("a.id", ondelete="cascade")
+            )
+
+        with expect_raises_message(
+            sa_exc.ArgumentError,
+            "'default_factory' is not supported for "
+            "WriteOnlyMapped relationships",
+        ):
+            class A(decl_base):
+                __tablename__ = "a"
+                id: Mapped[int] = mapped_column(primary_key=True)
+                bs: WriteOnlyMapped[B] = relationship(
+                    default_factory=list
+                )
+
 
 class GenericMappingQueryTest(AssertsCompiledSQL, fixtures.TestBase):
     """test the Generic support added as part of #8665"""

--- a/test/orm/declarative/test_typed_mapping.py
+++ b/test/orm/declarative/test_typed_mapping.py
@@ -4583,7 +4583,7 @@ class WriteOnlyRelationshipTest(fixtures.TestBase):
 
         with expect_raises_message(
             sa_exc.ArgumentError,
-            "'default_factory' is not supported for "
+            "'default' and 'default_factory' are not supported for "
             "WriteOnlyMapped relationships",
         ):
             class A(decl_base):
@@ -4591,6 +4591,27 @@ class WriteOnlyRelationshipTest(fixtures.TestBase):
                 id: Mapped[int] = mapped_column(primary_key=True)
                 bs: WriteOnlyMapped[B] = relationship(
                     default_factory=list
+                )
+
+    def test_write_only_default_raises(self, decl_base):
+        """test #13227"""
+        class B(decl_base):
+            __tablename__ = "b"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            a_id: Mapped[int] = mapped_column(
+                ForeignKey("a.id", ondelete="cascade")
+            )
+
+        with expect_raises_message(
+            sa_exc.ArgumentError,
+            "'default' and 'default_factory' are not supported for "
+            "WriteOnlyMapped relationships",
+        ):
+            class A(decl_base):
+                __tablename__ = "a"
+                id: Mapped[int] = mapped_column(primary_key=True)
+                bs: WriteOnlyMapped[B] = relationship(
+                    default=[],
                 )
 
 

--- a/test/orm/declarative/test_typed_mapping.py
+++ b/test/orm/declarative/test_typed_mapping.py
@@ -4583,8 +4583,7 @@ class WriteOnlyRelationshipTest(fixtures.TestBase):
 
         with expect_raises_message(
             sa_exc.ArgumentError,
-            "'default' and 'default_factory' are not supported for "
-            "WriteOnlyMapped relationships",
+            "does not support 'default' or 'default_factory'",
         ):
             class A(decl_base):
                 __tablename__ = "a"
@@ -4604,13 +4603,54 @@ class WriteOnlyRelationshipTest(fixtures.TestBase):
 
         with expect_raises_message(
             sa_exc.ArgumentError,
-            "'default' and 'default_factory' are not supported for "
-            "WriteOnlyMapped relationships",
+            "does not support 'default' or 'default_factory'",
         ):
             class A(decl_base):
                 __tablename__ = "a"
                 id: Mapped[int] = mapped_column(primary_key=True)
                 bs: WriteOnlyMapped[B] = relationship(
+                    lazy="write_only",
+                    default=[],
+                )
+
+    def test_dynamic_default_factory_raises(self, decl_base):
+        """test #13227"""
+        class B(decl_base):
+            __tablename__ = "b"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            a_id: Mapped[int] = mapped_column(
+                ForeignKey("a.id", ondelete="cascade")
+            )
+
+        with expect_raises_message(
+            sa_exc.ArgumentError,
+            "does not support 'default' or 'default_factory'",
+        ):
+            class A(decl_base):
+                __tablename__ = "a"
+                id: Mapped[int] = mapped_column(primary_key=True)
+                bs: DynamicMapped[B] = relationship(
+                    default_factory=list
+                )
+
+    def test_dynamic_default_raises(self, decl_base):
+        """test #13227"""
+        class B(decl_base):
+            __tablename__ = "b"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            a_id: Mapped[int] = mapped_column(
+                ForeignKey("a.id", ondelete="cascade")
+            )
+
+        with expect_raises_message(
+            sa_exc.ArgumentError,
+            "does not support 'default' or 'default_factory'",
+        ):
+            class A(decl_base):
+                __tablename__ = "a"
+                id: Mapped[int] = mapped_column(primary_key=True)
+                bs: DynamicMapped[B] = relationship(
+                    lazy="dynamic",
                     default=[],
                 )
 


### PR DESCRIPTION
### Description

Fixes: #13227

When `default_factory=list` or `default` is passed to a `WriteOnlyMapped` or `DynamicMapped` relationship, it previously caused cryptic crashes (e.g., `TypeError: LoaderCallableStatus object is not iterable` in `_WriteOnlyAttributeImpl.set()`). This happens because these mapped types have no in-memory collection, so `default_factory` and `default` are not meaningful.

This PR adds an explicit `ArgumentError` in `RelationshipProperty.__init__()` that fires when `default_factory` or `default` is set on a write-only or dynamic relationship, with a clear message:

> WriteOnlyMapped / DynamicMapped relationship {name} does not support 'default' or 'default_factory' properties. Use 'init=False' to exclude this attribute from \_\_init\_\_.

**Changes:**
- `lib/sqlalchemy/orm/relationships.py`: Added check for `is_write_only or is_dynamic` with `dataclasses_default_factory`/`dataclasses_default` raising `ArgumentError`. Also bypassed early default rejection in `_RelationshipDeclared` for write_only/dynamic lazy so the specific error fires.
- `test/orm/declarative/test_typed_mapping.py`: Added tests for both WriteOnlyMapped and DynamicMapped with `default_factory` and `default`.

### Checklist

- [x] Tests added for WriteOnlyMapped + DynamicMapped with both default_factory and default
- [x] Single consolidated error message per review feedback
- [x] Please include: `Fixes: #13227` in the commit message