### PR TITLE
Fix subqueryload losing .and_() criteria when combined with of_type()

### DIFF
--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -3383,6 +3383,12 @@ class _JoinCondition:
                 if (
                     parentmapper_for_element is not self.prop.parent
                     and parentmapper_for_element is not self.prop.mapper
+                    and not (
+                        parentmapper_for_element is not None
+                        and parentmapper_for_element.isa(
+                            self.prop.mapper
+                        )
+                    )
                     and elem not in self._secondary_lineage_set
                 ):
                     return _safe_annotate(elem, annotations)

--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -1760,7 +1760,7 @@ class _SubqueryLoader(_PostLoader):
         if loadopt and loadopt._extra_criteria:
             new_options += (
                 orm_util.LoaderCriteriaOption(
-                    self.entity,
+                    effective_entity,
                     loadopt._generate_extra_criteria(context),
                 ),
             )

--- a/test/orm/test_subquery_relations.py
+++ b/test/orm/test_subquery_relations.py
@@ -3837,3 +3837,85 @@ class Issue11173Test(fixtures.DeclarativeMappedTest):
 
                 for sub_item in sub_items:
                     eq_(sub_item.number, sub_item_number)
+
+
+class SubqueryloadOfTypeAndTest(fixtures.DeclarativeMappedTest):
+    """Test that .and_() criteria are preserved when combined with
+    of_type() in subqueryload."""
+
+    @classmethod
+    def setup_classes(cls):
+        Base = cls.DeclarativeBasic
+
+        class Employee(Base):
+            __tablename__ = "employee"
+            id = Column(Integer, primary_key=True)
+            name = Column(String(50))
+            company_id = Column(
+                Integer, ForeignKey("company.id"), nullable=True
+            )
+            type = Column(String(20))
+            __mapper_args__ = {
+                "polymorphic_on": type,
+                "polymorphic_identity": "employee",
+            }
+
+        class Engineer(Employee):
+            __tablename__ = "engineer"
+            id = Column(
+                Integer, ForeignKey("employee.id"), primary_key=True
+            )
+            primary_language = Column(String(50))
+            __mapper_args__ = {"polymorphic_identity": "engineer"}
+
+        class Manager(Employee):
+            __tablename__ = "manager"
+            id = Column(
+                Integer, ForeignKey("employee.id"), primary_key=True
+            )
+            department = Column(String(50))
+            __mapper_args__ = {"polymorphic_identity": "manager"}
+
+        class Company(Base):
+            __tablename__ = "company"
+            id = Column(Integer, primary_key=True)
+            name = Column(String(50))
+            employees = relationship("Employee")
+
+    @classmethod
+    def insert_data(cls, connection):
+        Company, Engineer, Manager = cls.classes(
+            "Company", "Engineer", "Manager"
+        )
+        with Session(connection) as sess:
+            c1 = Company(name="c1")
+            e1 = Engineer(name="e1", primary_language="python")
+            e2 = Engineer(name="e2", primary_language="java")
+            m1 = Manager(name="m1", department="engineering")
+            sess.add_all([c1, e1, e2, m1])
+            c1.employees = [e1, e2, m1]
+            sess.commit()
+
+    def test_subqueryload_of_type_and_criteria(self):
+        """Verify .and_() filter is applied when combining
+        of_type() with subqueryload."""
+        Company, Engineer = self.classes("Company", "Engineer")
+        s = fixture_session()
+
+        q = s.query(Company).options(
+            subqueryload(
+                Company.employees.of_type(Engineer).and_(
+                    Engineer.primary_language == "python"
+                )
+            )
+        )
+
+        result = q.all()
+        eq_(len(result), 1)
+        company = result[0]
+
+        # only python engineers should be loaded via subqueryload;
+        # java engineer and manager should be missing
+        eq_(len(company.employees), 1)
+        eq_(company.employees[0].name, "e1")
+        eq_(company.employees[0].primary_language, "python")


### PR DESCRIPTION
Fixed: #13207
Related: #13203

### Description
When using subqueryload with both of_type() targeting a joined-table subclass and .and_() to add additional filter criteria, the filter criteria were silently ignored. This is because:

1. `_SubqueryLoader._setup_options()` used `self.entity` (the base class mapper) instead of `effective_entity` (the polymorphic of_type() target) when creating the `LoaderCriteriaOption`. This caused the criteria to be associated with the wrong entity.

2. The `mark_exclude_cols` function in `_JoinCondition.join_targets` used identity checks against `self.prop.mapper` (the base class mapper) to determine if a column belongs to the relationship target. Columns from subclass mappers failed this check and were annotated with `should_not_adapt`, preventing the `ClauseAdapter` from rewriting them to use the subquery alias. Added a `mapper.isa()` check to include subclass mappers.

The `mapper.isa()` fix also resolves #13203 (joinedload variant).

### Changes
- `lib/sqlalchemy/orm/strategies.py`: Use `effective_entity` instead of `self.entity` in `_setup_options()`
- `lib/sqlalchemy/orm/relationships.py`: Add `mapper.isa()` check in `mark_exclude_cols`
- `test/orm/test_subquery_relations.py`: Add regression test verifying .and_() criteria are preserved with of_type() in subqueryload