### PR TITLE
Allow inspection registrations from module reloads

### DIFF
--- a/doc/build/changelog/unreleased_21/10748.rst
+++ b/doc/build/changelog/unreleased_21/10748.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: bug, general
+    :tickets: 10748
+
+    Allowed the inspection registry to replace an existing registration with a
+    reloaded callable from the same module and name. This avoids an assertion
+    failure for tooling that unloads and reloads SQLAlchemy modules while still
+    rejecting conflicting registrations.

--- a/lib/sqlalchemy/inspection.py
+++ b/lib/sqlalchemy/inspection.py
@@ -162,6 +162,9 @@ def _inspects(
                 existing_name = getattr(existing, "__name__", None)
                 existing_module = getattr(existing, "__module__", None)
 
+                # allow a new version of the same function or class, that is,
+                # a module reload; compare name/module attributes because
+                # classes may define custom __eq__ behavior.
                 if (
                     existing_name != fn_or_cls.__name__
                     or existing_module != fn_or_cls.__module__

--- a/lib/sqlalchemy/inspection.py
+++ b/lib/sqlalchemy/inspection.py
@@ -158,7 +158,17 @@ def _inspects(
     def decorate(fn_or_cls: _F) -> _F:
         for type_ in types:
             if type_ in _registrars:
-                raise AssertionError("Type %s is already registered" % type_)
+                existing = _registrars[type_]
+                existing_name = getattr(existing, "__name__", None)
+                existing_module = getattr(existing, "__module__", None)
+
+                if (
+                    existing_name != fn_or_cls.__name__
+                    or existing_module != fn_or_cls.__module__
+                ):
+                    raise AssertionError(
+                        "Type %s is already registered" % type_
+                    )
             _registrars[type_] = fn_or_cls
         return fn_or_cls
 

--- a/test/base/test_inspect.py
+++ b/test/base/test_inspect.py
@@ -74,3 +74,34 @@ class TestInspection(fixtures.TestBase):
         SomeFoo()
         eq_(inspect(SomeFoo()), 1)
         eq_(inspect(SomeSubFoo()), 2)
+
+    def test_inspects_allows_reloaded_registrar(self):
+        class SomeFoo(TestFixture):
+            pass
+
+        @inspection._inspects(SomeFoo)
+        def insp_somefoo(subject):
+            return 1
+
+        reloaded_insp_somefoo = type(insp_somefoo)(
+            insp_somefoo.__code__,
+            insp_somefoo.__globals__,
+            insp_somefoo.__name__,
+            insp_somefoo.__defaults__,
+            insp_somefoo.__closure__,
+        )
+        reloaded_insp_somefoo.__kwdefaults__ = insp_somefoo.__kwdefaults__
+
+        def insp_other_somefoo(subject):
+            return 2
+
+        assert_raises_message(
+            AssertionError,
+            "Type .* is already registered",
+            inspection._inspects(SomeFoo),
+            insp_other_somefoo,
+        )
+
+        inspection._inspects(SomeFoo)(reloaded_insp_somefoo)
+        assert inspection._registrars[SomeFoo] is reloaded_insp_somefoo
+        eq_(inspect(SomeFoo()), 1)


### PR DESCRIPTION
### Summary
- allow the inspection registry to accept a replacement registrar when it has the same module and name as the existing registration
- keep the existing duplicate-registration assertion for conflicting registrars
- add regression coverage for module reload style registration and a changelog entry

Closes #10748.

### Validation
- `/tmp/sqlalchemy-pr-venv/bin/python -m pytest test/base/test_inspect.py -q`
- `/tmp/sqlalchemy-pr-venv/bin/python -m compileall -q lib/sqlalchemy/inspection.py test/base/test_inspect.py`
