### PR TITLE
fix: Pool._invalidate lock and _finalize_fairy connection leak on BaseException

### DIFF
--- a/lib/sqlalchemy/pool/base.py
+++ b/lib/sqlalchemy/pool/base.py
@@ -280,6 +280,7 @@ class Pool(log.Identified, event.EventTarget):
         self._creator = creator
         self._recycle = recycle
         self._invalidate_time = 0
+        self._invalidate_lock = threading.Lock()
         self._pre_ping = pre_ping
         self._reset_on_return = util.parse_user_argument_for_enum(
             reset_on_return,
@@ -403,8 +404,9 @@ class Pool(log.Identified, event.EventTarget):
         time will be recycled upon next checkout.
         """
         rec = getattr(connection, "_connection_record", None)
-        if not rec or self._invalidate_time < rec.starttime:
-            self._invalidate_time = time.time()
+        with self._invalidate_lock:
+            if not rec or self._invalidate_time < rec.starttime:
+                self._invalidate_time = time.time()
         if _checkin and getattr(connection, "is_valid", False):
             connection.invalidate(exception)
 
@@ -1028,6 +1030,8 @@ def _finalize_fairy(
                 )
                 pool.logger.error(message)
                 util.warn(message)
+            if connection_record and connection_record.fairy_ref is not None:
+                connection_record.checkin()
 
     if connection_record and connection_record.fairy_ref is not None:
         connection_record.checkin()


### PR DESCRIPTION
## Summary

Fixes two bugs in `lib/sqlalchemy/pool/base.py`:

- **#24** `Pool._invalidate`: adds `_invalidate_lock` (`threading.Lock`) to `Pool.__init__` and acquires it around the `_invalidate_time` read-compare-write, preventing concurrent calls from silently discarding a newer invalidation timestamp
- **#26** `_finalize_fairy`: moves `connection_record.checkin()` into the `finally` block of the inner `try/except` so that a re-raised `BaseException` (e.g. `KeyboardInterrupt`, `SystemExit`) no longer permanently leaks the connection back to the pool; the original post-block call is kept as a no-op fallback for the `dbapi_connection is None` path

## Test plan
- [ ] `python -m pytest test/engine/test_pool.py -x -q`
- [ ] Verify GC-checkin tests (`test_checkin_event_gc`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)