### PR TITLE
test: cover missing error path

### DIFF
--- a/test/orm/test_bind.py
+++ b/test/orm/test_bind.py
@@ -502,6 +502,14 @@ class BindIntegrationTest(_fixtures.FixtureTest):
             testing.db,
         )
 
+        assert_raises_message(
+            sa.exc.ArgumentError,
+            "Not an acceptable bind target: foobar",
+            sess.bind_table,
+            "foobar",
+            testing.db,
+        )
+
         self.mapper_registry.map_imperatively(
             self.classes.User, self.tables.users
         )
@@ -511,6 +519,14 @@ class BindIntegrationTest(_fixtures.FixtureTest):
             sa.exc.ArgumentError,
             "Not an acceptable bind target: User()",
             sess.bind_mapper,
+            u_object,
+            testing.db,
+        )
+
+        assert_raises_message(
+            sa.exc.ArgumentError,
+            "Not an acceptable bind target: User()",
+            sess.bind_table,
             u_object,
             testing.db,
         )


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in test/orm/test_bind.py, test/orm/test_sync.py related to Python typing, tests, CLI ergonomics, observability; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.