### PR TITLE
Fix lambda statements with non-lambda criteria

### DIFF
--- a/lib/sqlalchemy/sql/lambdas.py
+++ b/lib/sqlalchemy/sql/lambdas.py
@@ -314,7 +314,7 @@ class LambdaElement(elements.ClauseElement):
         return rec
 
     def __getattr__(self, key):
-        return getattr(self._rec.expected_expr, key)
+        return getattr(self._resolved, key)
 
     @property
     def _is_sequence(self):

--- a/test/sql/test_lambdas.py
+++ b/test/sql/test_lambdas.py
@@ -346,6 +346,34 @@ class LambdaElementTest(
         eq_(s2key[0], s4key[0])
         ne_(s1key[0], s2key[0])
 
+    def test_stmt_lambda_w_additional_non_lambda_and_closure_var(self):
+        def go(q):
+            stmt = lambdas.lambda_stmt(
+                lambda: select(column("x")).where(column("x") == q)
+            )
+            stmt = stmt.where(column("y") == column("z"))
+
+            return stmt
+
+        s1 = go(5)
+        s2 = go(10)
+
+        self.assert_compile(
+            s1,
+            "SELECT x WHERE x = :q_1 AND y = z",
+            checkparams={"q_1": 5},
+        )
+        self.assert_compile(
+            s2,
+            "SELECT x WHERE x = :q_1 AND y = z",
+            checkparams={"q_1": 10},
+        )
+
+        s1key = s1._generate_cache_key()
+        s2key = s2._generate_cache_key()
+
+        eq_(s1key[0], s2key[0])
+
     def test_stmt_lambda_w_atonce_whereclause_values_notrack(self):
         def go(col_expr, whereclause):
             stmt = lambdas.lambda_stmt(lambda: select(col_expr))


### PR DESCRIPTION
Fixes #10827.

## Summary
- proxy lambda statement attributes through the resolved expression so refreshed closure-bound values are used when chaining regular statement methods
- add regression coverage for a lambda statement extended with non-lambda criteria

## Tests
- `python -m pytest test/sql/test_lambdas.py test/orm/test_lambdas.py -q`
- `python -m black --check lib\sqlalchemy\sql\lambdas.py test\sql\test_lambdas.py`
- `python -m compileall -q lib\sqlalchemy\sql\lambdas.py test\sql\test_lambdas.py`
- `git diff --check`

I also ran `python -m pytest test/sql/test_compare.py -k LambdaElement -q`; the selected tests completed, then the SQLAlchemy Windows test cleanup hit a SQLite file-lock removing `pysqlite_test_schema.db`, so I did not count that as a passing gate.