### PR TITLE
Add explicit USING support to DELETE

### DIFF
--- a/doc/build/changelog/unreleased_21/8130.rst
+++ b/doc/build/changelog/unreleased_21/8130.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: usecase, sql
+    :tickets: 8130
+
+    Added :meth:`_sql.Delete.using`, allowing explicit FROM expressions such
+    as joins to be rendered in backend-specific multiple-table DELETE forms
+    including MySQL/MariaDB ``DELETE .. USING``.

--- a/doc/build/tutorial/data_update.rst
+++ b/doc/build/tutorial/data_update.rst
@@ -261,6 +261,25 @@ syntaxes, such as ``DELETE FROM..USING`` on MySQL::
   {printsql}DELETE FROM user_account USING user_account, address
   WHERE user_account.id = address.user_id AND address.email_address = %s
 
+For backends that support a full FROM expression in the ``USING`` clause,
+the :meth:`_sql.Delete.using` method may be used to state that expression
+explicitly, such as a MySQL joined DELETE::
+
+  >>> delete_stmt = (
+  ...     delete(user_table)
+  ...     .using(
+  ...         user_table.outerjoin(
+  ...             address_table,
+  ...             user_table.c.id == address_table.c.user_id,
+  ...         )
+  ...     )
+  ...     .where(address_table.c.email_address == "patrick@aol.com")
+  ... )
+  >>> print(delete_stmt.compile(dialect=mysql.dialect()))
+  {printsql}DELETE FROM user_account USING user_account LEFT OUTER JOIN address
+  ON user_account.id = address.user_id
+  WHERE address.email_address = %s
+
 .. _tutorial_update_delete_rowcount:
 
 Getting Affected Row Count from UPDATE, DELETE

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -530,6 +530,9 @@ available.
   .. versionchanged:: 2.1 the :func:`_mysql.limit()` extension supersedes the
      previous use of ``mysql_limit``
 
+* DELETE with an explicit ``USING`` expression such as a JOIN, use
+  :meth:`_sql.Delete.using`.  See :ref:`tutorial_multi_table_deletes`.
+
 * optimizer hints, use :meth:`_expression.Select.prefix_with` and
   :meth:`_query.Query.prefix_with`::
 
@@ -1894,9 +1897,18 @@ class MySQLCompiler(
     ) -> str:
         """Render the DELETE .. USING clause specific to MySQL."""
         kw["asfrom"] = True
+        if any(
+            from_table in elem._cloned_set
+            for extra_from in extra_froms
+            for elem in sql_util.surface_selectables_only(extra_from)
+        ):
+            froms = extra_froms
+        else:
+            froms = [from_table] + extra_froms
+
         return "USING " + ", ".join(
             t._compiler_dispatch(self, fromhints=from_hints, **kw)
-            for t in [from_table] + extra_froms
+            for t in froms
         )
 
     def visit_empty_set_expr(

--- a/lib/sqlalchemy/sql/dml.py
+++ b/lib/sqlalchemy/sql/dml.py
@@ -83,6 +83,7 @@ if TYPE_CHECKING:
     from ._typing import _DMLColumnArgument
     from ._typing import _DMLColumnKeyMapping
     from ._typing import _DMLTableArgument
+    from ._typing import _FromClauseArgument
     from ._typing import _T0  # noqa
     from ._typing import _T1  # noqa
     from ._typing import _T2  # noqa
@@ -212,7 +213,9 @@ class DMLState(CompileState):
         ]
 
     def _make_extra_froms(
-        self, statement: DMLWhereBase
+        self,
+        statement: DMLWhereBase,
+        explicit_froms: Sequence[FromClause] = (),
     ) -> Tuple[FromClause, List[FromClause]]:
         froms: List[FromClause] = []
 
@@ -220,15 +223,26 @@ class DMLState(CompileState):
         primary_table = all_tables[0]
         seen = {primary_table}
 
+        def _consider_from(
+            from_: FromClause, include_surface_selectables: bool = False
+        ) -> None:
+            if not seen.intersection(from_._cloned_set):
+                froms.append(from_)
+            seen.update(from_._cloned_set)
+            if include_surface_selectables:
+                for elem in sql_util.surface_selectables_only(from_):
+                    seen.update(elem._cloned_set)
+
+        for from_ in explicit_froms:
+            _consider_from(from_, include_surface_selectables=True)
+
         consider = statement._where_criteria
         if self._dict_parameters:
             consider += tuple(self._dict_parameters.values())
 
         for crit in consider:
             for item in _from_objects(crit):
-                if not seen.intersection(item._cloned_set):
-                    froms.append(item)
-                seen.update(item._cloned_set)
+                _consider_from(item)
 
         froms.extend(all_tables[1:])
         return primary_table, froms
@@ -385,7 +399,7 @@ class DeleteDMLState(DMLState):
         self.statement = statement
 
         self.isdelete = True
-        t, ef = self._make_extra_froms(statement)
+        t, ef = self._make_extra_froms(statement, statement._extra_froms)
         self._primary_table = t
         self._extra_froms = ef
         self.is_multitable = ef
@@ -1846,6 +1860,7 @@ class Delete(
     _traverse_internals = (
         [
             ("table", InternalTraversal.dp_clauseelement),
+            ("_extra_froms", InternalTraversal.dp_clauseelement_tuple),
             ("_where_criteria", InternalTraversal.dp_clauseelement_tuple),
             ("_returning", InternalTraversal.dp_clauseelement_tuple),
             ("_hints", InternalTraversal.dp_table_hint_list),
@@ -1861,10 +1876,36 @@ class Delete(
         {"post_criteria": "_post_criteria_clause"}
     )
 
+    _extra_froms: Tuple[FromClause, ...] = ()
+
     def __init__(self, table: _DMLTableArgument):
         self.table = coercions.expect(
             roles.DMLTableRole, table, apply_propagate_attrs=self
         )
+
+    @_generative
+    def using(self, *froms: _FromClauseArgument) -> Self:
+        r"""Add one or more explicit ``USING`` expressions to this DELETE.
+
+        This method may be used for backend-specific multiple-table DELETE
+        forms where the secondary FROM expression needs to be stated
+        explicitly, such as MySQL's ``DELETE FROM table USING <join>`` form.
+
+        .. versionadded:: 2.1
+
+        .. seealso::
+
+            :ref:`tutorial_multi_table_deletes`
+
+        """
+
+        self._extra_froms += tuple(
+            coercions.expect(
+                roles.FromClauseRole, from_, apply_propagate_attrs=self
+            )
+            for from_ in froms
+        )
+        return self
 
     def _apply_syntax_extension_to_self(
         self, extension: SyntaxExtension

--- a/test/sql/test_compare.py
+++ b/test/sql/test_compare.py
@@ -770,6 +770,10 @@ class CoreFixtures:
             table_b.delete().with_dialect_options(sqlite_foo="some value"),
             table_b.delete().where(table_b.c.a == 5),
             table_b.delete().where(table_b.c.b == 5),
+            table_b.delete().using(table_a),
+            table_b.delete().using(
+                table_b.join(table_a, table_b.c.a == table_a.c.a)
+            ),
         ),
         lambda: (
             values(

--- a/test/sql/test_delete.py
+++ b/test/sql/test_delete.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy import String
 from sqlalchemy import testing
 from sqlalchemy.dialects import mysql
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.engine import default
 from sqlalchemy.testing import assert_raises_message
 from sqlalchemy.testing import AssertsCompiledSQL
@@ -163,6 +164,63 @@ class DeleteFromCompileTest(
             stmt,
             "DELETE FROM mytable , myothertable "
             "WHERE mytable.myid = myothertable.otherid",
+        )
+
+    def test_delete_explicit_using(self):
+        table1, table2 = self.tables.mytable, self.tables.myothertable
+
+        stmt = table1.delete().using(table2).where(table1.c.myid == 7)
+        self.assert_compile(
+            stmt,
+            "DELETE FROM mytable , myothertable "
+            "WHERE mytable.myid = :myid_1",
+            checkparams={"myid_1": 7},
+        )
+
+    def test_delete_explicit_using_dedupe_implicit_from(self):
+        table1, table2 = self.tables.mytable, self.tables.myothertable
+
+        stmt = (
+            table1.delete()
+            .using(table2)
+            .where(table1.c.myid == table2.c.otherid)
+        )
+        self.assert_compile(
+            stmt,
+            "DELETE FROM mytable , myothertable "
+            "WHERE mytable.myid = myothertable.otherid",
+        )
+
+    def test_delete_explicit_using_join_mysql(self):
+        table1, table2 = self.tables.mytable, self.tables.myothertable
+
+        stmt = (
+            table1.delete()
+            .using(table1.outerjoin(table2, table1.c.myid == table2.c.otherid))
+            .where(table2.c.othername == None)
+        )
+        self.assert_compile(
+            stmt,
+            "DELETE FROM mytable USING mytable LEFT OUTER JOIN myothertable "
+            "ON mytable.myid = myothertable.otherid "
+            "WHERE myothertable.othername IS NULL",
+            dialect=mysql.dialect(),
+        )
+
+    def test_delete_explicit_using_join_postgresql(self):
+        table1, table2 = self.tables.mytable, self.tables.myothertable
+
+        stmt = (
+            table1.delete()
+            .using(table2.outerjoin(table1, table1.c.myid == table2.c.otherid))
+            .where(table2.c.othername == None)
+        )
+        self.assert_compile(
+            stmt,
+            "DELETE FROM mytable USING myothertable LEFT OUTER JOIN mytable "
+            "ON mytable.myid = myothertable.otherid "
+            "WHERE myothertable.othername IS NULL",
+            dialect=postgresql.dialect(),
         )
 
     def test_correlation_to_extra(self):


### PR DESCRIPTION
## Summary

This adds `Delete.using(*froms)` so Core DELETE statements can state explicit backend-specific USING expressions, including joined FROM expressions for MySQL/MariaDB.

The compiler now tracks explicit DELETE USING expressions as part of the statement state and avoids rendering a duplicate target table when a MySQL USING expression already includes the DELETE target, such as `delete(t1).using(t1.outerjoin(t2, ...))`.

## Tests

- `python -m pytest test/sql/test_delete.py test/dialect/mysql/test_compiler.py::CompileTest test/dialect/postgresql/test_compiler.py::CompileTest test/sql/test_compare.py -q`
- `python -m py_compile lib/sqlalchemy/sql/dml.py lib/sqlalchemy/dialects/mysql/base.py test/dialect/mysql/test_compiler.py test/dialect/postgresql/test_compiler.py test/sql/test_compare.py`
- `python -m black --check lib/sqlalchemy/sql/dml.py lib/sqlalchemy/dialects/mysql/base.py test/dialect/mysql/test_compiler.py test/dialect/postgresql/test_compiler.py test/sql/test_compare.py`
- `git diff --check`

Fixes #8130