### PR TITLE
Removed erroneous debug print in pysqlcipher.py

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/pysqlcipher.py
+++ b/lib/sqlalchemy/dialects/sqlite/pysqlcipher.py
@@ -144,7 +144,6 @@ class SQLiteDialect_pysqlcipher(SQLiteDialect_pysqlite):
             cursor.execute(f"pragma key={passphrase}")
             for prag, value in query_pragmas.items():
                 cursor.execute(f"pragma {prag}={value}")
-            print(query_pragmas)
             cursor.close()
 
             if super_on_connect:


### PR DESCRIPTION
### Description
`on_connect` had a debug print left in. I removed it. It was a nuisance during use and causing pytest failures in my projects that look at stdout.

### Checklist

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
