### PR TITLE
Improve performance of selectinload result handling

### DIFF
--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -13,7 +13,6 @@ implementations, and related MapperOptions."""
 from __future__ import annotations
 
 import collections
-import itertools
 from typing import Any
 from typing import Dict
 from typing import Literal
@@ -56,6 +55,7 @@ from .. import inspect
 from .. import log
 from .. import sql
 from .. import util
+from ..engine.result import IteratorResult
 from ..sql import util as sql_util
 from ..sql import visitors
 from ..sql.selectable import LABEL_STYLE_TABLENAME_PLUS_COL
@@ -1830,9 +1830,12 @@ class _SubqueryLoader(_PostLoader):
             # to work with baked query, the parameters may have been
             # updated since this query was created, so take these into account
 
-            rows = list(q.params(self.params))
-            for k, v in itertools.groupby(rows, lambda x: x[1:]):
-                self._data[k].extend(vv[0] for vv in v)
+            data = self._data
+            for row in q.params(self.params):
+                # group plain tuples rather than Row slices, which would
+                # incur Row construction and Row.__eq__ per row
+                tup = row._to_tuple_instance()
+                data[tup[1:]].append(tup[0])
 
         def loader(self, state, dict_, row):
             if self._data is None:
@@ -3192,17 +3195,30 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
 
             mapper = self.parent
 
+            # attribute keys for the lookup columns; when these are
+            # present in the state's dict, equivalent to the
+            # PASSIVE_NO_FETCH attribute lookup below
+            lookup_keys = [
+                mapper._columntoproperty[lk].key
+                for lk in query_info.child_lookup_cols
+            ]
+
             for state, overwrite in states:
                 state_dict = state.dict
-                related_ident = tuple(
-                    mapper._get_state_attr_by_column(
-                        state,
-                        state_dict,
-                        lk,
-                        passive=attributes.PASSIVE_NO_FETCH,
+                try:
+                    related_ident = tuple(
+                        [state_dict[lk] for lk in lookup_keys]
                     )
-                    for lk in query_info.child_lookup_cols
-                )
+                except KeyError:
+                    related_ident = tuple(
+                        mapper._get_state_attr_by_column(
+                            state,
+                            state_dict,
+                            lk,
+                            passive=attributes.PASSIVE_NO_FETCH,
+                        )
+                        for lk in query_info.child_lookup_cols
+                    )
                 # if the loaded parent objects do not have the foreign key
                 # to the related item loaded, then degrade into the joined
                 # version of selectinload
@@ -3244,12 +3260,18 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
                 ]
                 in_expr = effective_entity._adapt_element(in_expr)
 
-        bundle_ent = orm_util.Bundle("pk", *pk_cols)
-        bundle_sql = bundle_ent.__clause_element__()
+        if query_info.zero_idx:
+            # single column key; select the column directly so that
+            # result rows carry the plain key value rather than a
+            # per-row Bundle Row object
+            pk_sql = pk_cols[0]
+        else:
+            bundle_ent = orm_util.Bundle("pk", *pk_cols)
+            pk_sql = bundle_ent.__clause_element__()
 
         entity_sql = effective_entity.__clause_element__()
         q = Select._create_raw_select(
-            _raw_columns=[bundle_sql, entity_sql],
+            _raw_columns=[pk_sql, entity_sql],
             _compile_options=_ORMCompileState.default_compile_options,
             _propagate_attrs={
                 "compile_state_plugin": "orm",
@@ -3399,6 +3421,21 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
                 chunksize,
             )
 
+    @staticmethod
+    def _iterate_result(result):
+        """Iterate (key, instance) pairs from the SELECT .. IN result.
+
+        When no uniquing is required, raw interim rows are consumed
+        directly, skipping per-row Row object construction.
+
+        """
+        if result.context is not None and result.context.requires_uniquing:
+            return iter(result.unique())
+        elif isinstance(result, IteratorResult):
+            return result._raw_row_iterator()
+        else:
+            return iter(result)
+
     def _load_via_child(
         self,
         our_states,
@@ -3416,26 +3453,23 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
         while our_keys:
             chunk = our_keys[0:chunksize]
             our_keys = our_keys[chunksize:]
+            primary_keys = [
+                key[0] if query_info.zero_idx else key for key in chunk
+            ]
             result = context.session.execute(
                 q,
-                params={
-                    "primary_keys": [
-                        key[0] if query_info.zero_idx else key for key in chunk
-                    ]
-                },
+                params={"primary_keys": primary_keys},
                 execution_options=execution_options,
             )
-            if result.context is not None and result.context.requires_uniquing:
-                result = result.unique()
-            data = {k: v for k, v in result}
+            data = dict(self._iterate_result(result))
 
-            for key in chunk:
+            for lookup_key, key in zip(primary_keys, chunk):
                 # for a real foreign key and no concurrent changes to the
                 # DB while running this method, "key" is always present in
                 # data.  However, for primaryjoins without real foreign keys
                 # a non-None primaryjoin condition may still refer to no
                 # related object.
-                related_obj = data.get(key, None)
+                related_obj = data.get(lookup_key, None)
                 for state, dict_, overwrite in our_states[key]:
                     if not overwrite and self.key in dict_:
                         continue
@@ -3474,17 +3508,17 @@ class _SelectInLoader(_PostLoader, util.MemoizedSlots):
                 params={"primary_keys": primary_keys},
                 execution_options=execution_options,
             )
-            if result.context is not None and result.context.requires_uniquing:
-                result = result.unique()
             data = collections.defaultdict(list)
-            for k, v in itertools.groupby(result, lambda x: x[0]):
-                data[k].extend(vv[1] for vv in v)
+            for k, v in self._iterate_result(result):
+                data[k].append(v)
 
-            for key, state, state_dict, overwrite in chunk:
+            for lookup_key, (key, state, state_dict, overwrite) in zip(
+                primary_keys, chunk
+            ):
                 if not overwrite and self.key in state_dict:
                     continue
 
-                collection = data.get(key, _empty_result)
+                collection = data.get(lookup_key, _empty_result)
 
                 if not uselist and collection:
                     if len(collection) > 1:

--- a/test/orm/test_selectin_relations.py
+++ b/test/orm/test_selectin_relations.py
@@ -4654,3 +4654,88 @@ class TestCompositePlusNonComposite(fixtures.DeclarativeMappedTest):
 
         eq_(a2.bs, [B2()])
         eq_(a1.bs, [B()])
+
+
+class UselistFalseMultipleRowsTest(fixtures.DeclarativeMappedTest):
+    """test the warning emitted by the selectin loader for a
+    uselist=False relationship that matches more than one row"""
+
+    @classmethod
+    def setup_classes(cls):
+        Base = cls.DeclarativeBasic
+
+        class A(ComparableEntity, Base):
+            __tablename__ = "a"
+            id = Column(Integer, primary_key=True)
+            b = relationship("B", uselist=False)
+
+        class B(ComparableEntity, Base):
+            __tablename__ = "b"
+            id = Column(Integer, primary_key=True)
+            a_id = Column(ForeignKey("a.id"))
+
+    @classmethod
+    def insert_data(cls, connection):
+        A, B = cls.classes("A", "B")
+        s = Session(connection)
+        s.add(A(id=1))
+        s.add_all([B(id=1, a_id=1), B(id=2, a_id=1)])
+        s.commit()
+
+    def test_multiple_rows_uselist_false_warns(self):
+        A = self.classes.A
+        s = fixture_session()
+        with testing.expect_warnings(
+            "Multiple rows returned with uselist=False for "
+            "eagerly-loaded attribute 'A.b'"
+        ):
+            a1 = s.query(A).options(selectinload(A.b)).one()
+        assert a1.b is not None
+        assert a1.b.id in (1, 2)
+
+
+class SelectinM2ONoRelatedRowTest(fixtures.DeclarativeMappedTest):
+    """test many-to-one selectinload where the candidate foreign key
+    value matches no related row, or is NULL"""
+
+    @classmethod
+    def setup_classes(cls):
+        Base = cls.DeclarativeBasic
+
+        class A(ComparableEntity, Base):
+            __tablename__ = "a"
+            id = Column(Integer, primary_key=True)
+
+        class B(ComparableEntity, Base):
+            __tablename__ = "b"
+            id = Column(Integer, primary_key=True)
+            a_id = Column(Integer)
+            a = relationship("A", primaryjoin="foreign(B.a_id) == A.id")
+
+    @classmethod
+    def insert_data(cls, connection):
+        A, B = cls.classes("A", "B")
+        s = Session(connection)
+        s.add(A(id=1))
+        s.add_all(
+            [
+                B(id=1, a_id=1),
+                B(id=2, a_id=42),
+                B(id=3, a_id=None),
+            ]
+        )
+        s.commit()
+
+    def test_missing_and_null_fk(self):
+        A, B = self.classes("A", "B")
+        s = fixture_session()
+        bs = s.query(B).order_by(B.id).options(selectinload(B.a)).all()
+
+        with self.assert_statement_count(testing.db, 0):
+            eq_(bs[0].a, A(id=1))
+
+            # a_id value with no matching A row
+            is_(bs[1].a, None)
+
+            # NULL a_id
+            is_(bs[2].a, None)


### PR DESCRIPTION
The "SELECT .. IN" query emitted by selectinload now selects a single-column key directly rather than wrapping it in a Bundle, avoiding construction of a nested Row object per result row.  The loader consumes interim row tuples via Result._raw_row_iterator() when no uniquing is required, skipping per-row Row construction, and groups rows with a plain append loop in place of itertools.groupby.  Many-to-one selectin loads use a fast path that reads foreign key values directly from the parent instance dict, falling back to attribute-level access for expired attributes. subqueryload now groups its results on plain tuples rather than Row slices, which would incur Row construction and Row.__eq__ per row.

Adds tests pinning behavior of the rewritten result handling: the uselist=False multiple-rows warning, and many-to-one loads where the foreign key value matches no row or is NULL.

Benchmarked on an in-memory SQLite database (median of 100 runs, ms):

| case | before | after | Δ |
|---|---|---|---|
| selectin o2m (500×10) | 20.09 ms | 15.11 ms | −25% |
| selectin o2m, few big collections (20×500) | 35.88 ms | 26.73 ms | −26% |
| selectin m2m (500×10) | 13.48 ms | 8.87 ms | −34% |
| selectin nested (50×10×10) | 20.09 ms | 14.62 ms | −27% |
| selectin m2o (5000→200) | 17.34 ms | 15.64 ms | −10% |
| subqueryload o2m (500×10) | 23.92 ms | 21.10 ms | −12% |
| plain loads / joinedload | — | — | unchanged |

