### PR TITLE
SQL codestyle: trim spacing around 'INHERITS' table list

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2868,9 +2868,9 @@ class PGDDLCompiler(compiler.DDLCompiler):
             if not isinstance(inherits, (list, tuple)):
                 inherits = (inherits,)
             table_opts.append(
-                "\n INHERITS ( "
+                "\n INHERITS ("
                 + ", ".join(self.preparer.quote(name) for name in inherits)
-                + " )"
+                + ")"
             )
 
         if pg_opts["partition_by"]:

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -502,7 +502,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         )
         self.assert_compile(
             schema.CreateTable(tbl),
-            "CREATE TABLE atable (id INTEGER) INHERITS ( i1 )",
+            "CREATE TABLE atable (id INTEGER) INHERITS (i1)",
         )
 
     def test_create_table_inherits_tuple(self):
@@ -515,7 +515,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         )
         self.assert_compile(
             schema.CreateTable(tbl),
-            "CREATE TABLE atable (id INTEGER) INHERITS ( i1, i2 )",
+            "CREATE TABLE atable (id INTEGER) INHERITS (i1, i2)",
         )
 
     def test_create_table_inherits_quoting(self):
@@ -529,7 +529,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         self.assert_compile(
             schema.CreateTable(tbl),
             "CREATE TABLE atable (id INTEGER) INHERITS "
-            '( "Quote Me", "quote Me Too" )',
+            '("Quote Me", "quote Me Too")',
         )
 
     def test_create_table_inherits_schema_qualified_quoted_name(self):
@@ -545,7 +545,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         self.assert_compile(
             schema.CreateTable(tbl),
             "CREATE TABLE atable (id INTEGER) "
-            "INHERITS ( my_schema.parent_table )",
+            "INHERITS (my_schema.parent_table)",
         )
 
     def test_create_table_partition_by_list(self):


### PR DESCRIPTION
### Description
This is _pedantic_ consistency with other comma-separated SQL lists - e.g. `VALUES`, `IN`, `DISTINCT ON` - and subqueries, where generally parantheses are not inner-padded by space characters.

The test cases updated illustrate the difference:

```diff
-            "CREATE TABLE atable (id INTEGER) INHERITS ( i1 )",
+            "CREATE TABLE atable (id INTEGER) INHERITS (i1)",
```

```diff
-            "CREATE TABLE atable (id INTEGER) INHERITS ( i1, i2 )",
+            "CREATE TABLE atable (id INTEGER) INHERITS (i1, i2)",

```

I noticed during source code diff review between [v2.0.50 and v2.0.51](https://github.com/sqlalchemy/sqlalchemy/compare/rel_2_0_50...rel_2_0_51) that spaces are added on each side within the parentheses containing the inherited table list.

If it's intentional to draw attention to the fact that these are tables and not column names -- then my apologies, that would seem sorta reasonable.

The parsing/interpretation of these spaces seems unlikely to be the change that microscopically moves the performance needle enough to offset the climate crisis -- indeed the overhead of reading this and responding may be larger -- this is purely me being pedantic.

### Checklist

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed

**Have a nice day!**
(you too; plus weekend)