### PR TITLE
Document quoted_name use with PostgreSQL INHERITS

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1236,6 +1236,21 @@ constraints, enabling table inheritance hierarchies in PostgreSQL.
 
     Table("some_table", metadata, ..., postgresql_inherits=("t1", "t2", ...))
 
+For schema-qualified parent table names, use :class:`.quoted_name` with
+``quote=False`` to prevent the dotted name from being quoted as a single
+identifier::
+
+    from sqlalchemy.sql import quoted_name
+
+    Table(
+        "some_table",
+        metadata,
+        ...,
+        postgresql_inherits=quoted_name(
+            "my_schema.some_supertable", quote=False
+        ),
+    )
+
 ``ON COMMIT``
 ^^^^^^^^^^^^^
 

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -5706,9 +5706,8 @@ class quoted_name(util.MemoizedSlots, str):
     :class:`_schema.Table`, :class:`_schema.Column`, and others.
     The class can also be
     passed explicitly as the name to any function that receives a name which
-    can be quoted.  Such as to use the :meth:`_engine.Engine.has_table`
-    method with
-    an unconditionally quoted name::
+    can be quoted, such as :meth:`.Inspector.has_table` with an
+    unconditionally quoted name::
 
         from sqlalchemy import create_engine
         from sqlalchemy import inspect
@@ -5720,6 +5719,11 @@ class quoted_name(util.MemoizedSlots, str):
     The above logic will run the "has table" logic against the Oracle Database
     backend, passing the name exactly as ``"some_table"`` without converting to
     upper case.
+
+    A :class:`.quoted_name` object with ``quote=False`` may be passed to APIs
+    that apply automatic quoting in order to keep the given name unquoted,
+    such as when a PostgreSQL ``INHERITS`` option refers to a schema-qualified
+    table name like ``my_schema.some_table``.
 
     """
 

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -69,6 +69,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import column
 from sqlalchemy.sql import literal_column
 from sqlalchemy.sql import operators
+from sqlalchemy.sql import quoted_name
 from sqlalchemy.sql import table
 from sqlalchemy.sql import util as sql_util
 from sqlalchemy.sql.functions import GenericFunction
@@ -529,6 +530,22 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
             schema.CreateTable(tbl),
             "CREATE TABLE atable (id INTEGER) INHERITS "
             '( "Quote Me", "quote Me Too" )',
+        )
+
+    def test_create_table_inherits_schema_qualified_quoted_name(self):
+        m = MetaData()
+        tbl = Table(
+            "atable",
+            m,
+            Column("id", Integer),
+            postgresql_inherits=quoted_name(
+                "my_schema.parent_table", quote=False
+            ),
+        )
+        self.assert_compile(
+            schema.CreateTable(tbl),
+            "CREATE TABLE atable (id INTEGER) "
+            "INHERITS ( my_schema.parent_table )",
         )
 
     def test_create_table_partition_by_list(self):


### PR DESCRIPTION
### Description

Fixes #12877.

This documents how to use `quoted_name(..., quote=False)` with PostgreSQL `postgresql_inherits` when the parent table name is schema-qualified, so the dotted name is not quoted as a single identifier.

It also updates the `quoted_name` docs to refer to `Inspector.has_table` instead of the old `Engine.has_table` reference, and adds a compiler test for the `postgresql_inherits` rendering.

### Checklist

This pull request is:

- [x] A documentation / typographical / small typing error fix
- [ ] A short code fix
- [ ] A new feature implementation

### Tests

- `pytest test/dialect/postgresql/test_compiler.py -q -k 'inherits'`
- `python -m py_compile lib/sqlalchemy/dialects/postgresql/base.py lib/sqlalchemy/sql/elements.py test/dialect/postgresql/test_compiler.py`
- `git diff --check`
