### PR TITLE
fix: prevent incorrect operator rewrite when negating ANY/ALL comparisons

### DIFF
--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -4301,7 +4301,12 @@ class BinaryExpression(OperatorExpression[_T]):
         return self.left._from_objects + self.right._from_objects
 
     def _negate(self):
-        if self.negate is not None:
+        if self.negate is not None and not getattr(
+            self.right, "_is_collection_aggregate", False
+        ) and not (
+            getattr(self.right, "name", None) is not None
+            and getattr(self.right, "name", "").lower() in ("any", "all")
+        ):
             return BinaryExpression(
                 self.left,
                 self.right._negate_in_binary(self.negate, self.operator),

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -2349,6 +2349,64 @@ class ArrayTest(AssertsCompiledSQL, fixtures.TestBase):
         is_(expr.type.__class__, postgresql.ARRAY)
         is_(expr.type.item_type.__class__, element_type)
 
+    def test_any_all_negation(self):
+        # Test that negation of == ANY/ALL and != ANY/ALL uses NOT()
+        # instead of rewriting the operator.
+        # This addresses issue #13343 where ~(col == any(arr)) was
+        # incorrectly compiled to col != any(arr) instead of
+        # NOT (col = any(arr)).
+
+        # Test any_() constructor
+        self.assert_compile(
+            ~(column("x") == any_(array([1, 2]))),
+            "NOT (x = ANY (ARRAY[%(param_1)s::INTEGER, %(param_2)s::INTEGER]))",
+        )
+        self.assert_compile(
+            ~(column("x") != any_(array([1, 2]))),
+            "NOT (x != ANY (ARRAY[%(param_1)s::INTEGER, %(param_2)s::INTEGER]))",
+        )
+
+        # Test all_() constructor
+        self.assert_compile(
+            ~(column("x") == all_(array([1, 2]))),
+            "NOT (x = ALL (ARRAY[%(param_1)s::INTEGER, %(param_2)s::INTEGER]))",
+        )
+        self.assert_compile(
+            ~(column("x") != all_(array([1, 2]))),
+            "NOT (x != ALL (ARRAY[%(param_1)s::INTEGER, %(param_2)s::INTEGER]))",
+        )
+
+        # Test func.any() - the original bug report case
+        self.assert_compile(
+            ~(column("x") == func.any(array([1, 2]))),
+            "NOT (x = any(ARRAY[%(param_1)s::INTEGER, %(param_2)s::INTEGER]))",
+        )
+        self.assert_compile(
+            ~(column("x") != func.any(array([1, 2]))),
+            "NOT (x != any(ARRAY[%(param_1)s::INTEGER, %(param_2)s::INTEGER]))",
+        )
+
+        # Test func.all()
+        self.assert_compile(
+            ~(column("x") == func.all(array([1, 2]))),
+            "NOT (x = all(ARRAY[%(param_1)s::INTEGER, %(param_2)s::INTEGER]))",
+        )
+        self.assert_compile(
+            ~(column("x") != func.all(array([1, 2]))),
+            "NOT (x != all(ARRAY[%(param_1)s::INTEGER, %(param_2)s::INTEGER]))",
+        )
+
+    def test_any_all_negation_other_ops(self):
+        # Test that other operators with ANY/ALL still work correctly.
+        self.assert_compile(
+            column("x") < any_(array([1, 2])),
+            "x < ANY (ARRAY[%(param_1)s::INTEGER, %(param_2)s::INTEGER])",
+        )
+        self.assert_compile(
+            column("x") > all_(array([1, 2])),
+            "x > ALL (ARRAY[%(param_1)s::INTEGER, %(param_2)s::INTEGER])",
+        )
+
 
 AnEnum = pep435_enum("AnEnum")
 AnEnum("Foo", 1)


### PR DESCRIPTION
Fixes #13343

The negation of == ANY() / == ALL() and != ANY() / != ALL() was incorrectly rewriting the operator rather than wrapping with NOT (). This produced semantically different SQL in PostgreSQL.

Changes:
- Extended BinaryExpression._negate() to skip operator rewriting when RHS is a CollectionAggregate or Function named any/all
- Added comprehensive compile tests for all variants (any_(), all_(), func.any(), func.all())