### PR TITLE
Use Trusted Publishing to upload to PyPI

### DIFF
--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -13,7 +13,61 @@ on:
 #   TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
 
 jobs:
-  build_wheels:
+  build_source_dist_and_pure_python_wheel:
+    name: Build source dist and pure-Python wheel
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Remove tag-build from pyproject.toml
+        # sqlalchemy has `tag-build` set to `dev` in pyproject.toml. It needs to be removed before creating the wheel
+        # otherwise it gets tagged with `dev0`
+        shell: pwsh
+        # This is equivalent to the sed commands:
+        # `sed -i '/tag-build="dev"/d' pyproject.toml`
+        # `sed -i '/tag-build = "dev"/d' pyproject.toml`
+
+        # `-replace` uses a regexp match
+        run: |
+          (get-content pyproject.toml) | %{$_ -replace 'tag-build.?=.?"dev"',""} | set-content pyproject.toml
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: pip
+
+      - name: Build source dist and pure-Python wheel
+        run: |
+          python -m pip install --upgrade pip
+          pip --version
+          pip install build twine
+          pip list
+          DISABLE_SQLALCHEMY_CEXT=y python -m build
+          twine check dist/*
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: packages
+          path: dist/
+
+  pypi_publish_source_dist_and_pure_python_wheel:
+    needs: [build_source_dist_and_pure_python_wheel]
+    name: Upload source dist and pure-Python wheel to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: packages
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  build_platform_wheels:
     name: ${{ matrix.wheel_mode }} wheels ${{ matrix.python }} on ${{ matrix.os }} ${{ matrix.os == 'ubuntu-22.04' && matrix.linux_archs || '' }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -36,12 +90,6 @@ jobs:
           - "aarch64"
           - "x86_64"
           - "riscv64"
-
-        include:
-          # create pure python build
-          - os: ubuntu-22.04
-            wheel_mode: pure-python
-            python: "cp-314*"
 
         exclude:
           - os: "windows-2022"
@@ -68,6 +116,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       # See details at https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation
       - name: Set up QEMU
@@ -98,25 +148,6 @@ jobs:
           # setting it here does not work on linux
           # PYTHONNOUSERSITE: "1"
 
-
-      - name: Set up Python for twine and pure-python wheel
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-
-      - name: Build pure-python wheel
-        if: ${{ matrix.wheel_mode == 'pure-python' && runner.os == 'Linux' }}
-        run: |
-          python -m pip install --upgrade pip
-          pip --version
-          pip install build
-          pip list
-          DISABLE_SQLALCHEMY_CEXT=y python -m build --wheel --outdir ./wheelhouse
-
-      # - uses: actions/upload-artifact@v3
-      #   with:
-      #     path: ./wheelhouse/*.whl
-
       - name: Upload wheels to release
         # upload the generated wheels to the github release
         uses: sqlalchemyorg/upload-release-assets@sa
@@ -124,14 +155,21 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           files: './wheelhouse/*.whl'
 
-      - name: Publish wheel
-        # the action https://github.com/marketplace/actions/pypi-publish runs only on linux and we cannot specify
-        # additional options
-        env:
-          TWINE_USERNAME: __token__
-          # replace TWINE_PASSWORD with token for real pypi
-          # TWINE_PASSWORD: ${{ secrets.test_pypi_token }}
-          TWINE_PASSWORD: ${{ secrets.pypi_token }}
-        run: |
-          python -m pip install -U twine
-          twine upload --skip-existing ./wheelhouse/*
+      - uses: actions/upload-artifact@v7
+        with:
+          name: platform_wheels
+          path: wheelhouse/
+
+  pypi_publish_platform_wheels:
+    needs: [build_platform_wheels]
+    name: Upload platform wheels to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: platform_wheels
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -13,8 +13,8 @@ on:
 #   TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
 
 jobs:
-  build_source_dist_and_pure_python_wheel:
-    name: Build source dist and pure-Python wheel
+  build_pure_python_wheel:
+    name: Build pure-Python wheel
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
@@ -39,13 +39,13 @@ jobs:
           python-version: "3.14"
           cache: pip
 
-      - name: Build source dist and pure-Python wheel
+      - name: Build pure-Python wheel
         run: |
           python -m pip install --upgrade pip
           pip --version
           pip install build twine
           pip list
-          DISABLE_SQLALCHEMY_CEXT=y python -m build
+          DISABLE_SQLALCHEMY_CEXT=y python -m build --wheel
           twine check dist/*
 
       - uses: actions/upload-artifact@v7
@@ -53,9 +53,9 @@ jobs:
           name: packages
           path: dist/
 
-  pypi_publish_source_dist_and_pure_python_wheel:
-    needs: [build_source_dist_and_pure_python_wheel]
-    name: Upload source dist and pure-Python wheel to PyPI
+  pypi_publish_pure_python_wheel:
+    needs: [build_pure_python_wheel]
+    name: Upload pure-Python wheel to PyPI
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -16,6 +16,7 @@ jobs:
   build_pure_python_wheel:
     name: Build pure-Python wheel
     runs-on: ubuntu-22.04
+    permissions: {}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -70,6 +71,7 @@ jobs:
   build_platform_wheels:
     name: ${{ matrix.wheel_mode }} wheels ${{ matrix.python }} on ${{ matrix.os }} ${{ matrix.os == 'ubuntu-22.04' && matrix.linux_archs || '' }}
     runs-on: ${{ matrix.os }}
+    permissions: {}
     strategy:
       matrix:
         # emulated wheels on linux take too much time, split wheels into multiple runs


### PR DESCRIPTION
### Description

Fix https://github.com/sqlalchemy/sqlalchemy/discussions/13324 .

Split building from upload and sdist/pure-Python packages from platform wheels into 4 jobs to allow fast publication on PyPI.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
- [ ] A short code fix
- [x] A new feature implementation
