### PR TITLE
quote driver name and pass-through keys in pyodbc connect string

### DIFF
--- a/doc/build/changelog/unreleased_20/pyodbc_connect_args_quoting.rst
+++ b/doc/build/changelog/unreleased_20/pyodbc_connect_args_quoting.rst
@@ -1,0 +1,11 @@
+.. change::
+    :tags: bug, mssql
+
+    Tightened the construction of the ODBC connection string in the pyodbc
+    connector so that the driver name and the names of pass-through
+    connection parameters are brace-quoted in the same way their values
+    already are.  Previously a ``}`` in the driver name, or a ``;`` in the
+    name of a pass-through parameter, could close the surrounding token
+    early and leave the remainder of the string to be read as further
+    connection attributes.  The same fix is applied to the mssql-python
+    connector.  Pull request courtesy dxbjavid.

--- a/lib/sqlalchemy/connectors/pyodbc.py
+++ b/lib/sqlalchemy/connectors/pyodbc.py
@@ -105,7 +105,9 @@ class PyODBCConnector(Connector):
                         "DSN-less connections"
                     )
                 else:
-                    connectors.append("DRIVER={%s}" % driver)
+                    connectors.append(
+                        "DRIVER={%s}" % str(driver).replace("}", "}}")
+                    )
 
                 connectors.extend(
                     [
@@ -136,7 +138,9 @@ class PyODBCConnector(Connector):
                     "AutoTranslate=%s" % keys.pop("odbc_autotranslate")
                 )
 
-            connectors.extend(["%s=%s" % (k, v) for k, v in keys.items()])
+            connectors.extend(
+                ["%s=%s" % (check_quote(k), v) for k, v in keys.items()]
+            )
 
         return ((";".join(connectors),), connect_args)
 

--- a/lib/sqlalchemy/dialects/mssql/mssqlpython.py
+++ b/lib/sqlalchemy/dialects/mssql/mssqlpython.py
@@ -145,7 +145,9 @@ class MSDialect_mssqlpython(MSDialect):
             if authentication:
                 connectors.append("Authentication=%s" % authentication)
 
-        connectors.extend(["%s=%s" % (k, v) for k, v in keys.items()])
+        connectors.extend(
+            ["%s=%s" % (check_quote(k), v) for k, v in keys.items()]
+        )
 
         return ((";".join(connectors),), connect_args)
 

--- a/test/dialect/mssql/test_engine.py
+++ b/test/dialect/mssql/test_engine.py
@@ -294,6 +294,7 @@ class ParseConnectTest(fixtures.TestBase):
                 "somehost%3BPORT%3D50001",
                 "somedb%3BPORT%3D50001",
             ),
+            "driver=foob",
             (
                 "DRIVER={foob};Server=somehost%3BPORT%3D50001;"
                 "Database={somedb;PORT=50001};UID={someuser;PORT=50001};"
@@ -308,64 +309,59 @@ class ParseConnectTest(fixtures.TestBase):
                 "localhost",
                 "mydb",
             ),
+            "driver=foob",
             (
                 "DRIVER={foob};Server=localhost;"
                 "Database=mydb;UID=larry;"
                 "PWD={{moe}",
             ),
         ),
-        argnames="tokens, connection_string",
-        id_="iaa",
+        (
+            # the driver name is always wrapped in braces, so a closing
+            # brace in the value has to be escaped, otherwise it ends the
+            # brace early and the remainder is read as further attributes
+            "driver_brace_injection",
+            (
+                "username",
+                "password",
+                "hostspec",
+                "database",
+            ),
+            "driver=foob%7DUID%3Devil",
+            (
+                "DRIVER={foob}}UID=evil};Server=hostspec;Database=database;"
+                "UID=username;PWD=password",
+            ),
+        ),
+        (
+            # names of pass-through parameters get the same brace quoting
+            # as their values, so a semicolon in a parameter name can't be
+            # used to smuggle in an extra attribute
+            "pass_through_key_injection",
+            (
+                "username",
+                "password",
+                "hostspec",
+                "database",
+            ),
+            "driver=foob&foo%3BUID=evil",
+            (
+                "DRIVER={foob};Server=hostspec;Database=database;"
+                "UID=username;PWD=password;{foo;UID}=evil",
+            ),
+        ),
+        argnames="tokens, query, connection_string",
+        id_="iaaa",
     )
-    def test_pyodbc_token_injection(self, tokens, connection_string):
-        u = url.make_url("mssql+pyodbc://%s:%s@%s/%s?driver=foob" % tokens)
+    def test_pyodbc_token_injection(self, tokens, query, connection_string):
+        u = url.make_url(
+            "mssql+pyodbc://%s:%s@%s/%s?%s" % (tokens + (query,))
+        )
         dialect = pyodbc.dialect()
         connection = dialect.create_connect_args(u)
         eq_(
             (
                 connection_string,
-                {},
-            ),
-            connection,
-        )
-
-    def test_pyodbc_driver_token_injection(self):
-        # the driver name is always wrapped in braces, so a closing brace
-        # in the value has to be escaped, otherwise it ends the brace early
-        # and the remainder is read as further connection attributes
-        dialect = pyodbc.dialect()
-        u = url.make_url(
-            "mssql+pyodbc://username:password@hostspec/database"
-            "?driver=foob%7DUID%3Devil"
-        )
-        connection = dialect.create_connect_args(u)
-        eq_(
-            (
-                (
-                    "DRIVER={foob}}UID=evil};Server=hostspec;Database=database;"
-                    "UID=username;PWD=password",
-                ),
-                {},
-            ),
-            connection,
-        )
-
-    def test_pyodbc_pass_through_key_injection(self):
-        # names of pass-through parameters get the same brace quoting as
-        # their values, so a semicolon in a parameter name can't be used to
-        # smuggle in an extra attribute
-        dialect = pyodbc.dialect()
-        u = url.make_url(
-            "mssql+pyodbc://username:password@hostspec/database"
-            "?driver=foob&foo%3BUID=evil"
-        )
-        connection = dialect.create_connect_args(u)
-        eq_(
-            (
-                (
-                    "DRIVER={foob};Server=hostspec;Database=database;"
-                    "UID=username;PWD=password;{foo;UID}=evil",
-                ),
                 {},
             ),
             connection,

--- a/test/dialect/mssql/test_engine.py
+++ b/test/dialect/mssql/test_engine.py
@@ -354,9 +354,7 @@ class ParseConnectTest(fixtures.TestBase):
         id_="iaaa",
     )
     def test_pyodbc_token_injection(self, tokens, query, connection_string):
-        u = url.make_url(
-            "mssql+pyodbc://%s:%s@%s/%s?%s" % (tokens + (query,))
-        )
+        u = url.make_url("mssql+pyodbc://%s:%s@%s/%s?%s" % (tokens + (query,)))
         dialect = pyodbc.dialect()
         connection = dialect.create_connect_args(u)
         eq_(

--- a/test/dialect/mssql/test_engine.py
+++ b/test/dialect/mssql/test_engine.py
@@ -329,6 +329,48 @@ class ParseConnectTest(fixtures.TestBase):
             connection,
         )
 
+    def test_pyodbc_driver_token_injection(self):
+        # the driver name is always wrapped in braces, so a closing brace
+        # in the value has to be escaped, otherwise it ends the brace early
+        # and the remainder is read as further connection attributes
+        dialect = pyodbc.dialect()
+        u = url.make_url(
+            "mssql+pyodbc://username:password@hostspec/database"
+            "?driver=foob%7DUID%3Devil"
+        )
+        connection = dialect.create_connect_args(u)
+        eq_(
+            (
+                (
+                    "DRIVER={foob}}UID=evil};Server=hostspec;Database=database;"
+                    "UID=username;PWD=password",
+                ),
+                {},
+            ),
+            connection,
+        )
+
+    def test_pyodbc_pass_through_key_injection(self):
+        # names of pass-through parameters get the same brace quoting as
+        # their values, so a semicolon in a parameter name can't be used to
+        # smuggle in an extra attribute
+        dialect = pyodbc.dialect()
+        u = url.make_url(
+            "mssql+pyodbc://username:password@hostspec/database"
+            "?driver=foob&foo%3BUID=evil"
+        )
+        connection = dialect.create_connect_args(u)
+        eq_(
+            (
+                (
+                    "DRIVER={foob};Server=hostspec;Database=database;"
+                    "UID=username;PWD=password;{foo;UID}=evil",
+                ),
+                {},
+            ),
+            connection,
+        )
+
     def test_pymssql_port_setting(self):
         dialect = pymssql.dialect()
 


### PR DESCRIPTION
### Description

Fixes: #13380

The pyodbc connector assembles the ODBC connection string by joining `keyword=value` tokens with `;`. Parameter values are brace-quoted by `check_quote` when they contain a `;` or a leading `{`, which is the handling added in #8062 / #11250. Two tokens skip that quoting though: the driver name, which is always wrapped in `DRIVER={...}` without escaping an embedded `}`, and the names of pass-through parameters, which are emitted as-is. A `}` in the driver value closes the brace early, and a `;` in a parameter name starts a new attribute, so the remainder gets read by the driver manager as further connection attributes.

For example `mssql+pyodbc://username:password@hostspec/database?driver=foob%7DUID%3Devil` builds, on the unpatched connector:

```
DRIVER={foob}UID=evil};Server=hostspec;Database=database;UID=username;PWD=password
```

where `UID=evil` has escaped the braces. Similarly a parameter named `foo;UID` lands as a bare `;foo;UID=evil`, adding a `UID` attribute. After the change the driver's `}` is doubled and the keys pass through the same `check_quote`, so each stays a single token (`DRIVER={foob}}UID=evil}` and `{foo;UID}=evil`).

This is reachable wherever any part of the URL (the driver, or extra ODBC keywords) is built from untrusted input. The mssql-python connector shares the pass-through-key handling and is fixed alongside. Tests are added next to the existing `test_pyodbc_token_injection` cases.

### Checklist

This pull request is:

- [x] A short code fix
	- Fixes #13380
	- builds on the ODBC token-quoting from #8062 / #11250
	- tests included in `test/dialect/mssql/test_engine.py`

**Have a nice day!**