### PR TITLE
Forward info kwarg from ExcludeConstraint to ColumnCollectionConstraint

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/ext.py
+++ b/lib/sqlalchemy/dialects/postgresql/ext.py
@@ -229,6 +229,9 @@ class ExcludeConstraint(ColumnCollectionConstraint):
           Optional string.  If set, emit INITIALLY <value> when issuing DDL
           for this constraint.
 
+        :param info: Optional data dictionary which will be populated into the
+            :attr:`.SchemaItem.info` attribute of this object.
+
         :param using:
           Optional string.  If set, emit USING <index_method> when issuing DDL
           for this constraint. Defaults to 'gist'.
@@ -281,6 +284,7 @@ class ExcludeConstraint(ColumnCollectionConstraint):
             name=kw.get("name"),
             deferrable=kw.get("deferrable"),
             initially=kw.get("initially"),
+            info=kw.get("info"),
         )
         self.using = kw.get("using", "gist")
         where = kw.get("where")

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -1262,6 +1262,13 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             ")",
         )
 
+    def test_exclude_constraint_info(self):
+        ec = ExcludeConstraint(("a", "="))
+        eq_(ec.info, {})
+
+        ec = ExcludeConstraint(("a", "="), info={"foo": "bar"})
+        eq_(ec.info, {"foo": "bar"})
+
     def test_exclude_constraint_min(self):
         m = MetaData()
         tbl = Table("testtbl", m, Column("room", Integer, primary_key=True))


### PR DESCRIPTION
### Description
I noticed that when passing the 'info' keyword argument to ExcludeConstraint, it isn't being forwarded to ColumnCollectionConstraint.__init__().

This patch explicitly adds info=kw.get("info") alongside name, deferrable, and initially so that custom user metadata propagates correctly up to the parent constraint class.

Note: I originally opened this as a repository Discussion here: [Discussion 13314](https://github.com/sqlalchemy/sqlalchemy/discussions/13314)

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
- [x] A short code fix
- [ ] A new feature implementation

Fixes: https://github.com/sqlalchemy/sqlalchemy/issues/13317

**Have a nice day!**
*Special thanks to https://github.com/mw-salamon for helping me track down and uncover this issue!*