### PR TITLE
Perf/conditional unique selectinload

### DIFF
--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -3470,15 +3470,18 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
                 for key, state, state_dict, overwrite in chunk
             ]
 
+            result = context.session.execute(
+                q,
+                params={"primary_keys": primary_keys},
+                execution_options=execution_options,
+            )
+            # uniquing only needed when a nested joinedload on a collection
+            # inflates rows; otherwise `instances()` leaves the result
+            # without a unique filter and per-row hashing is pure overhead.
+            if result._unique_filter_state is not None:
+                result = result.unique()
             data = collections.defaultdict(list)
-            for k, v in itertools.groupby(
-                context.session.execute(
-                    q,
-                    params={"primary_keys": primary_keys},
-                    execution_options=execution_options,
-                ).unique(),
-                lambda x: x[0],
-            ):
+            for k, v in itertools.groupby(result, lambda x: x[0]):
                 data[k].extend(vv[1] for vv in v)
 
             for key, state, state_dict, overwrite in chunk:

--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -3416,19 +3416,25 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
         while our_keys:
             chunk = our_keys[0:chunksize]
             our_keys = our_keys[chunksize:]
-            data = {
-                k: v
-                for k, v in context.session.execute(
-                    q,
-                    params={
-                        "primary_keys": [
-                            key[0] if query_info.zero_idx else key
-                            for key in chunk
-                        ]
-                    },
-                    execution_options=execution_options,
-                ).unique()
-            }
+            result = context.session.execute(
+                q,
+                params={
+                    "primary_keys": [
+                        key[0] if query_info.zero_idx else key
+                        for key in chunk
+                    ]
+                },
+                execution_options=execution_options,
+            )
+            # the inner query only produces duplicate rows when a nested
+            # joinedload on a collection is in effect, in which case
+            # `instances()` will have already set `_unique_filter_state` on
+            # the result as a guard (see loading.instances). uniquing rows
+            # has measurable cost (hashing each Row), so skip the call when
+            # the result didn't request it.
+            if result._unique_filter_state is not None:
+                result = result.unique()
+            data = {k: v for k, v in result}
 
             for key in chunk:
                 # for a real foreign key and no concurrent changes to the

--- a/test/orm/test_events.py
+++ b/test/orm/test_events.py
@@ -528,8 +528,14 @@ class ORMExecuteTest(
             "autoflush": True,
             "is_post_load": True,
         }
+        # yield_per conflicts with unique() inside the loader.  immediateload
+        # calls unique() unconditionally; selectinload only calls unique() when
+        # a nested joinedload on a collection inflates rows, so without one it
+        # no longer conflicts.
         operation_should_fail = (
-            event_style.set_in_event_for_relationship and option_type.yield_per
+            event_style.set_in_event_for_relationship
+            and option_type.yield_per
+            and loader_opt is immediateload
         )
 
         if event_style.noop_event:
@@ -544,8 +550,7 @@ class ORMExecuteTest(
             # event where we actually set these options for relationship
             # loaders.  assert that what we do here does in fact get
             # to those loaders.   the yield_per setting will fail for
-            # immediateload and selectinload because they both use unique()
-            # on the result.
+            # immediateload because it calls unique() unconditionally.
             def go(context):
                 if context.is_relationship_load:
                     if option_type.yield_per:

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -4422,9 +4422,8 @@ class TestSelectinWithNestedJoinedCollectionDedup(
     _load_via_parent must deduplicate those rows so that each parent row ends
     up with exactly one copy of each child object.
 
-    Guards the optimization introduced alongside issue #XXXX that makes
-    .unique() conditional — ensures it still fires when loading.instances()
-    sets _unique_filter_state.
+    Also verifies that the joinedload is folded into the selectin query rather
+    than issuing a separate third query — the total SQL count must be 2.
     """
 
     @classmethod
@@ -4463,8 +4462,9 @@ class TestSelectinWithNestedJoinedCollectionDedup(
         # user 1: one address with TWO dingalings — this is the key fixture.
         # When selectinload(User.addresses).joinedload(Address.dingalings) runs
         # the inner selectin query, address 1 will appear in 2 result rows
-        # (one per dingaling).  Without .unique(), user.addresses would
-        # contain address 1 twice.
+        # (one per dingaling).  Without .unique(), loading.require_unique would
+        # raise InvalidRequestError: "The unique() method must be invoked on
+        # this Result".
         sess.add(
             User(
                 id=1,
@@ -4505,21 +4505,29 @@ class TestSelectinWithNestedJoinedCollectionDedup(
         User, Address, Dingaling = self.classes("User", "Address", "Dingaling")
         sess = fixture_session()
 
-        users = (
-            sess.query(User)
-            .options(
-                selectinload(User.addresses).joinedload(Address.dingalings)
+        def go():
+            # expunge so we get fresh queries on each call
+            sess.expunge_all()
+            return (
+                sess.query(User)
+                .options(
+                    selectinload(User.addresses).joinedload(Address.dingalings)
+                )
+                .order_by(User.id)
+                .all()
             )
-            .order_by(User.id)
-            .all()
-        )
+
+        # assert exactly 2 SQL queries: 1 for User, 1 for the selectin
+        # (joinedload folds into the selectin query, not a third query)
+        users = self.assert_sql_count(testing.db, go, 2)
 
         eq_(len(users), 2)
 
         u1 = users[0]
         # Address 1 has 2 dingalings; without .unique() the selectin result
-        # would produce 2 rows for address 1 and user.addresses would have a
-        # duplicate entry.
+        # would produce 2 rows for address 1 and loading.require_unique would
+        # raise InvalidRequestError.  The assertions below are belt-and-
+        # suspenders for if the conditional logic changes.
         address_ids = [a.id for a in u1.addresses]
         assert len(address_ids) == len(set(address_ids)), (
             f"user {u1.id} has duplicate addresses: {address_ids}"

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -4227,6 +4227,30 @@ class M2MOmitJoinTest(
                 [3],
             )
 
+    def test_m2m_selectin_no_duplicate_children(
+        self, simple_m2m, connection
+    ):
+        """selectinload over m2m must not produce duplicate items in the
+        parent's collection when no nested joinedload is present (omit_join
+        fast path).
+        """
+        A = simple_m2m
+
+        with Session(connection) as session:
+            results = (
+                session.execute(
+                    select(A).options(selectinload(A.bs)).order_by(A.id)
+                )
+                .scalars()
+                .all()
+            )
+
+        for a in results:
+            b_ids = [b.id for b in a.bs]
+            assert len(b_ids) == len(set(b_ids)), (
+                f"A id={a.id} has duplicate bs: {b_ids}"
+            )
+
 
 class SameNamePolymorphicTest(fixtures.DeclarativeMappedTest):
     @classmethod

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -4230,21 +4230,38 @@ class M2MOmitJoinTest(
     def test_m2m_selectin_no_duplicate_children(
         self, simple_m2m, connection
     ):
-        """selectinload over m2m must not produce duplicate items in the
-        parent's collection when no nested joinedload is present (omit_join
-        fast path).
+        """selectinload over m2m (omit_join fast path) must load the correct
+        collection members and must not produce duplicate items.
+
+        The simple_m2m fixture has a1.bs=[b1,b2] and a2.bs=[b1].
         """
         A = simple_m2m
 
         with Session(connection) as session:
-            results = (
-                session.execute(
+
+            def go():
+                statement = (
                     select(A).options(selectinload(A.bs)).order_by(A.id)
                 )
-                .scalars()
-                .all()
+                return session.execute(statement).scalars().all()
+
+            results = self.assert_sql_execution(
+                connection,
+                go,
+                CompiledSQL("SELECT a.id FROM a ORDER BY a.id", {}),
+                CompiledSQL(
+                    "SELECT a_b.a_id, b.id "
+                    "FROM a_b JOIN b ON b.id = a_b.b_id "
+                    "WHERE a_b.a_id IN "
+                    "(__[POSTCOMPILE_primary_keys])",
+                    {"primary_keys": [1, 2]},
+                ),
             )
 
+        eq_(sorted(b.id for b in results[0].bs), [1, 2])
+        eq_(sorted(b.id for b in results[1].bs), [1])
+
+        # belt-and-suspenders: no duplicates in either collection
         for a in results:
             b_ids = [b.id for b in a.bs]
             assert len(b_ids) == len(set(b_ids)), (

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -4412,6 +4412,133 @@ class TestBakedCancelsCorrectly(fixtures.DeclarativeMappedTest):
         self.assert_sql_count(testing.db, go, 2)
 
 
+class TestSelectinWithNestedJoinedCollectionDedup(
+    fixtures.DeclarativeMappedTest
+):
+    """Regression guard for selectinload(...).joinedload(...) on a collection.
+
+    When the inner selectin query uses joinedload on a collection, the result
+    rows are multiplied (one row per grandchild).  The .unique() call in
+    _load_via_parent must deduplicate those rows so that each parent row ends
+    up with exactly one copy of each child object.
+
+    Guards the optimization introduced alongside issue #XXXX that makes
+    .unique() conditional — ensures it still fires when loading.instances()
+    sets _unique_filter_state.
+    """
+
+    @classmethod
+    def setup_classes(cls):
+        Base = cls.DeclarativeBasic
+
+        class User(ComparableEntity, Base):
+            __tablename__ = "sel_dedup_user"
+            id = Column(Integer, primary_key=True)
+            name = Column(String(50))
+            addresses = relationship(
+                "Address", back_populates="user", order_by="Address.id"
+            )
+
+        class Address(ComparableEntity, Base):
+            __tablename__ = "sel_dedup_address"
+            id = Column(Integer, primary_key=True)
+            user_id = Column(ForeignKey("sel_dedup_user.id"))
+            email = Column(String(50))
+            user = relationship("User", back_populates="addresses")
+            dingalings = relationship(
+                "Dingaling", back_populates="address", order_by="Dingaling.id"
+            )
+
+        class Dingaling(ComparableEntity, Base):
+            __tablename__ = "sel_dedup_dingaling"
+            id = Column(Integer, primary_key=True)
+            address_id = Column(ForeignKey("sel_dedup_address.id"))
+            data = Column(String(50))
+            address = relationship("Address", back_populates="dingalings")
+
+    @classmethod
+    def insert_data(cls, connection):
+        User, Address, Dingaling = cls.classes("User", "Address", "Dingaling")
+        sess = Session(connection)
+        # user 1: one address with TWO dingalings — this is the key fixture.
+        # When selectinload(User.addresses).joinedload(Address.dingalings) runs
+        # the inner selectin query, address 1 will appear in 2 result rows
+        # (one per dingaling).  Without .unique(), user.addresses would
+        # contain address 1 twice.
+        sess.add(
+            User(
+                id=1,
+                name="u1",
+                addresses=[
+                    Address(
+                        id=1,
+                        email="a1@example.com",
+                        dingalings=[
+                            Dingaling(id=1, data="d1"),
+                            Dingaling(id=2, data="d2"),
+                        ],
+                    ),
+                    Address(id=2, email="a2@example.com"),
+                ],
+            )
+        )
+        # user 2: one address, one dingaling — control case
+        sess.add(
+            User(
+                id=2,
+                name="u2",
+                addresses=[
+                    Address(
+                        id=3,
+                        email="a3@example.com",
+                        dingalings=[Dingaling(id=3, data="d3")],
+                    )
+                ],
+            )
+        )
+        sess.commit()
+
+    def test_selectin_with_nested_joined_collection_still_dedupes(self):
+        """Regression: selectinload(...).joinedload(...) on a collection must
+        continue to dedupe inner rows after the conditional-unique optimization.
+        """
+        User, Address, Dingaling = self.classes("User", "Address", "Dingaling")
+        sess = fixture_session()
+
+        users = (
+            sess.query(User)
+            .options(
+                selectinload(User.addresses).joinedload(Address.dingalings)
+            )
+            .order_by(User.id)
+            .all()
+        )
+
+        eq_(len(users), 2)
+
+        u1 = users[0]
+        # Address 1 has 2 dingalings; without .unique() the selectin result
+        # would produce 2 rows for address 1 and user.addresses would have a
+        # duplicate entry.
+        address_ids = [a.id for a in u1.addresses]
+        assert len(address_ids) == len(set(address_ids)), (
+            f"user {u1.id} has duplicate addresses: {address_ids}"
+        )
+        eq_(len(u1.addresses), 2)
+
+        # Also verify the grandchildren loaded correctly
+        target_address = next(a for a in u1.addresses if a.id == 1)
+        eq_(len(target_address.dingalings), 2)
+
+        u2 = users[1]
+        address_ids2 = [a.id for a in u2.addresses]
+        assert len(address_ids2) == len(set(address_ids2)), (
+            f"user {u2.id} has duplicate addresses: {address_ids2}"
+        )
+        eq_(len(u2.addresses), 1)
+        eq_(len(u2.addresses[0].dingalings), 1)
+
+
 class TestCompositePlusNonComposite(fixtures.DeclarativeMappedTest):
     __requires__ = ("tuple_in",)
 


### PR DESCRIPTION
### Description

`_SelectInLoader._load_via_parent` and `_load_via_child` currently call `.unique()` unconditionally on the inner `Result`. The uniqueness pass is only required when a nested `joinedload` on a collection is in effect — in that case the JOIN inflates rows (one row per `(child, grandchild)` instead of one per child) and the outer groupby would produce duplicated entries without dedup.

`loading.instances()` already signals exactly this condition: it sets `Result._unique_filter_state` to a `require_unique` guard when the inner compile state has `multi_row_eager_loaders=True`. When that flag is unset (no nested collection joinedload), `_unique_filter_state` stays `None`, meaning the inner query produces unique rows by construction:

- `omit_join` 1:N — one row per child
- `omit_join` M2O — one row per parent
- `omit_join` M2M — one row per `(parent, entity)`
- `load_with_join` (non-omit) — one row per `(parent, child)`

This PR makes the `.unique()` call conditional:

```python
if result._unique_filter_state is not None:
    result = result.unique()
```

Per-row hashing in `_iterator_getter` is avoided in the common leaf-load case. On an in-memory SQLite bench (2000 parents × 5 children + M:N tags):

| Workload | before | after | delta |
|---|---|---|---|
| selectin children (1:N) | 74.9 ms | ~61 ms | **−18%** |
| selectin tags M2M | 30.3 ms | ~26 ms | **−14%** |
| joined children (1:N) | 46.5 ms | 46.5 ms | ~0% |
| plain parent load | 3.75 ms | 3.7 ms | ~0% |

**Behaviour change:** `yield_per` set in a `do_orm_execute` event for a relationship load no longer raises `InvalidRequestError("Can't use yield_per in conjunction with unique")` for `selectinload` without a nested collection joinedload — because `.unique()` is no longer called in that path. `immediateload` is unaffected (it still calls `.unique()` unconditionally).

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
    - Good to go, no issue or tests are needed
- [ ] A short code fix
    - please include the issue number, and create an issue if none exists, which
      must include a complete example of the issue.  one line code fixes without an
      issue and demonstration will not be accepted.
    - Please include: `Fixes: #<issue number>` in the commit message
    - please include tests.   one line code fixes without tests will not be accepted.
- [x] A new feature implementation
    - please include the issue number, and create an issue if none exists, which must
      include a complete example of how the feature would look.
    - Please include: `Fixes: #13339` in the commit message
    - please include tests.

Fixes: #13339

**Have a nice day!**
