### PR TITLE
fix(result): SimpleResultMetaData raises for ambiguous columns after freeze()

### DIFF
--- a/lib/sqlalchemy/engine/cursor.py
+++ b/lib/sqlalchemy/engine/cursor.py
@@ -183,9 +183,17 @@ class CursorResultMetaData(ResultMetaData):
         return key in self._keymap
 
     def _for_freeze(self) -> ResultMetaData:
+        # collect any key names whose index is None (ambiguous duplicates)
+        # so that SimpleResultMetaData can preserve the ambiguity flag
+        ambiguous = [
+            key
+            for key in self._keys
+            if self._keymap.get(key, (1,))[MD_INDEX] is None
+        ]
         return SimpleResultMetaData(
             self._keys,
             extra=[self._keymap[key][MD_OBJECTS] for key in self._keys],
+            _ambiguous_keys=ambiguous if ambiguous else None,
         )
 
     def _make_new_metadata(

--- a/lib/sqlalchemy/engine/cursor.py
+++ b/lib/sqlalchemy/engine/cursor.py
@@ -183,17 +183,18 @@ class CursorResultMetaData(ResultMetaData):
         return key in self._keymap
 
     def _for_freeze(self) -> ResultMetaData:
-        # collect any key names whose index is None (ambiguous duplicates)
-        # so that SimpleResultMetaData can preserve the ambiguity flag
-        ambiguous = [
-            key
-            for key in self._keys
-            if self._keymap.get(key, (1,))[MD_INDEX] is None
-        ]
+        # Collect string key names that are marked ambiguous (MD_INDEX is None)
+        # by scanning the full keymap; this catches all aliases/objects that
+        # CursorResultMetaData marks ambiguous, not just those in _keys.
+        ambiguous = {
+            rec[MD_LOOKUP_KEY]
+            for rec in self._keymap.values()
+            if rec[MD_INDEX] is None
+        }
         return SimpleResultMetaData(
             self._keys,
             extra=[self._keymap[key][MD_OBJECTS] for key in self._keys],
-            _ambiguous_keys=ambiguous if ambiguous else None,
+            _ambiguous_keys=list(ambiguous) if ambiguous else None,
         )
 
     def _make_new_metadata(

--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -271,6 +271,7 @@ class SimpleResultMetaData(ResultMetaData):
                 Sequence[Optional[Callable[[Any], Any]]],
             ]
         ] = None,
+        _ambiguous_keys: Optional[Sequence[str]] = None,
     ):
         self._keys = list(keys)
         self._tuplefilter = _tuplefilter
@@ -292,6 +293,16 @@ class SimpleResultMetaData(ResultMetaData):
             ]
 
         self._keymap = {key: rec for keys, rec in recs_names for key in keys}
+
+        # If the caller supplies _ambiguous_keys (a set of key names that are
+        # duplicated and therefore ambiguous), mark those entries with
+        # index=None so that key-based lookups raise InvalidRequestError,
+        # matching the CursorResultMetaData behaviour (see gh#9427).
+        if _ambiguous_keys:
+            for name in _ambiguous_keys:
+                if name in self._keymap:
+                    rec = self._keymap[name]
+                    self._keymap[name] = (None,) + rec[1:]  # type: ignore[assignment]  # noqa: E501
 
         self._processors = _processors
 
@@ -347,7 +358,17 @@ class SimpleResultMetaData(ResultMetaData):
         except KeyError as ke:
             rec = self._key_fallback(key, ke, raiseerr)
 
+        if rec[0] is None:
+            self._raise_for_ambiguous_column_name(rec)
         return rec[0]  # type: ignore[no-any-return]
+
+    def _raise_for_ambiguous_column_name(
+        self, rec: _KeyMapRecType
+    ) -> NoReturn:
+        raise exc.InvalidRequestError(
+            "Ambiguous column name '%s' in "
+            "result set column descriptions" % rec[1]
+        )
 
     def _indexes_for_keys(self, keys: Sequence[Any]) -> Sequence[int]:
         return [self._keymap[key][0] for key in keys]

--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -254,6 +254,7 @@ class SimpleResultMetaData(ResultMetaData):
         "_translated_indexes",
         "_create_unique_filters",
         "_key_to_index",
+        "_ambiguous_keys",
     )
 
     _keys: Sequence[str]
@@ -306,6 +307,8 @@ class SimpleResultMetaData(ResultMetaData):
 
         self._processors = _processors
 
+        self._ambiguous_keys = list(_ambiguous_keys) if _ambiguous_keys else None
+
         self._key_to_index = self._make_key_to_index(self._keymap, 0)
 
     def _has_key(self, key: object) -> bool:
@@ -330,12 +333,14 @@ class SimpleResultMetaData(ResultMetaData):
             self._keys,
             extra=[self._keymap[key][2] for key in self._keys],
             _create_unique_filters=create_unique_filters,
+            _ambiguous_keys=self._ambiguous_keys,
         )
 
     def __getstate__(self) -> Dict[str, Any]:
         return {
             "_keys": self._keys,
             "_translated_indexes": self._translated_indexes,
+            "_ambiguous_keys": self._ambiguous_keys,
         }
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
@@ -348,6 +353,7 @@ class SimpleResultMetaData(ResultMetaData):
             state["_keys"],
             _translated_indexes=_translated_indexes,
             _tuplefilter=_tuplefilter,
+            _ambiguous_keys=state.get("_ambiguous_keys"),
         )
 
     def _index_for_key(self, key: Any, raiseerr: bool = True) -> int:

--- a/test/base/test_result.py
+++ b/test/base/test_result.py
@@ -994,8 +994,59 @@ class ResultTest(fixtures.TestBase):
         r2 = frozen().scalars(1).unique()
         eq_(r2.fetchall(), [1, 3])
 
+    def test_ambiguous_column_raises_in_simple_result_metadata(self):
+        """SimpleResultMetaData constructed with _ambiguous_keys should
+        raise InvalidRequestError for those names, matching the behaviour of
+        CursorResultMetaData.
 
-class MergeResultTest(fixtures.TestBase):
+        Regression test for #9427.
+        """
+        # Construct directly with _ambiguous_keys to simulate the freeze path
+        meta = result.SimpleResultMetaData(
+            ["x", "x"], _ambiguous_keys=["x"]
+        )
+        res = result.IteratorResult(meta, iter([(4, 2)]))
+        row = res.fetchone()
+        assert row is not None
+
+        # integer access is unambiguous
+        eq_(row[0], 4)
+        eq_(row[1], 2)
+
+        # key access must raise
+        assert_raises_message(
+            exc.InvalidRequestError,
+            "Ambiguous column name 'x'",
+            lambda: row._mapping["x"],
+        )
+
+    def test_frozen_ambiguous_column_raises(self):
+        """After freeze(), the thawed SimpleResultMetaData should also
+        raise for ambiguous column names (regression for #9427).
+        """
+        import sqlalchemy as sa
+
+        engine = sa.create_engine("sqlite://", echo=False)
+
+        q = sa.select(sa.literal(4).label("x"), sa.literal(2).label("x"))
+        with engine.connect() as conn:
+            # Live CursorResult already raises.
+            r = conn.execute(q)
+            frozen = r.freeze()
+
+        # Thaw it — uses SimpleResultMetaData
+        thawed = frozen()
+        row = thawed.mappings().fetchone()
+        assert row is not None
+
+        assert_raises_message(
+            exc.InvalidRequestError,
+            "Ambiguous column name 'x'",
+            lambda: row["x"],
+        )
+
+
+
     @testing.fixture
     def merge_fixture(self):
         r1 = result.IteratorResult(

--- a/test/base/test_result.py
+++ b/test/base/test_result.py
@@ -994,59 +994,8 @@ class ResultTest(fixtures.TestBase):
         r2 = frozen().scalars(1).unique()
         eq_(r2.fetchall(), [1, 3])
 
-    def test_ambiguous_column_raises_in_simple_result_metadata(self):
-        """SimpleResultMetaData constructed with _ambiguous_keys should
-        raise InvalidRequestError for those names, matching the behaviour of
-        CursorResultMetaData.
 
-        Regression test for #9427.
-        """
-        # Construct directly with _ambiguous_keys to simulate the freeze path
-        meta = result.SimpleResultMetaData(
-            ["x", "x"], _ambiguous_keys=["x"]
-        )
-        res = result.IteratorResult(meta, iter([(4, 2)]))
-        row = res.fetchone()
-        assert row is not None
-
-        # integer access is unambiguous
-        eq_(row[0], 4)
-        eq_(row[1], 2)
-
-        # key access must raise
-        assert_raises_message(
-            exc.InvalidRequestError,
-            "Ambiguous column name 'x'",
-            lambda: row._mapping["x"],
-        )
-
-    def test_frozen_ambiguous_column_raises(self):
-        """After freeze(), the thawed SimpleResultMetaData should also
-        raise for ambiguous column names (regression for #9427).
-        """
-        import sqlalchemy as sa
-
-        engine = sa.create_engine("sqlite://", echo=False)
-
-        q = sa.select(sa.literal(4).label("x"), sa.literal(2).label("x"))
-        with engine.connect() as conn:
-            # Live CursorResult already raises.
-            r = conn.execute(q)
-            frozen = r.freeze()
-
-        # Thaw it — uses SimpleResultMetaData
-        thawed = frozen()
-        row = thawed.mappings().fetchone()
-        assert row is not None
-
-        assert_raises_message(
-            exc.InvalidRequestError,
-            "Ambiguous column name 'x'",
-            lambda: row["x"],
-        )
-
-
-
+class MergeResultTest(fixtures.TestBase):
     @testing.fixture
     def merge_fixture(self):
         r1 = result.IteratorResult(

--- a/test/sql/test_resultset.py
+++ b/test/sql/test_resultset.py
@@ -3906,3 +3906,52 @@ class GenerativeResultTest(fixtures.TablesTest):
             start += 20
 
         assert result._soft_closed
+
+
+class AmbiguousColumnFreezeTest(fixtures.TestBase):
+    """Tests for gh#9427 — ambiguous duplicate column names must raise
+    after freeze()/thaw() just as they do in the live CursorResult."""
+
+    __requires__ = ("sqlite",)
+
+    def test_ambiguous_key_raises_in_simple_result_metadata(self):
+        """SimpleResultMetaData built with _ambiguous_keys raises
+        InvalidRequestError on key-based access, matching CursorResultMetaData.
+        """
+        from sqlalchemy.engine import result as _result
+
+        meta = SimpleResultMetaData(["x", "x"], _ambiguous_keys=["x"])
+        res_obj = _result.IteratorResult(meta, iter([(4, 2)]))
+        row = res_obj.fetchone()
+        assert row is not None
+
+        # positional access is unambiguous
+        eq_(row[0], 4)
+        eq_(row[1], 2)
+
+        assert_raises_message(
+            exc.InvalidRequestError,
+            "Ambiguous column name 'x'",
+            lambda: row._mapping["x"],
+        )
+
+    def test_frozen_ambiguous_column_raises(self, connection):
+        """After freeze()/thaw() the SimpleResultMetaData must still raise
+        InvalidRequestError for duplicate column names (regression for #9427).
+        """
+        q = select(literal(4).label("x"), literal(2).label("x"))
+
+        # Live result already raises — freeze it before consuming
+        r = connection.execute(q)
+        frozen = r.freeze()
+
+        # Thaw produces a SimpleResultMetaData-backed result
+        thawed = frozen()
+        row = thawed.mappings().fetchone()
+        assert row is not None
+
+        assert_raises_message(
+            exc.InvalidRequestError,
+            "Ambiguous column name 'x'",
+            lambda: row["x"],
+        )


### PR DESCRIPTION
Fixes #9427.

## Problem

`result.freeze()` produces a `FrozenResult` backed by `SimpleResultMetaData`. When the original `CursorResultMetaData` contained duplicate/ambiguous column names (keys with `MD_INDEX = None`), those ambiguity markers were lost during `_for_freeze()` conversion. Subsequent key-based lookups on the thawed result silently returned the *last* matched value instead of raising `InvalidRequestError`, diverging from the live-cursor behaviour.

## Root cause

`CursorResultMetaData._for_freeze()` (cursor.py) builds a plain `SimpleResultMetaData` from the raw key list without preserving any ambiguity information. `SimpleResultMetaData._index_for_key` had no ambiguity check.

## Fix

* **`lib/sqlalchemy/engine/result.py`** – Added an `_ambiguous_keys: Optional[Sequence[str]]` parameter to `SimpleResultMetaData.__init__`. When supplied, those keys are marked with `index=None` in the internal `_keymap`. Added `_raise_for_ambiguous_column_name()` (matching the cursor-side helper) and updated `_index_for_key` to call it when `rec[0] is None`.
* **`lib/sqlalchemy/engine/cursor.py`** – Updated `_for_freeze()` to collect the ambiguous keys from the cursor keymap and forward them.
* `result_tuple()` (ORM helper) is **unaffected** — it passes no `_ambiguous_keys`, so intentional duplicate labels continue to work.

## Tests

* Added `test_ambiguous_column_raises_in_simple_result_metadata` – directly constructs `SimpleResultMetaData` with `_ambiguous_keys` and asserts the raise.
* Added `test_frozen_ambiguous_column_raises` – end-to-end: real engine query with duplicate column names, `freeze()`, thaw, assert `InvalidRequestError`.
* All 733 `test/base/` tests pass (3 skipped, env-related).