### PR TITLE
fix catastrophic backtracking in mysql index comment reflection regex

### DIFF
--- a/doc/build/changelog/unreleased_20/13393.rst
+++ b/doc/build/changelog/unreleased_20/13393.rst
@@ -1,0 +1,9 @@
+.. change::
+  :tags: bug, mysql
+  :tickets: 13393
+
+  Fixed catastrophic regex backtracking in the MySQL reflection parser when
+  parsing an index ``COMMENT`` from ``SHOW CREATE TABLE`` output. The comment
+  sub-pattern was ambiguous on runs of single quotes, so a crafted index
+  comment could make table reflection hang. The pattern now uses the same
+  unambiguous single-quoted-string form already used for column comments.

--- a/lib/sqlalchemy/dialects/mysql/reflection.py
+++ b/lib/sqlalchemy/dialects/mysql/reflection.py
@@ -518,7 +518,7 @@ class MySQLTableDefinitionParser:
             r"(?: +USING +(?P<using_post>\S+))?"
             r"(?: +KEY_BLOCK_SIZE *[ =]? *(?P<keyblock>\S+))?"
             r"(?: +WITH PARSER +(?P<parser>\S+))?"
-            r"(?: +COMMENT +(?P<comment>(\x27\x27|\x27([^\x27])*?\x27)+))?"
+            r"(?: +COMMENT +(?P<comment>\x27(?:\x27\x27|[^\x27])*\x27))?"
             r"(?: +/\*(?P<version_sql>.+)\*/ *)?"
             r",?$" % quotes
         )

--- a/test/dialect/mysql/test_reflection.py
+++ b/test/dialect/mysql/test_reflection.py
@@ -1,4 +1,5 @@
 import re
+import time
 
 from sqlalchemy import BigInteger
 from sqlalchemy import Column
@@ -1501,6 +1502,18 @@ class RawReflectionTest(fixtures.TestBase):
         m = regex.match("  PRIMARY KEY (`id`)")
         eq_(m.group("type"), "PRIMARY")
         eq_(m.group("columns"), "`id`")
+
+    def test_key_reflection_comment_no_backtracking(self):
+        # the COMMENT subpattern used to be ambiguous on runs of single
+        # quotes, which made a crafted index comment take exponential time
+        # to (fail to) match.  the line below would hang for many seconds
+        # against the old pattern; guard it with a generous timeout.
+        regex = self.parser._re_key
+        line = "  KEY (`id`) COMMENT " + ("'" * 60) + "x"
+
+        start = time.monotonic()
+        assert not regex.match(line)
+        assert time.monotonic() - start < 1.0
 
     def test_key_reflection_columns(self):
         regex = self.parser._re_key


### PR DESCRIPTION
### Description

while reflecting a mysql table, `MySQLTableDefinitionParser._re_key` parses each KEY/index line from `SHOW CREATE TABLE`. the COMMENT sub-pattern was an outer repeat over an alternation of a doubled-quote token and a lazily matched quoted string, which is ambiguous on a run of single quotes and so backtracks catastrophically when the comment is followed by something that fails the trailing anchor. an index comment is controlled by whoever created the index, so a table made by a lower-privileged user can stall reflection. the same file already parses column comments and csv strings with the unambiguous `'(?:''|[^'])*'` form, so this aligns `_re_key` with that; valid comments still match the same text. issue #13393 has a small reproducer, and the added test hangs on the old pattern.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation

**Have a nice day!**