### PR TITLE
Apply tuple bind expressions to expanding IN values

### DIFF
--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -3427,11 +3427,27 @@ class SQLCompiler(Compiled):
             and isinstance(values[0], collections_abc.Sequence)
             and not isinstance(values[0], (str, bytes))
         ):
-            if typ_dialect_impl._has_bind_expression:
-                raise NotImplementedError(
-                    "bind_expression() on TupleType not supported with "
-                    "literal_binds"
-                )
+            if typ_dialect_impl._is_tuple_type:
+
+                def _render_tuple_literal(value, typ):
+                    rendered = self.render_literal_value(value, typ)
+                    impl = typ.dialect_impl(self.dialect)
+                    if not impl._has_bind_expression:
+                        return rendered
+
+                    replacement = "__SQLA_BIND_EXPR__"
+                    bind_expression = impl.bind_expression(
+                        elements.literal_column(replacement, type_=typ)
+                    )
+                    return self.process(
+                        bind_expression, skip_bind_expression=True
+                    ).replace(replacement, rendered)
+
+                tuple_types = parameter.type.types
+
+            else:
+                _render_tuple_literal = None
+                tuple_types = ()
 
             replacement_expression = (
                 "VALUES " if self.dialect.tuple_in_values else ""
@@ -3439,10 +3455,14 @@ class SQLCompiler(Compiled):
                 "(%s)"
                 % (
                     ", ".join(
-                        self.render_literal_value(value, param_type)
-                        for value, param_type in zip(
-                            tuple_element, parameter.type.types
+                        (
+                            _render_tuple_literal(value, tuple_types[idx])
+                            if _render_tuple_literal
+                            else self.render_literal_value(
+                                value, parameter.type
+                            )
                         )
+                        for idx, value in enumerate(tuple_element)
                     )
                 )
                 for i, tuple_element in enumerate(values)
@@ -3522,6 +3542,28 @@ class SQLCompiler(Compiled):
             and not isinstance(values[0], (str, bytes))
         ):
             assert not typ_dialect_impl._is_array
+
+            if typ_dialect_impl._is_tuple_type:
+
+                def _render_tuple_bindtemplate(name, typ):
+                    impl = typ.dialect_impl(dialect)
+                    if not impl._has_bind_expression:
+                        return _render_bindtemplate(name)
+
+                    replacement = "__SQLA_BIND_EXPR__"
+                    bind_expression = impl.bind_expression(
+                        elements.literal_column(replacement, type_=typ)
+                    )
+                    return self.process(
+                        bind_expression, skip_bind_expression=True
+                    ).replace(replacement, _render_bindtemplate(name))
+
+                tuple_types = parameter.type.types
+
+            else:
+                _render_tuple_bindtemplate = None
+                tuple_types = ()
+
             to_update = [
                 ("%s_%s_%s" % (name, i, j), value)
                 for i, tuple_element in enumerate(values, 1)
@@ -3534,8 +3576,15 @@ class SQLCompiler(Compiled):
                 "(%s)"
                 % (
                     ", ".join(
-                        _render_bindtemplate(
-                            to_update[i * len(tuple_element) + j][0]
+                        (
+                            _render_tuple_bindtemplate(
+                                to_update[i * len(tuple_element) + j][0],
+                                tuple_types[j],
+                            )
+                            if _render_tuple_bindtemplate
+                            else _render_bindtemplate(
+                                to_update[i * len(tuple_element) + j][0]
+                            )
                         )
                         for j, value in enumerate(tuple_element)
                     )

--- a/test/sql/test_type_expressions.py
+++ b/test/sql/test_type_expressions.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy import testing
+from sqlalchemy import tuple_
 from sqlalchemy import TypeDecorator
 from sqlalchemy import union
 from sqlalchemy.sql import LABEL_STYLE_TABLENAME_PLUS_COL
@@ -216,6 +217,38 @@ class SelectTest(_ExprFixture, fixtures.TestBase, AssertsCompiledSQL):
                 "(lower('hi'), lower('there'), lower('some'), lower('expr'))",
                 literal_binds=True,
             )
+
+    def test_in_binds_tuple(self):
+        table = self._fixture()
+
+        stmt = select(table).where(
+            tuple_(table.c.x, table.c.y).in_(
+                [
+                    ("x1", "y1"),
+                    ("x2", "y2"),
+                    ("x3", "y3"),
+                ]
+            )
+        )
+
+        self.assert_compile(
+            stmt,
+            "SELECT test_table.x, lower(test_table.y) AS y "
+            "FROM test_table WHERE (test_table.x, test_table.y) IN "
+            "((:param_1_1_1, lower(:param_1_1_2)), "
+            "(:param_1_2_1, lower(:param_1_2_2)), "
+            "(:param_1_3_1, lower(:param_1_3_2)))",
+            render_postcompile=True,
+        )
+
+        self.assert_compile(
+            stmt,
+            "SELECT test_table.x, lower(test_table.y) AS y "
+            "FROM test_table WHERE (test_table.x, test_table.y) IN "
+            "(('x1', lower('y1')), ('x2', lower('y2')), "
+            "('x3', lower('y3')))",
+            literal_binds=True,
+        )
 
     def test_dialect(self):
         table = self._fixture()


### PR DESCRIPTION
### Description

Tuple-valued expanding parameters now apply each element type's `bind_expression()` when rendering expanded tuples. This matches scalar `IN` behavior for custom types and covers both `render_postcompile` and `literal_binds`.

Fixes: #8992

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
- [x] A short code fix
  - Fixes: #8992
  - includes regression coverage in `test/sql/test_type_expressions.py`
- [ ] A new feature implementation

Local checks:
- `uv run --group tests pytest test/sql/test_type_expressions.py -q`
- `uv run --group tests pytest test/sql/test_compiler.py -q -k "tuple_expanding_in or expanding_parameter"`
- `uv run --group lint flake8 lib/sqlalchemy/sql/compiler.py test/sql/test_type_expressions.py`
- `uv run --group lint black --check lib/sqlalchemy/sql/compiler.py test/sql/test_type_expressions.py`