### PR TITLE
Process ORM result rows as plain tuples without Row construction

### DIFF
--- a/lib/sqlalchemy/engine/_result_cy.py
+++ b/lib/sqlalchemy/engine/_result_cy.py
@@ -282,6 +282,59 @@ class BaseResultInternal(Generic[_R]):
         assert make_rows is not None
         return make_rows(self._fetchall_impl())
 
+    def _all_interim_rows(self) -> Sequence[Any]:
+        """Return all remaining rows as plain processed tuples, without
+        constructing :class:`.Row` objects when possible.
+
+        Used by ORM loading, whose row getters are position-based and
+        accept any tuple-like row.  Falls back to Row construction for
+        row-logging or scalar-source results.
+
+        """
+        real_result = self if self._real_result is None else self._real_result
+
+        if (
+            real_result._row_logging_fn is not None
+            or real_result._source_supports_scalars
+        ):
+            return self._raw_all_rows()
+
+        metadata = self._metadata
+        tuple_filters = metadata._tuplefilter
+
+        rows = self._fetchall_impl()
+
+        ep = metadata._effective_processors
+        if ep is not None:
+            if tuple_filters is not None:
+                ep = tuple_filters(ep)
+            processors: tuple = tuple(ep)
+            proc_size: cython.Py_ssize_t = len(processors)
+            proc_valid = tuple(
+                [i for i, p in enumerate(processors) if p is not None]
+            )
+            if tuple_filters is not None:
+                return [
+                    _apply_processors(
+                        processors, proc_size, proc_valid, tuple_filters(row)
+                    )
+                    for row in rows
+                ]
+            else:
+                return [
+                    _apply_processors(processors, proc_size, proc_valid, row)
+                    for row in rows
+                ]
+        elif tuple_filters is not None:
+            interim = [tuple_filters(row) for row in rows]
+            if interim and type(interim[0]) is not tuple:
+                interim = [tuple(row) for row in interim]
+            return interim
+        else:
+            if rows and type(rows[0]) is not tuple:
+                return [tuple(row) for row in rows]
+            return rows
+
     def _allrows(self) -> Sequence[_R]:
         post_creational_filter = self._post_creational_filter
 

--- a/lib/sqlalchemy/orm/loading.py
+++ b/lib/sqlalchemy/orm/loading.py
@@ -228,7 +228,7 @@ def instances(
                 if not fetch:
                     break
             else:
-                fetch = cursor._raw_all_rows()
+                fetch = cursor._all_interim_rows()
 
             if single_entity:
                 proc = process[0]

--- a/test/orm/test_loading.py
+++ b/test/orm/test_loading.py
@@ -1,21 +1,30 @@
+import logging
+
 from sqlalchemy import delete
 from sqlalchemy import exc
 from sqlalchemy import insert
+from sqlalchemy import Integer
 from sqlalchemy import literal
 from sqlalchemy import literal_column
 from sqlalchemy import select
+from sqlalchemy import String
 from sqlalchemy import testing
 from sqlalchemy import text
+from sqlalchemy import TypeDecorator
 from sqlalchemy import update
 from sqlalchemy.orm import loading
 from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Session
+from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_true
 from sqlalchemy.testing import mock
 from sqlalchemy.testing.assertions import assert_raises
 from sqlalchemy.testing.assertions import assert_raises_message
 from sqlalchemy.testing.assertions import eq_
 from sqlalchemy.testing.assertions import expect_raises_message
+from sqlalchemy.testing.assertions import is_
 from sqlalchemy.testing.fixtures import fixture_session
+from sqlalchemy.testing.schema import Column
 from . import _fixtures
 
 # class GetFromIdentityTest(_fixtures.FixtureTest):
@@ -270,3 +279,58 @@ class MergeResultTest(_fixtures.FixtureTest):
         it = list(it())
         eq_([(x.id, y) for x, y in it], [(7, 7), (8, 8), (9, 9)])
         eq_(list(it[0]._mapping.keys()), ["User", "id"])
+
+
+class InterimRowsLoadTest(fixtures.DeclarativeMappedTest):
+    """ORM loading fetches rows as plain processed tuples via
+    Result._all_interim_rows(); test that result processors apply and
+    that engine-level row logging, which requires Row objects, still
+    loads correctly via its fallback."""
+
+    @classmethod
+    def setup_classes(cls):
+        Base = cls.DeclarativeBasic
+
+        class UpperString(TypeDecorator):
+            impl = String(50)
+            cache_ok = True
+
+            def process_result_value(self, value, dialect):
+                return value.upper() if value is not None else None
+
+        class A(Base):
+            __tablename__ = "interim_a"
+            id = Column(Integer, primary_key=True)
+            data = Column(UpperString())
+
+    @classmethod
+    def insert_data(cls, connection):
+        A = cls.classes.A
+        s = Session(connection)
+        s.add_all([A(id=1, data="one"), A(id=2, data=None)])
+        s.commit()
+
+    def _assert_load(self):
+        A = self.classes.A
+        s = fixture_session()
+        a1, a2 = s.query(A).order_by(A.id).all()
+        eq_(a1.data, "ONE")
+        is_(a2.data, None)
+
+    def test_result_processors_applied(self):
+        self._assert_load()
+
+    def test_row_logging_fallback(self):
+        logger = logging.getLogger("sqlalchemy.engine")
+        old_level = logger.level
+        old_propagate = logger.propagate
+        handler = logging.NullHandler()
+        logger.addHandler(handler)
+        logger.setLevel(logging.DEBUG)
+        logger.propagate = False
+        try:
+            self._assert_load()
+        finally:
+            logger.setLevel(old_level)
+            logger.propagate = old_propagate
+            logger.removeHandler(handler)

--- a/test/sql/test_resultset.py
+++ b/test/sql/test_resultset.py
@@ -3934,3 +3934,70 @@ class GenerativeResultTest(fixtures.TablesTest):
             start += 20
 
         assert result._soft_closed
+
+
+class AllInterimRowsTest(fixtures.TablesTest):
+    """test Result._all_interim_rows(), which ORM loading uses to fetch
+    processed rows without constructing Row objects."""
+
+    @classmethod
+    def define_tables(cls, metadata):
+        class UpperString(TypeDecorator):
+            impl = String(50)
+            cache_ok = True
+
+            def process_result_value(self, value, dialect):
+                return value.upper() if value is not None else None
+
+        Table(
+            "interim",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("plain", String(50)),
+            Column("upper", UpperString()),
+        )
+
+    @classmethod
+    def insert_data(cls, connection):
+        connection.execute(
+            cls.tables.interim.insert(),
+            [
+                {"id": 1, "plain": "p1", "upper": "u1"},
+                {"id": 2, "plain": "p2", "upper": None},
+            ],
+        )
+
+    def test_processors_applied(self, connection):
+        """rows are plain tuples with result processors applied"""
+        t = self.tables.interim
+        result = connection.execute(select(t).order_by(t.c.id))
+        rows = result._all_interim_rows()
+        eq_(list(rows), [(1, "p1", "U1"), (2, "p2", None)])
+        for r in rows:
+            is_(type(r), tuple)
+
+    def test_no_processors(self, connection):
+        """rows with no result processors in play are plain tuples"""
+        t = self.tables.interim
+        result = connection.execute(select(t.c.id, t.c.plain).order_by(t.c.id))
+        rows = result._all_interim_rows()
+        eq_(list(rows), [(1, "p1"), (2, "p2")])
+        for r in rows:
+            is_(type(r), tuple)
+
+    def test_empty_result(self, connection):
+        t = self.tables.interim
+        result = connection.execute(select(t).where(t.c.id == -1))
+        eq_(list(result._all_interim_rows()), [])
+
+    def test_row_logging_falls_back_to_rows(self, connection):
+        """with a row logging function present, Row objects are built so
+        that they can be logged"""
+        t = self.tables.interim
+        result = connection.execute(select(t).order_by(t.c.id))
+        result._row_logging_fn = lambda row: row
+        rows = result._all_interim_rows()
+        eq_(len(rows), 2)
+        for r in rows:
+            is_true(isinstance(r, Row))
+        eq_(tuple(rows[0]), (1, "p1", "U1"))


### PR DESCRIPTION
Adds Result._all_interim_rows(), which returns the remaining rows as processed plain tuples, applying result processors and tuple filters but skipping Row object construction.  ORM loading uses this for its row fetch; its row getters are position-based itemgetters that accept any tuple-like row.  Results that require row logging or have scalar sources fall back to Row construction.