### PR TITLE
test: add coverage for delete with nested alias exists

### DIFF
--- a/test/sql/test_delete.py
+++ b/test/sql/test_delete.py
@@ -145,6 +145,25 @@ class DeleteTest(_DeleteTestBase, fixtures.TablesTest, AssertsCompiledSQL):
             ")",
         )
 
+    def test_delete_with_nested_alias_exists(self):
+        table1, table2 = self.tables.mytable, self.tables.myothertable
+
+        t2_alias = table2.alias("t2_alias")
+
+        stmt = table1.delete().where(
+            exists()
+            .where(t2_alias.c.otherid == table1.c.myid)
+            .where(t2_alias.c.othername == "x")
+        )
+
+        self.assert_compile(
+            stmt,
+            "DELETE FROM mytable WHERE EXISTS "
+            "(SELECT * FROM myothertable AS t2_alias "
+            "WHERE t2_alias.otherid = mytable.myid "
+            "AND t2_alias.othername = :othername_1)",
+        )
+
 
 class DeleteFromCompileTest(
     _DeleteTestBase, fixtures.TablesTest, AssertsCompiledSQL


### PR DESCRIPTION
### Description

Adds test coverage for compiling a `DELETE` statement with a correlated `EXISTS` subquery that uses an aliased table.

This verifies that SQLAlchemy correctly renders the aliased table inside the nested `EXISTS` clause while correlating it against the outer `DELETE` target.

### Checklist

This pull request is:

- [x] A documentation / typographical / small typing error fix
- [ ] A short code fix
- [ ] A new feature implementation