### PR TITLE
Adjust TypeError message to Python 3.15

### DIFF
--- a/test/engine/test_processors.py
+++ b/test/engine/test_processors.py
@@ -78,7 +78,7 @@ class _DateProcessorTest(fixtures.TestBase):
     @combinations("str_to_datetime", "str_to_time", "str_to_date")
     def test_no_string(self, meth):
         with expect_raises_message(
-            TypeError, "fromisoformat: argument must be str"
+            TypeError, r"fromisoformat.* argument must be str"
         ):
             fn = getattr(self.module, meth)
             fn(2012)


### PR DESCRIPTION
<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
The `.fromisoformat()` error message tested in `test_no_string()` changed in Python 3.15, this fixes the test.

See #13308 for the `rel_2_0` branch.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix (in a test, therefore I didn’t create an issue)
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
