### PR TITLE
fix catastrophic backtracking in hstore literal parser

### DIFF
--- a/doc/build/changelog/unreleased_20/13370.rst
+++ b/doc/build/changelog/unreleased_20/13370.rst
@@ -1,0 +1,11 @@
+.. change::
+    :tags: bug, postgresql
+    :tickets: 13370
+
+    Fixed issue where the regular expression used by the pure Python hstore
+    result processor, in use when ``use_native_hstore=False`` is set, could
+    exhibit catastrophic backtracking on malformed hstore text containing an
+    unterminated quoted segment followed by a run of backslashes, with
+    parsing time roughly doubling for each additional backslash.  Such input
+    is now rejected immediately; parsing of valid hstore values is
+    unchanged.  Pull request courtesy dxbjavid.

--- a/lib/sqlalchemy/dialects/postgresql/hstore.py
+++ b/lib/sqlalchemy/dialects/postgresql/hstore.py
@@ -319,12 +319,12 @@ class _HStoreMatrixFunction(sqlfunc.GenericFunction[Any]):
 HSTORE_PAIR_RE = re.compile(
     r"""
 (
-  "(?P<key> (\\ . | [^"])* )"       # Quoted key
+  "(?P<key> (\\ . | [^"\\])* )"     # Quoted key
 )
 [ ]* => [ ]*    # Pair operator, optional adjoining whitespace
 (
     (?P<value_null> NULL )          # NULL value
-  | "(?P<value> (\\ . | [^"])* )"   # Quoted value
+  | "(?P<value> (\\ . | [^"\\])* )" # Quoted value
 )
 """,
     re.VERBOSE,

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -4152,6 +4152,16 @@ class HStoreTest(AssertsCompiledSQL, fixtures.TestBase):
         )
         eq_(proc('"\\\\\\"a"=>"\\\\\\"1"'), {'\\"a': '\\"1'})
 
+    def test_result_deserialize_malformed_no_backtracking(self):
+        # a quoted segment with a long run of backslashes and no closing
+        # quote used to make HSTORE_PAIR_RE backtrack catastrophically; the
+        # parser should reject it promptly instead of hanging
+        dialect = postgresql.dialect(use_native_hstore=False)
+        proc = self.test_table.c.hash.type._cached_result_processor(
+            dialect, None
+        )
+        assert_raises(ValueError, proc, '"' + "\\" * 40 + "!")
+
     def test_bind_serialize_psycopg2(self):
         from sqlalchemy.dialects.postgresql import psycopg2
 


### PR DESCRIPTION
### Description

`HSTORE_PAIR_RE` parses quoted hstore keys and values with `(\\ . | [^"])*`, where a backslash matches both the `\\ .` branch and the `[^"]` branch. For a run of backslashes the engine can split it many ways, so when the rest of the pattern fails to match (an opened quote with no closing quote) it backtracks through all of them and the time roughly doubles per extra backslash. `_parse_hstore` runs this in the pure-Python result processor used when `use_native_hstore=False`, so malformed text on that path can hang. Excluding the backslash from the negated class gives each character one parse and matches the same valid hstore, since a backslash there is always followed by another character. Full reproduction is in #13370.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
- [x] A short code fix
	- Fixes: #13370
	- regression test added in `test/dialect/postgresql/test_types.py::HStoreTest::test_result_deserialize_malformed_no_backtracking`, which times out on the current parser and passes with the fix
- [ ] A new feature implementation

**Have a nice day!**
