### PR TITLE
fix: prevent is_pep695 from falsely returning True for Annotated types

### DIFF
--- a/lib/sqlalchemy/util/typing.py
+++ b/lib/sqlalchemy/util/typing.py
@@ -343,6 +343,13 @@ def is_pep695(type_: _AnnotationScanType) -> TypeGuard[TypeAliasType]:
     # python 3.10. For sqlalchemy use cases it's fine to consider it a TAT
     # though.
     # NOTE: things seems to work also without this additional check
+
+    # Annotated types (PEP 593) wrap the inner type; __origin__ returns the
+    # first type argument (e.g. a TypeAliasType) rather than Annotated itself
+    # which would cause is_pep695 to falsely return True.  Annotated types
+    # are handled separately via is_pep593() in the caller.
+    if is_pep593(type_):
+        return False
     if is_generic(type_):
         return is_pep695(type_.__origin__)
     return isinstance(type_, _type_instances.TypeAliasType)


### PR DESCRIPTION
Fixes #13386.

**Problem:**
`is_pep695()` recurses through `__origin__` for generic types, but `Annotated.__origin__` returns the first type argument rather than `Annotated` itself. When the inner type is a `TypeAliasType`, `is_pep695()` incorrectly returns `True` for the `Annotated` wrapper. The ORM caller then attempts `raw_pep_695_type.__value__` on the `Annotated` object, which does not have that attribute.

**Fix:**
Return `False` from `is_pep695()` when `is_pep593()` is `True`, matching the established pattern where the ORM caller already handles PEP 593 types separately in its `is_pep593()` / `pep_593_components` branch.

**Testing:**
- Verified `Annotated[TypeAliasType, mapped_column(JSON)]` no longer crashes
- Verified bare `TypeAliasType` still correctly identified as PEP 695
- Verified `Annotated` types correctly identified as PEP 593
- 2684 existing declarative ORM tests pass (0 failures)

Built with SQLAlchemy under my direction.