### PR TITLE
Fix yield_per leaking into selectinload queries

### DIFF
--- a/lib/sqlalchemy/orm/context.py
+++ b/lib/sqlalchemy/orm/context.py
@@ -534,8 +534,21 @@ class _ORMCompileState(_AbstractORMCompileState):
 
         if "sa_top_level_orm_context" in execution_options:
             ctx = execution_options["sa_top_level_orm_context"]
-            execution_options = ctx.query._execution_options.merge_with(
-                ctx.execution_options, execution_options
+            top_level_execution_options = (
+                ctx.query._execution_options.merge_with(ctx.execution_options)
+            )
+            if "yield_per" in top_level_execution_options:
+                # loader-generated statements shouldn't inherit the
+                # top-level result batching size
+                top_level_execution_options = util.immutabledict(
+                    {
+                        key: value
+                        for key, value in top_level_execution_options.items()
+                        if key != "yield_per"
+                    }
+                )
+            execution_options = top_level_execution_options.merge_with(
+                execution_options
             )
 
         if not execution_options:

--- a/lib/sqlalchemy/orm/context.py
+++ b/lib/sqlalchemy/orm/context.py
@@ -100,6 +100,9 @@ _path_registry = PathRegistry.root
 
 LABEL_STYLE_LEGACY_ORM = SelectLabelStyle.LABEL_STYLE_LEGACY_ORM
 
+# Result batching applies only to the statement being consumed.
+_LOADER_EXEC_OPTION_EXCLUSIONS = frozenset(["yield_per"])
+
 
 class QueryContext:
     __slots__ = (
@@ -534,19 +537,16 @@ class _ORMCompileState(_AbstractORMCompileState):
 
         if "sa_top_level_orm_context" in execution_options:
             ctx = execution_options["sa_top_level_orm_context"]
-            top_level_execution_options = (
-                ctx.query._execution_options.merge_with(ctx.execution_options)
+            merged_top_level_options = ctx.query._execution_options.merge_with(
+                ctx.execution_options
             )
-            if "yield_per" in top_level_execution_options:
-                # loader-generated statements shouldn't inherit the
-                # top-level result batching size
-                top_level_execution_options = util.immutabledict(
-                    {
-                        key: value
-                        for key, value in top_level_execution_options.items()
-                        if key != "yield_per"
-                    }
-                )
+            top_level_execution_options = util.immutabledict(
+                {
+                    key: value
+                    for key, value in merged_top_level_options.items()
+                    if key not in _LOADER_EXEC_OPTION_EXCLUSIONS
+                }
+            )
             execution_options = top_level_execution_options.merge_with(
                 execution_options
             )

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -1,5 +1,6 @@
 import sqlalchemy as sa
 from sqlalchemy import bindparam
+from sqlalchemy import event
 from sqlalchemy import ForeignKey
 from sqlalchemy import ForeignKeyConstraint
 from sqlalchemy import Integer
@@ -2934,6 +2935,46 @@ class SelfReferentialTest(fixtures.MappedTest):
             )
 
         self.assert_sql_count(testing.db, go, 4)
+
+    @testing.requires.independent_cursors
+    def test_yield_per_orm_execute_event(self, data_fixture):
+        nodes = self.tables.nodes
+
+        Node = self.classes.Node
+
+        self.mapper_registry.map_imperatively(
+            Node,
+            nodes,
+            properties={
+                "children": relationship(
+                    Node, lazy="selectin", join_depth=1, order_by=nodes.c.id
+                )
+            },
+        )
+        with fixture_session() as sess:
+            data_fixture(sess)
+
+            @event.listens_for(sess, "do_orm_execute")
+            def do_orm_execute(ctx):
+                pass
+
+            stmt = (
+                select(Node)
+                .where(nodes.c.parent_id.is_(None))
+                .order_by(Node.id)
+                .execution_options(yield_per=5)
+            )
+
+            eq_(
+                [
+                    ("n1", ["n11", "n12", "n13"]),
+                    ("n2", ["n21"]),
+                ],
+                [
+                    (node.data, [child.data for child in node.children])
+                    for node in sess.scalars(stmt)
+                ],
+            )
 
     def test_lazy_fallback_doesnt_affect_eager(self, data_fixture):
         nodes = self.tables.nodes

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -2937,7 +2937,7 @@ class SelfReferentialTest(fixtures.MappedTest):
         self.assert_sql_count(testing.db, go, 4)
 
     @testing.requires.independent_cursors
-    def test_yield_per_orm_execute_event(self, data_fixture):
+    def test_yield_per_orm_execute_event(self, connection, data_fixture):
         nodes = self.tables.nodes
 
         Node = self.classes.Node
@@ -2951,8 +2951,18 @@ class SelfReferentialTest(fixtures.MappedTest):
                 )
             },
         )
-        with fixture_session() as sess:
+        with fixture_session(bind=connection) as sess:
             data_fixture(sess)
+
+            execution_yield_per = []
+
+            @event.listens_for(connection, "before_cursor_execute")
+            def before_cursor_execute(
+                conn, cursor, statement, parameters, context, executemany
+            ):
+                execution_yield_per.append(
+                    context.execution_options.get("yield_per")
+                )
 
             @event.listens_for(sess, "do_orm_execute")
             def do_orm_execute(ctx):
@@ -2975,6 +2985,7 @@ class SelfReferentialTest(fixtures.MappedTest):
                     for node in sess.scalars(stmt)
                 ],
             )
+            eq_(execution_yield_per, [5, None])
 
     def test_lazy_fallback_doesnt_affect_eager(self, data_fixture):
         nodes = self.tables.nodes


### PR DESCRIPTION
Fixes #13301.

### Summary
- keep top-level `yield_per` from being inherited by loader-generated ORM statements
- add a selectinload regression with a no-op `do_orm_execute` listener

### Testing
- `python -m pytest test/orm/test_selectin_relations.py::SelfReferentialTest::test_yield_per_orm_execute_event -q`
- `python -m pytest test/orm/test_selectin_relations.py::SelfReferentialTest test/orm/test_selectin_relations.py::ChunkingTest::test_yield_per test/orm/test_query.py::ExecutionOptionsTest::test_execution_options_to_load_options -q`
- `python -m pytest test/orm/test_selectin_relations.py -q`
- `python -m pytest test/orm/test_query.py::YieldTest test/orm/test_query.py::YieldIterationTest test/orm/test_query.py::ExecutionOptionsTest -q`
- `python -m ruff check lib/sqlalchemy/orm/context.py test/orm/test_selectin_relations.py`
- `git diff --check`