### PR TITLE
Validate test provisioning follower identifiers before composing DDL

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/provision.py
+++ b/lib/sqlalchemy/dialects/mssql/provision.py
@@ -26,6 +26,7 @@ from ...testing.provision import normalize_sequence
 from ...testing.provision import post_configure_engine
 from ...testing.provision import run_reap_dbs
 from ...testing.provision import temp_table_keyword_args
+from ...testing.provision import validate_follower_ident
 
 
 @post_configure_engine.for_db("mssql")
@@ -61,6 +62,7 @@ def generate_driver_url(url, driver, query_str):
 
 @create_db.for_db("mssql")
 def _mssql_create_db(cfg, eng, ident):
+    ident = validate_follower_ident(ident)
     with eng.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
         conn.exec_driver_sql("create database %s" % ident)
         conn.exec_driver_sql(
@@ -76,11 +78,13 @@ def _mssql_create_db(cfg, eng, ident):
 
 @drop_db.for_db("mssql")
 def _mssql_drop_db(cfg, eng, ident):
+    ident = validate_follower_ident(ident)
     with eng.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
         _mssql_drop_ignore(conn, ident)
 
 
 def _mssql_drop_ignore(conn, ident):
+    ident = validate_follower_ident(ident)
     try:
         # typically when this happens, we can't KILL the session anyway,
         # so let the cleanup process drop the DBs
@@ -99,6 +103,7 @@ def _mssql_drop_ignore(conn, ident):
 
 @run_reap_dbs.for_db("mssql")
 def _reap_mssql_dbs(url, idents):
+    idents = {validate_follower_ident(ident) for ident in idents}
     log.info("db reaper connecting to %r", url)
     eng = create_engine(url)
     with eng.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:

--- a/lib/sqlalchemy/dialects/mysql/provision.py
+++ b/lib/sqlalchemy/dialects/mysql/provision.py
@@ -16,6 +16,7 @@ from ...testing.provision import delete_from_all_tables
 from ...testing.provision import drop_db
 from ...testing.provision import generate_driver_url
 from ...testing.provision import temp_table_keyword_args
+from ...testing.provision import validate_follower_ident
 from ...testing.provision import upsert
 
 
@@ -61,6 +62,7 @@ def generate_driver_url(url, driver, query_str):
 
 @create_db.for_db("mysql", "mariadb")
 def _mysql_create_db(cfg, eng, ident):
+    ident = validate_follower_ident(ident)
     with eng.begin() as conn:
         try:
             _mysql_drop_db(cfg, conn, ident)
@@ -81,12 +83,14 @@ def _mysql_create_db(cfg, eng, ident):
 
 @configure_follower.for_db("mysql", "mariadb")
 def _mysql_configure_follower(config, ident):
+    ident = validate_follower_ident(ident)
     config.test_schema = "%s_test_schema" % ident
     config.test_schema_2 = "%s_test_schema_2" % ident
 
 
 @drop_db.for_db("mysql", "mariadb")
 def _mysql_drop_db(cfg, eng, ident):
+    ident = validate_follower_ident(ident)
     with eng.begin() as conn:
         conn.exec_driver_sql("DROP DATABASE %s_test_schema" % ident)
         conn.exec_driver_sql("DROP DATABASE %s_test_schema_2" % ident)

--- a/lib/sqlalchemy/dialects/mysql/provision.py
+++ b/lib/sqlalchemy/dialects/mysql/provision.py
@@ -16,8 +16,8 @@ from ...testing.provision import delete_from_all_tables
 from ...testing.provision import drop_db
 from ...testing.provision import generate_driver_url
 from ...testing.provision import temp_table_keyword_args
-from ...testing.provision import validate_follower_ident
 from ...testing.provision import upsert
+from ...testing.provision import validate_follower_ident
 
 
 @generate_driver_url.for_db("mysql", "mariadb")

--- a/lib/sqlalchemy/dialects/oracle/provision.py
+++ b/lib/sqlalchemy/dialects/oracle/provision.py
@@ -27,6 +27,7 @@ from ...testing.provision import set_default_schema_on_connection
 from ...testing.provision import stop_test_class_outside_fixtures
 from ...testing.provision import temp_table_keyword_args
 from ...testing.provision import update_db_opts
+from ...testing.provision import validate_follower_ident
 from ...testing.warnings import warn_test_suite
 
 
@@ -65,6 +66,7 @@ def _oracle_generate_driver_url(url, driver, query_str):
 
 @create_db.for_db("oracle")
 def _oracle_create_db(cfg, eng, ident):
+    ident = validate_follower_ident(ident)
     # NOTE: make sure you've run "ALTER DATABASE default tablespace users" or
     # similar, so that the default tablespace is not "system"; reflection will
     # fail otherwise
@@ -84,11 +86,13 @@ def _oracle_create_db(cfg, eng, ident):
 
 @configure_follower.for_db("oracle")
 def _oracle_configure_follower(config, ident):
+    ident = validate_follower_ident(ident)
     config.test_schema = "%s_ts1" % ident
     config.test_schema_2 = "%s_ts2" % ident
 
 
 def _ora_drop_ignore(conn, dbname):
+    dbname = validate_follower_ident(dbname, include_related=True)
     try:
         conn.exec_driver_sql("drop user %s cascade" % dbname)
         log.info("Reaped db: %s", dbname)
@@ -123,6 +127,7 @@ def _ora_drop_all_schema_objects_post_tables(cfg, eng):
 
 @drop_db.for_db("oracle")
 def _oracle_drop_db(cfg, eng, ident):
+    ident = validate_follower_ident(ident)
     with eng.begin() as conn:
         # cx_Oracle seems to occasionally leak open connections when a large
         # suite it run, even if we confirm we have zero references to
@@ -224,6 +229,7 @@ def _oracle_post_configure_engine(url, engine, follower_ident):
 
 @run_reap_dbs.for_db("oracle")
 def _reap_oracle_dbs(url, idents):
+    idents = {validate_follower_ident(ident) for ident in idents}
     log.info("db reaper connecting to %r", url)
     eng = create_engine(url)
     with eng.begin() as conn:

--- a/lib/sqlalchemy/dialects/postgresql/provision.py
+++ b/lib/sqlalchemy/dialects/postgresql/provision.py
@@ -21,8 +21,8 @@ from ...testing.provision import post_configure_engine
 from ...testing.provision import prepare_for_drop_tables
 from ...testing.provision import set_default_schema_on_connection
 from ...testing.provision import temp_table_keyword_args
-from ...testing.provision import validate_follower_ident
 from ...testing.provision import upsert
+from ...testing.provision import validate_follower_ident
 
 
 @create_db.for_db("postgresql")

--- a/lib/sqlalchemy/dialects/postgresql/provision.py
+++ b/lib/sqlalchemy/dialects/postgresql/provision.py
@@ -21,11 +21,13 @@ from ...testing.provision import post_configure_engine
 from ...testing.provision import prepare_for_drop_tables
 from ...testing.provision import set_default_schema_on_connection
 from ...testing.provision import temp_table_keyword_args
+from ...testing.provision import validate_follower_ident
 from ...testing.provision import upsert
 
 
 @create_db.for_db("postgresql")
 def _pg_create_db(cfg, eng, ident):
+    ident = validate_follower_ident(ident)
     template_db = cfg.options.postgresql_templatedb
 
     with eng.execution_options(isolation_level="AUTOCOMMIT").begin() as conn:
@@ -61,6 +63,7 @@ def _pg_create_db(cfg, eng, ident):
 
 @drop_db.for_db("postgresql")
 def _pg_drop_db(cfg, eng, ident):
+    ident = validate_follower_ident(ident)
     with eng.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
         with conn.begin():
             conn.execute(

--- a/lib/sqlalchemy/testing/provision.py
+++ b/lib/sqlalchemy/testing/provision.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import collections
 import contextlib
 import logging
+import re
 
 from . import config
 from . import engines
@@ -28,6 +29,28 @@ from ..util import decorator
 log = logging.getLogger(__name__)
 
 FOLLOWER_IDENT = None
+
+_FOLLOWER_IDENT = r"test_[0-9a-f]{12}"
+_FOLLOWER_IDENT_REGEXP = re.compile(rf"^{_FOLLOWER_IDENT}$")
+_FOLLOWER_RELATED_IDENT_REGEXP = re.compile(
+    rf"^{_FOLLOWER_IDENT}(?:_(?:test_schema|test_schema_2|ts1|ts2))?$"
+)
+
+
+def validate_follower_ident(ident, include_related=False):
+    if not isinstance(ident, str):
+        raise ValueError("SQLAlchemy test follower identifier must be a string")
+
+    regexp = (
+        _FOLLOWER_RELATED_IDENT_REGEXP
+        if include_related
+        else _FOLLOWER_IDENT_REGEXP
+    )
+    if not regexp.match(ident):
+        raise ValueError(
+            "Unsafe SQLAlchemy test follower identifier: %r" % ident
+        )
+    return ident
 
 
 class register:
@@ -73,6 +96,7 @@ class register:
 
 
 def create_follower_db(follower_ident):
+    follower_ident = validate_follower_ident(follower_ident)
     for cfg in _configs_for_db_operation():
         log.info("CREATE database %s, URI %r", follower_ident, cfg.db.url)
         create_db(cfg, cfg.db, follower_ident)
@@ -87,6 +111,7 @@ def setup_config(db_url, options, file_config, follower_ident):
     dialect.load_provisioning()
 
     if follower_ident:
+        follower_ident = validate_follower_ident(follower_ident)
         db_url = follower_url_from_main(db_url, follower_ident)
     db_opts = {}
     update_db_opts(db_url, db_opts, options)
@@ -110,6 +135,7 @@ def setup_config(db_url, options, file_config, follower_ident):
 
 
 def drop_follower_db(follower_ident):
+    follower_ident = validate_follower_ident(follower_ident)
     for cfg in _configs_for_db_operation():
         log.info("DROP database %s, URI %r", follower_ident, cfg.db.url)
         drop_db(cfg, cfg.db, follower_ident)
@@ -420,6 +446,7 @@ def follower_url_from_main(url, ident):
     :param ident: the pytest-xdist "worker identifier" to be used as the
                   database name
     """
+    ident = validate_follower_ident(ident)
     url = sa_url.make_url(url)
     return url.set(database=ident)
 
@@ -453,6 +480,7 @@ def reap_dbs(idents_file):
         for line in file_:
             line = line.strip()
             db_name, db_url = line.split(" ")
+            db_name = validate_follower_ident(db_name)
             url_obj = sa_url.make_url(db_url)
             if db_name not in dialects:
                 dialects[db_name] = url_obj.get_dialect()

--- a/lib/sqlalchemy/testing/provision.py
+++ b/lib/sqlalchemy/testing/provision.py
@@ -39,7 +39,9 @@ _FOLLOWER_RELATED_IDENT_REGEXP = re.compile(
 
 def validate_follower_ident(ident, include_related=False):
     if not isinstance(ident, str):
-        raise ValueError("SQLAlchemy test follower identifier must be a string")
+        raise ValueError(
+            "SQLAlchemy test follower identifier must be a string"
+        )
 
     regexp = (
         _FOLLOWER_RELATED_IDENT_REGEXP

--- a/test/dialect/test_provision.py
+++ b/test/dialect/test_provision.py
@@ -1,13 +1,20 @@
-from sqlalchemy.dialects.mssql import provision as mssql_provision  # noqa: F401
-from sqlalchemy.dialects.mysql import provision as mysql_provision  # noqa: F401
-from sqlalchemy.dialects.oracle import provision as oracle_provision  # noqa: F401
-from sqlalchemy.dialects.postgresql import provision as postgresql_provision  # noqa: F401
+import sqlalchemy.dialects.mssql.provision as mssql_provision
+import sqlalchemy.dialects.mysql.provision as mysql_provision
+import sqlalchemy.dialects.oracle.provision as oracle_provision
+import sqlalchemy.dialects.postgresql.provision as postgresql_provision
 from sqlalchemy.testing import assert_raises_message
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing.provision import create_db
 from sqlalchemy.testing.provision import drop_db
 from sqlalchemy.testing.provision import validate_follower_ident
+
+_PROVISION_MODULES = (
+    mssql_provision,
+    mysql_provision,
+    oracle_provision,
+    postgresql_provision,
+)
 
 
 class CaptureConnection:

--- a/test/dialect/test_provision.py
+++ b/test/dialect/test_provision.py
@@ -1,0 +1,121 @@
+from sqlalchemy.dialects.mssql import provision as mssql_provision  # noqa: F401
+from sqlalchemy.dialects.mysql import provision as mysql_provision  # noqa: F401
+from sqlalchemy.dialects.oracle import provision as oracle_provision  # noqa: F401
+from sqlalchemy.dialects.postgresql import provision as postgresql_provision  # noqa: F401
+from sqlalchemy.testing import assert_raises_message
+from sqlalchemy.testing import eq_
+from sqlalchemy.testing import fixtures
+from sqlalchemy.testing.provision import create_db
+from sqlalchemy.testing.provision import drop_db
+from sqlalchemy.testing.provision import validate_follower_ident
+
+
+class CaptureConnection:
+    def __init__(self):
+        self.sql = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *arg):
+        return False
+
+    def begin(self):
+        return self
+
+    def execution_options(self, **kw):
+        return self
+
+    def exec_driver_sql(self, statement, *arg, **kw):
+        self.sql.append(statement)
+
+
+class CaptureEngine:
+    def __init__(self):
+        self.conn = CaptureConnection()
+
+    def begin(self):
+        return self.conn
+
+    def connect(self):
+        return self.conn
+
+    def execution_options(self, **kw):
+        return self
+
+
+class ProvisionFollowerIdentTest(fixtures.TestBase):
+    def test_validate_follower_ident(self):
+        eq_(
+            validate_follower_ident("test_012345abcdef"),
+            "test_012345abcdef",
+        )
+        eq_(
+            validate_follower_ident(
+                "test_012345abcdef_test_schema", include_related=True
+            ),
+            "test_012345abcdef_test_schema",
+        )
+
+    def test_validate_follower_ident_rejects_unexpected_text(self):
+        assert_raises_message(
+            ValueError,
+            "Unsafe SQLAlchemy test follower identifier",
+            validate_follower_ident,
+            "test_012345abcdef; SELECT 1; --",
+        )
+
+        assert_raises_message(
+            ValueError,
+            "Unsafe SQLAlchemy test follower identifier",
+            validate_follower_ident,
+            "test_012345abcdef_test_schema",
+        )
+
+    def test_valid_mysql_create_still_emits_sql(self):
+        engine = CaptureEngine()
+
+        create_db.fns["mysql"](None, engine, "test_012345abcdef")
+
+        eq_(
+            engine.conn.sql[-3:],
+            [
+                "CREATE DATABASE test_012345abcdef CHARACTER SET utf8mb4",
+                "CREATE DATABASE test_012345abcdef_test_schema "
+                "CHARACTER SET utf8mb4",
+                "CREATE DATABASE test_012345abcdef_test_schema_2 "
+                "CHARACTER SET utf8mb4",
+            ],
+        )
+
+    def test_create_db_rejects_unsafe_ident_before_sql(self):
+        unsafe_ident = "test_012345abcdef; SELECT 1; --"
+
+        for backend in ("mssql", "mysql", "oracle", "postgresql"):
+            engine = CaptureEngine()
+
+            assert_raises_message(
+                ValueError,
+                "Unsafe SQLAlchemy test follower identifier",
+                create_db.fns[backend],
+                None,
+                engine,
+                unsafe_ident,
+            )
+            eq_(engine.conn.sql, [])
+
+    def test_drop_db_rejects_unsafe_ident_before_sql(self):
+        unsafe_ident = "test_012345abcdef; SELECT 1; --"
+
+        for backend in ("mssql", "mysql", "oracle", "postgresql"):
+            engine = CaptureEngine()
+
+            assert_raises_message(
+                ValueError,
+                "Unsafe SQLAlchemy test follower identifier",
+                drop_db.fns[backend],
+                None,
+                engine,
+                unsafe_ident,
+            )
+            eq_(engine.conn.sql, [])


### PR DESCRIPTION
### Description

This adds validation for SQLAlchemy's test provisioning follower identifiers before backend helpers compose create/drop DDL for temporary test databases, schemas, or users.

The normal pytest-xdist path already generates identifiers shaped like `test_` plus 12 lowercase hex characters. The new helper makes that expected shape explicit, and only allows known derived provisioning suffixes (`_test_schema`, `_test_schema_2`, `_ts1`, `_ts2`) where those derived names are intentionally used.

This is a test/provisioning hardening change. It does not change SQLAlchemy runtime query behavior.

The regression tests use fake connections and do not require a live database. Before the guard, the MySQL provisioning helper accepts malformed text and composes it into DDL strings. After the guard, the same input raises `ValueError` before any SQL is emitted.

Changes:

- Add `validate_follower_ident()` in `sqlalchemy.testing.provision`.
- Validate shared create/drop/setup/reap provisioning entry points.
- Validate backend create/drop/configure/reap helpers before they compose follower DDL.
- Add offline tests for accepted generated IDs and rejected malformed IDs.

Verification:

```text
python -m pytest test/dialect/test_provision.py -q
# 5 passed

python -m compileall -q lib/sqlalchemy test/dialect/test_provision.py
# passed

git diff --check
# passed
```

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
- [x] A short code fix
  - Issue: `Fixes: #13389`
  - Tests included: `test/dialect/test_provision.py`
- [ ] A new feature implementation

Issue: https://github.com/sqlalchemy/sqlalchemy/issues/13389
