### PR TITLE
Fix PostgreSQL CHECK constraint reflection stripping unrelated parens

### DIFF
--- a/doc/build/changelog/unreleased_21/13157.rst
+++ b/doc/build/changelog/unreleased_21/13157.rst
@@ -1,0 +1,14 @@
+.. change::
+    :tags: bug, postgresql, reflection
+    :tickets: 13157
+
+    Fixed reflection of PostgreSQL CHECK constraints where an expression made
+    up of multiple parenthesized sub-expressions, such as ``(x IS NULL OR y IS
+    NULL) AND (x IS NULL OR y IS NULL)``, would have its leading and trailing
+    parentheses incorrectly stripped, producing an unbalanced and
+    syntactically invalid reflected expression.  The removal of the single
+    layer of enclosing parentheses that PostgreSQL adds around the constraint
+    text is now performed using quote-aware, balanced parenthesis matching,
+    and only strips the outer parentheses when they actually enclose the
+    entire expression.  The underlying parenthesis-matching helper is now
+    shared with the SQLite dialect, which performed the same style of parsing.

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2041,63 +2041,6 @@ ischema_names = {
 }
 
 
-def _strip_outer_parens(text: str) -> str:
-    """Remove one layer of outer parentheses from ``text`` if and only if
-    they actually wrap the entire expression.
-
-    The previous implementation used ``re.sub(r"^[\\s\\n]*\\((.+)\\)[\\s\\n]*$", ...)``
-    which assumed the leading ``(`` matched the trailing ``)``. For inputs
-    such as ``(a) AND (b)`` that produced syntactically invalid text
-    (``a) AND (b``). Walk the string and only strip when the position-zero
-    ``(`` closes at the position-last ``)``.
-
-    Single and double quoted string literals are skipped so parens inside
-    them do not affect the count. PostgreSQL ``''`` and ``""`` escapes
-    (a doubled quote inside a quoted literal) are handled.
-    """
-    stripped = text.strip()
-    if len(stripped) < 2 or stripped[0] != "(" or stripped[-1] != ")":
-        return text
-
-    depth = 0
-    in_single = False
-    in_double = False
-    i = 0
-    n = len(stripped)
-    while i < n:
-        ch = stripped[i]
-        if in_single:
-            if ch == "'":
-                if i + 1 < n and stripped[i + 1] == "'":
-                    i += 2
-                    continue
-                in_single = False
-        elif in_double:
-            if ch == '"':
-                if i + 1 < n and stripped[i + 1] == '"':
-                    i += 2
-                    continue
-                in_double = False
-        elif ch == "'":
-            in_single = True
-        elif ch == '"':
-            in_double = True
-        elif ch == "(":
-            depth += 1
-        elif ch == ")":
-            depth -= 1
-            if depth == 0 and i != n - 1:
-                # The leading ``(`` closed before the end, so the outer
-                # parens do not wrap the whole expression.
-                return text
-        i += 1
-
-    if depth != 0:
-        return text
-
-    return stripped[1:-1]
-
-
 class PGCompiler(compiler.SQLCompiler):
     def visit_to_tsvector_func(self, element, **kw):
         return self._assert_pg_ts_ext(element, **kw)
@@ -5493,7 +5436,7 @@ class PGDialect(default._BackendsMultiReflection, default.DefaultDialect):
                 util.warn("Could not parse CHECK constraint text: %r" % src)
                 sqltext = ""
             else:
-                sqltext = _strip_outer_parens(m.group(1))
+                sqltext = util.strip_outer_parens(m.group(1))
             entry = {
                 "name": check_name,
                 "sqltext": sqltext,

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2041,6 +2041,63 @@ ischema_names = {
 }
 
 
+def _strip_outer_parens(text: str) -> str:
+    """Remove one layer of outer parentheses from ``text`` if and only if
+    they actually wrap the entire expression.
+
+    The previous implementation used ``re.sub(r"^[\\s\\n]*\\((.+)\\)[\\s\\n]*$", ...)``
+    which assumed the leading ``(`` matched the trailing ``)``. For inputs
+    such as ``(a) AND (b)`` that produced syntactically invalid text
+    (``a) AND (b``). Walk the string and only strip when the position-zero
+    ``(`` closes at the position-last ``)``.
+
+    Single and double quoted string literals are skipped so parens inside
+    them do not affect the count. PostgreSQL ``''`` and ``""`` escapes
+    (a doubled quote inside a quoted literal) are handled.
+    """
+    stripped = text.strip()
+    if len(stripped) < 2 or stripped[0] != "(" or stripped[-1] != ")":
+        return text
+
+    depth = 0
+    in_single = False
+    in_double = False
+    i = 0
+    n = len(stripped)
+    while i < n:
+        ch = stripped[i]
+        if in_single:
+            if ch == "'":
+                if i + 1 < n and stripped[i + 1] == "'":
+                    i += 2
+                    continue
+                in_single = False
+        elif in_double:
+            if ch == '"':
+                if i + 1 < n and stripped[i + 1] == '"':
+                    i += 2
+                    continue
+                in_double = False
+        elif ch == "'":
+            in_single = True
+        elif ch == '"':
+            in_double = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0 and i != n - 1:
+                # The leading ``(`` closed before the end, so the outer
+                # parens do not wrap the whole expression.
+                return text
+        i += 1
+
+    if depth != 0:
+        return text
+
+    return stripped[1:-1]
+
+
 class PGCompiler(compiler.SQLCompiler):
     def visit_to_tsvector_func(self, element, **kw):
         return self._assert_pg_ts_ext(element, **kw)
@@ -5436,9 +5493,7 @@ class PGDialect(default._BackendsMultiReflection, default.DefaultDialect):
                 util.warn("Could not parse CHECK constraint text: %r" % src)
                 sqltext = ""
             else:
-                sqltext = re.compile(
-                    r"^[\s\n]*\((.+)\)[\s\n]*$", flags=re.DOTALL
-                ).sub(r"\1", m.group(1))
+                sqltext = _strip_outer_parens(m.group(1))
             entry = {
                 "name": check_name,
                 "sqltext": sqltext,

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2878,32 +2878,14 @@ class SQLiteDialect(default.DefaultDialect):
                     flags=re.DOTALL,
                 )
 
-            # Find the matching closing parenthesis by counting balanced parens
-            # Must track string context to ignore parens inside string literals
-            start = match.end()  # Position after 'CHECK ('
-            paren_count = 1
-            in_single_quote = False
-            in_double_quote = False
-
-            for pos, char in enumerate(table_data[start:], start):
-                # Track string literal context
-                if char == "'" and not in_double_quote:
-                    in_single_quote = not in_single_quote
-                elif char == '"' and not in_single_quote:
-                    in_double_quote = not in_double_quote
-                # Only count parens when not inside a string literal
-                elif not in_single_quote and not in_double_quote:
-                    if char == "(":
-                        paren_count += 1
-                    elif char == ")":
-                        paren_count -= 1
-                        if paren_count == 0:
-                            # Successfully found matching closing parenthesis
-                            sqltext = table_data[start:pos].strip()
-                            cks.append(
-                                {"sqltext": sqltext, "name": constraint_name}
-                            )
-                            break
+            # Find the matching closing parenthesis with quote-aware paren
+            # counting. ``match.end() - 1`` is the position of the ``(``
+            # that opened the CHECK clause; ``match.end()`` is the first
+            # character of the constraint body.
+            close = util.find_matching_paren(table_data, match.end() - 1)
+            if close != -1:
+                sqltext = table_data[match.end():close].strip()
+                cks.append({"sqltext": sqltext, "name": constraint_name})
 
         cks.sort(key=lambda d: d["name"] or "~")  # sort None as last
         if cks:

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2884,7 +2884,7 @@ class SQLiteDialect(default.DefaultDialect):
             # character of the constraint body.
             close = util.find_matching_paren(table_data, match.end() - 1)
             if close != -1:
-                sqltext = table_data[match.end():close].strip()
+                sqltext = table_data[match.end() : close].strip()
                 cks.append({"sqltext": sqltext, "name": constraint_name})
 
         cks.sort(key=lambda d: d["name"] or "~")  # sort None as last

--- a/lib/sqlalchemy/util/__init__.py
+++ b/lib/sqlalchemy/util/__init__.py
@@ -100,9 +100,9 @@ from .langhelpers import decorator as decorator
 from .langhelpers import dictlike_iteritems as dictlike_iteritems
 from .langhelpers import duck_type_collection as duck_type_collection
 from .langhelpers import ellipses_string as ellipses_string
-from .langhelpers import find_matching_paren as find_matching_paren
 from .langhelpers import EnsureKWArg as EnsureKWArg
 from .langhelpers import FastIntFlag as FastIntFlag
+from .langhelpers import find_matching_paren as find_matching_paren
 from .langhelpers import format_argspec_init as format_argspec_init
 from .langhelpers import format_argspec_plus as format_argspec_plus
 from .langhelpers import generic_fn_descriptor as generic_fn_descriptor
@@ -138,7 +138,6 @@ from .langhelpers import (
 )
 from .langhelpers import PluginLoader as PluginLoader
 from .langhelpers import quoted_token_parser as quoted_token_parser
-from .langhelpers import strip_outer_parens as strip_outer_parens
 from .langhelpers import restore_annotations as restore_annotations
 from .langhelpers import ro_memoized_property as ro_memoized_property
 from .langhelpers import ro_non_memoized_property as ro_non_memoized_property
@@ -146,6 +145,7 @@ from .langhelpers import rw_hybridproperty as rw_hybridproperty
 from .langhelpers import safe_reraise as safe_reraise
 from .langhelpers import set_creation_order as set_creation_order
 from .langhelpers import string_or_unprintable as string_or_unprintable
+from .langhelpers import strip_outer_parens as strip_outer_parens
 from .langhelpers import symbol as symbol
 from .langhelpers import TypingOnly as TypingOnly
 from .langhelpers import (

--- a/lib/sqlalchemy/util/__init__.py
+++ b/lib/sqlalchemy/util/__init__.py
@@ -100,6 +100,7 @@ from .langhelpers import decorator as decorator
 from .langhelpers import dictlike_iteritems as dictlike_iteritems
 from .langhelpers import duck_type_collection as duck_type_collection
 from .langhelpers import ellipses_string as ellipses_string
+from .langhelpers import find_matching_paren as find_matching_paren
 from .langhelpers import EnsureKWArg as EnsureKWArg
 from .langhelpers import FastIntFlag as FastIntFlag
 from .langhelpers import format_argspec_init as format_argspec_init
@@ -137,6 +138,7 @@ from .langhelpers import (
 )
 from .langhelpers import PluginLoader as PluginLoader
 from .langhelpers import quoted_token_parser as quoted_token_parser
+from .langhelpers import strip_outer_parens as strip_outer_parens
 from .langhelpers import restore_annotations as restore_annotations
 from .langhelpers import ro_memoized_property as ro_memoized_property
 from .langhelpers import ro_non_memoized_property as ro_non_memoized_property

--- a/lib/sqlalchemy/util/langhelpers.py
+++ b/lib/sqlalchemy/util/langhelpers.py
@@ -2128,6 +2128,91 @@ def wrap_callable(wrapper, fn):
         return _f
 
 
+def find_matching_paren(text: str, start: int = 0) -> int:
+    """Return the index of the ``)`` that matches the ``(`` at ``start``.
+
+    The walk skips single-quoted (``'...'``) and double-quoted (``"..."``)
+    string literals, so parentheses inside string literals do not affect
+    the depth counter. ``''`` and ``""`` are treated as escaped quotes
+    inside their respective contexts, matching PostgreSQL/SQLite literal
+    conventions.
+
+    Returns ``-1`` if the opening parenthesis is never closed (unbalanced).
+    The character at ``text[start]`` is assumed to be ``(``; callers should
+    check before calling.
+
+    E.g.::
+
+        >>> find_matching_paren("(a + b)")
+        6
+        >>> find_matching_paren("((a)(b))")
+        7
+        >>> find_matching_paren("(a = '(' AND b = ')')")
+        20
+
+    """
+    depth = 0
+    in_single = False
+    in_double = False
+    n = len(text)
+    i = start
+    while i < n:
+        ch = text[i]
+        if in_single:
+            if ch == "'":
+                if i + 1 < n and text[i + 1] == "'":
+                    i += 2
+                    continue
+                in_single = False
+        elif in_double:
+            if ch == '"':
+                if i + 1 < n and text[i + 1] == '"':
+                    i += 2
+                    continue
+                in_double = False
+        elif ch == "'":
+            in_single = True
+        elif ch == '"':
+            in_double = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def strip_outer_parens(text: str) -> str:
+    """Remove one layer of outer parentheses from ``text`` if they wrap the
+    entire (stripped) string.
+
+    Whitespace is preserved if the parentheses do not wrap the whole
+    expression. String literals are honored via :func:`find_matching_paren`,
+    so ``"(a = '(' AND b = ')')"`` correctly strips to
+    ``"a = '(' AND b = ')'"`` rather than being interpreted as two separate
+    paren groups.
+
+    E.g.::
+
+        >>> strip_outer_parens("(a IS NOT NULL)")
+        'a IS NOT NULL'
+        >>> strip_outer_parens("(a) AND (b)")
+        '(a) AND (b)'
+        >>> strip_outer_parens("a NOT NULL")
+        'a NOT NULL'
+
+    """
+    stripped = text.strip()
+    if len(stripped) < 2 or stripped[0] != "(" or stripped[-1] != ")":
+        return text
+    close = find_matching_paren(stripped, 0)
+    if close == len(stripped) - 1:
+        return stripped[1:-1]
+    return text
+
+
 def quoted_token_parser(value):
     """Parse a dotted identifier with accommodation for quoted names.
 

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -3561,6 +3561,64 @@ class QuotedTokenParserTest(fixtures.TestBase):
         self._test('"na.me"', ["na.me"])
 
 
+class FindMatchingParenTest(fixtures.TestBase):
+    @testing.combinations(
+        ("(a + b)", 0, 6),
+        ("((a)(b))", 0, 7),
+        ("(a IS NULL OR b IS NULL)", 0, 23),
+        # Sibling parens, not nested -- depth returns to 0 before the end.
+        ("(a) AND (b)", 0, 2),
+        # Parens inside single-quoted literal must not affect the count.
+        ("(a = '(' AND b = ')')", 0, 20),
+        # Doubled single-quote inside a quoted literal is a single-quote
+        # escape; the literal continues until the next unescaped ``'``.
+        ("(a = 'it''s')", 0, 12),
+        # Parens inside double-quoted identifier must not affect the count.
+        ('("col(1)" IS NOT NULL)', 0, 21),
+        # ``start`` other than 0.
+        ("xx(a)yy", 2, 4),
+        argnames="text, start, expected",
+    )
+    def test_balanced(self, text, start, expected):
+        eq_(langhelpers.find_matching_paren(text, start), expected)
+
+    def test_unbalanced(self):
+        eq_(langhelpers.find_matching_paren("(a + b", 0), -1)
+        eq_(langhelpers.find_matching_paren("(a + b'", 0), -1)
+
+
+class StripOuterParensTest(fixtures.TestBase):
+    @testing.combinations(
+        ("(a IS NOT NULL)", "a IS NOT NULL"),
+        ("((a > 1) AND (a < 5))", "(a > 1) AND (a < 5)"),
+        # Multiply-wrapped: strip only the outer layer.
+        ("(((a > 1) AND (a < 5)))", "((a > 1) AND (a < 5))"),
+        # Already unwrapped -- no change.
+        ("a NOT NULL", "a NOT NULL"),
+        # Sibling parens, NOT a single wrap -- must not strip.
+        (
+            "(x IS NULL OR y IS NULL) AND (x IS NULL OR y IS NULL)",
+            "(x IS NULL OR y IS NULL) AND (x IS NULL OR y IS NULL)",
+        ),
+        # Parens inside literals must not throw off the depth counter.
+        ("(a = '(' AND b = ')')", "a = '(' AND b = ')'"),
+        ("a = '(' AND b = ')'", "a = '(' AND b = ')'"),
+        # Whitespace is preserved on the unstripped portion.
+        (
+            "(\n(a < 1)\n OR\n (a >= 5)\n)",
+            "\n(a < 1)\n OR\n (a >= 5)\n",
+        ),
+        # Empty / pathological inputs.
+        ("", ""),
+        ("()", ""),
+        ("(", "("),
+        (")", ")"),
+        argnames="src, expected",
+    )
+    def test_strip(self, src, expected):
+        eq_(langhelpers.strip_outer_parens(src), expected)
+
+
 class BackslashReplaceTest(fixtures.TestBase):
     def test_ascii_to_utf8(self):
         eq_(

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -1208,6 +1208,44 @@ class RegexTest(fixtures.TestBase):
 
         eq_(received, expected)
 
+    @testing.combinations(
+        # Regression for #13157: independent sibling parens must not be
+        # treated as if they wrap the whole expression.
+        (
+            "(x IS NULL OR y IS NULL) AND (x IS NULL OR y IS NULL)",
+            "(x IS NULL OR y IS NULL) AND (x IS NULL OR y IS NULL)",
+        ),
+        # The existing strip-once cases (regression coverage for the
+        # samples enumerated in get_multi_check_constraints).
+        ("((a > 1) AND (a < 5))", "(a > 1) AND (a < 5)"),
+        (
+            "((a = 1) OR ((a > 2) AND (a < 5)))",
+            "(a = 1) OR ((a > 2) AND (a < 5))",
+        ),
+        ("(some_boolean_function(a))", "some_boolean_function(a)"),
+        # Already unwrapped -- no change.
+        ("a NOT NULL", "a NOT NULL"),
+        # Parens inside a single-quoted literal must not throw off the
+        # depth counter.
+        ("(a = '(' AND b = ')')", "a = '(' AND b = ')'"),
+        ("a = '(' AND b = ')'", "a = '(' AND b = ')'"),
+        # Doubled '' inside a quoted literal is the PG single-quote escape.
+        ("(a = 'it''s')", "a = 'it''s'"),
+        # Parens inside a double-quoted identifier must not throw off the
+        # depth counter either.
+        ('("col(1)" IS NOT NULL)', '"col(1)" IS NOT NULL'),
+        # Newlines / whitespace.
+        (
+            "(\n(a < 1)\n OR\n (a >= 5)\n)",
+            "\n(a < 1)\n OR\n (a >= 5)\n",
+        ),
+        argnames="src, expected",
+    )
+    def test_strip_outer_parens(self, src, expected):
+        from sqlalchemy.dialects.postgresql.base import _strip_outer_parens
+
+        eq_(_strip_outer_parens(src), expected)
+
 
 class ReflectionTest(
     ReflectionFixtures, AssertsCompiledSQL, ComparesIndexes, fixtures.TestBase
@@ -2746,6 +2784,56 @@ class ReflectionTest(
                 {
                     "name": "some name",
                     "sqltext": "c != 'hi\nim a name\n'",
+                    "comment": None,
+                },
+            ],
+        )
+
+    def test_reflect_check_constraint_unwrapped_parens(self):
+        """Sibling-paren CHECK expressions must round-trip unchanged through
+        reflection.
+
+        Regression test for #13157: the previous second-strip regex was
+        ``r"^[\\s\\n]*\\((.+)\\)[\\s\\n]*$"`` which greedily paired the
+        leading ``(`` with the trailing ``)`` and dropped both, producing
+        syntactically invalid SQL like ``x IS NULL OR y IS NULL) AND
+        (x IS NULL OR y IS NULL``.
+        """
+        rows = [
+            (
+                "foo",
+                "broken",
+                "CHECK ((x IS NULL OR y IS NULL)"
+                " AND (x IS NULL OR y IS NULL))",
+                None,
+            ),
+            (
+                "foo",
+                "with_literal_parens",
+                "CHECK ((a = '(' AND b = ')'))",
+                None,
+            ),
+        ]
+        conn = mock.Mock(
+            execute=lambda *arg, **kw: mock.MagicMock(
+                fetchall=lambda: rows, __iter__=lambda self: iter(rows)
+            )
+        )
+        check_constraints = testing.db.dialect.get_check_constraints(
+            conn, "foo"
+        )
+        eq_(
+            check_constraints,
+            [
+                {
+                    "name": "broken",
+                    "sqltext": "(x IS NULL OR y IS NULL)"
+                    " AND (x IS NULL OR y IS NULL)",
+                    "comment": None,
+                },
+                {
+                    "name": "with_literal_parens",
+                    "sqltext": "a = '(' AND b = ')'",
                     "comment": None,
                 },
             ],

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -1242,9 +1242,9 @@ class RegexTest(fixtures.TestBase):
         argnames="src, expected",
     )
     def test_strip_outer_parens(self, src, expected):
-        from sqlalchemy.dialects.postgresql.base import _strip_outer_parens
+        from sqlalchemy.util import strip_outer_parens
 
-        eq_(_strip_outer_parens(src), expected)
+        eq_(strip_outer_parens(src), expected)
 
 
 class ReflectionTest(


### PR DESCRIPTION
Fixes #13157.

The second pass over the CHECK constraint body in `get_multi_check_constraints` used a naive

```python
re.sub(r"^[\s\n]*\((.+)\)[\s\n]*$", r"\1", m.group(1))
```

which greedily paired the leading `(` with the trailing `)`. For an expression like

```
(x IS NULL OR y IS NULL) AND (x IS NULL OR y IS NULL)
```

the substitution dropped both and produced syntactically invalid SQL:

```
x IS NULL OR y IS NULL) AND (x IS NULL OR y IS NULL
```

Replaces the regex with a small `_strip_outer_parens` helper that only strips when the position-zero `(` actually closes at the position-last `)`, walking the string and ignoring parens inside single- and double-quoted literals (handling PostgreSQL's `''` and `""` doubled-quote escapes). This matches the paren-counting approach already used by the sqlite dialect's CHECK reflection.

Tests in `test/dialect/postgresql/test_reflection.py`:

- `RegexTest.test_strip_outer_parens` — 10 parametrized cases covering the regression, the existing strip-once cases enumerated in the source comments, no-op cases, literals containing parens, doubled-quote escapes, and the newline cases from `test_reflect_extra_newlines`.
- `ReflectionTest.test_reflect_check_constraint_unwrapped_parens` — mock-based end-to-end exercising `get_check_constraints` with the issue repro plus a literal-containing-parens case.

`pytest test/dialect/postgresql/test_reflection.py::RegexTest`: 40 passed (33 existing + 7 new strip-paren cases).

I did not extend this PR to the broader "we should have a dedicated SQL expression parser" direction discussed in the thread (zzzeek's note). Happy to do that as a follow-up if useful.
