### PR TITLE
Document deprecated MySQL (M,D) float syntax and improve error message

### DIFF
--- a/doc/build/changelog/unreleased_20/11132.rst
+++ b/doc/build/changelog/unreleased_20/11132.rst
@@ -1,0 +1,10 @@
+.. change::
+    :tags: bug, mysql
+    :tickets: 11132
+
+    Documented that the ``DOUBLE(M,D)``, ``REAL(M,D)`` and ``FLOAT(M,D)``
+    precision / scale syntaxes rendered by the MySQL dialect's
+    :class:`_mysql.DOUBLE`, :class:`_mysql.REAL` and :class:`_mysql.FLOAT`
+    datatypes are non-standard MySQL extensions which are deprecated by
+    MySQL, and altered the error message raised when only one of
+    ``precision`` / ``scale`` is passed to mention this caveat.

--- a/lib/sqlalchemy/dialects/mysql/types.py
+++ b/lib/sqlalchemy/dialects/mysql/types.py
@@ -70,7 +70,10 @@ class _FloatType(
         ):
             raise exc.ArgumentError(
                 "You must specify both precision and scale or omit "
-                "both altogether."
+                "both altogether. The DOUBLE(M,D), REAL(M,D) and "
+                "FLOAT(M,D) syntaxes are non-standard MySQL extensions "
+                "which are deprecated by MySQL; omitting precision and "
+                "scale is recommended."
             )
         super().__init__(precision=precision, asdecimal=asdecimal, **kw)
         self.scale = scale
@@ -218,6 +221,17 @@ class DOUBLE(_FloatType, sqltypes.DOUBLE[Union[decimal.Decimal, float]]):
             to change this scale, or ``asdecimal=False`` to return values
             directly as Python floating points.
 
+        .. warning::
+
+            Specifying both ``precision`` and ``scale`` renders the
+            ``DOUBLE(M,D)`` syntax, which is a non-standard MySQL extension
+            that is deprecated by MySQL; MySQL documentation indicates that
+            support for it may be removed in a future release.  Omitting
+            ``precision`` and ``scale`` is recommended.  See
+            `Floating-Point Types
+            <https://dev.mysql.com/doc/refman/8.4/en/floating-point-types.html>`_
+            in the MySQL documentation.
+
         :param precision: Total digits in this number.  If scale and precision
           are both None, values are stored to limits allowed by the server.
 
@@ -258,6 +272,17 @@ class REAL(_FloatType, sqltypes.REAL[Union[decimal.Decimal, float]]):
             to change this scale, or ``asdecimal=False`` to return values
             directly as Python floating points.
 
+        .. warning::
+
+            Specifying both ``precision`` and ``scale`` renders the
+            ``REAL(M,D)`` syntax, which is a non-standard MySQL extension
+            that is deprecated by MySQL; MySQL documentation indicates that
+            support for it may be removed in a future release.  Omitting
+            ``precision`` and ``scale`` is recommended.  See
+            `Floating-Point Types
+            <https://dev.mysql.com/doc/refman/8.4/en/floating-point-types.html>`_
+            in the MySQL documentation.
+
         :param precision: Total digits in this number.  If scale and precision
           are both None, values are stored to limits allowed by the server.
 
@@ -289,6 +314,17 @@ class FLOAT(_FloatType, sqltypes.FLOAT[Union[decimal.Decimal, float]]):
         **kw: Any,
     ):
         """Construct a FLOAT.
+
+        .. warning::
+
+            Specifying both ``precision`` and ``scale`` renders the
+            ``FLOAT(M,D)`` syntax, which is a non-standard MySQL extension
+            that is deprecated by MySQL; MySQL documentation indicates that
+            support for it may be removed in a future release.  Omitting
+            ``precision`` and ``scale`` is recommended.  See
+            `Floating-Point Types
+            <https://dev.mysql.com/doc/refman/8.4/en/floating-point-types.html>`_
+            in the MySQL documentation.
 
         :param precision: Total digits in this number.  If scale and precision
           are both None, values are stored to limits allowed by the server.

--- a/test/dialect/mysql/test_types.py
+++ b/test/dialect/mysql/test_types.py
@@ -202,6 +202,26 @@ class TypeCompileTest(fixtures.TestBase, AssertsCompiledSQL):
         self.assert_compile(eval("mysql.%r" % type_inst), res)
 
     @testing.combinations(
+        (mysql.DOUBLE, {"precision": 17}),
+        (mysql.DOUBLE, {"scale": 7}),
+        (mysql.REAL, {"precision": 17}),
+        (mysql.REAL, {"scale": 7}),
+        argnames="type_, kw",
+    )
+    def test_double_real_requires_both_precision_and_scale(self, type_, kw):
+        """test #11132"""
+        assert_raises_message(
+            exc.ArgumentError,
+            r"You must specify both precision and scale or omit both "
+            r"altogether\. The DOUBLE\(M,D\), REAL\(M,D\) and FLOAT\(M,D\) "
+            r"syntaxes are non-standard MySQL extensions which are "
+            r"deprecated by MySQL; omitting precision and scale is "
+            r"recommended\.",
+            type_,
+            **kw,
+        )
+
+    @testing.combinations(
         (mysql.MSChar, [1], {}, "CHAR(1)"),
         (mysql.NCHAR, [1], {}, "NATIONAL CHAR(1)"),
         (mysql.MSChar, [1], {"binary": True}, "CHAR(1) BINARY"),


### PR DESCRIPTION
### Description

Fixes #11132.

Per maintainer guidance in the issue, this PR does two things:

1. **Documents the caveat**: adds a `.. warning::` to the MySQL dialect's `DOUBLE`, `REAL` and `FLOAT` datatype docs stating that the `DOUBLE(M,D)` / `REAL(M,D)` / `FLOAT(M,D)` precision/scale syntaxes are non-standard MySQL extensions deprecated by MySQL (with a link to the MySQL floating-point types documentation), and that omitting precision and scale is recommended.
2. **Alters the exception message** raised by `_FloatType.__init__` when only one of `precision` / `scale` is passed, so it now explains the deprecation instead of only demanding both parameters.

Tests: added `test_double_real_requires_both_precision_and_scale` (4 parametrized cases over `DOUBLE`/`REAL` × precision-only/scale-only) pinning the new message. Full `test/dialect/mysql/test_types.py` passes (130 passed); `black --check` and `flake8` are clean on the touched files.

A changelog file `doc/build/changelog/unreleased_20/11132.rst` is included.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
- [x] A short code fix
  - please include the issue number, and create an issue if none exists, which
    must include a complete example of the issue.  one line code fixes
    without an issue and demonstration will not be accepted.
  - Please include: `Fixes: #11132` in the commit message
  - please include tests.   one line code fixes without tests will not be
    accepted.
- [ ] A new feature implementation
