### PR TITLE
fix: SessionTransaction.commit cleanup leak and multi-connection rollback abort

### DIFF
--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -1329,11 +1329,15 @@ class SessionTransaction(_StateChange, TransactionalContext):
                 self._prepare_impl()
 
         if self._parent is None or self.nested:
-            for conn, trans, should_commit, autoclose in set(
-                self._connections.values()
-            ):
-                if should_commit:
-                    trans.commit()
+            try:
+                for conn, trans, should_commit, autoclose in set(
+                    self._connections.values()
+                ):
+                    if should_commit:
+                        trans.commit()
+            except:
+                self.close()
+                raise
 
             self._state = SessionTransactionState.COMMITTED
             self.session.dispatch.after_commit(self.session)
@@ -1373,7 +1377,11 @@ class SessionTransaction(_StateChange, TransactionalContext):
                 if transaction._parent is None or transaction.nested:
                     try:
                         for t in set(transaction._connections.values()):
-                            t[1].rollback()
+                            try:
+                                t[1].rollback()
+                            except:
+                                if rollback_err is None:
+                                    rollback_err = sys.exc_info()
 
                         transaction._state = SessionTransactionState.DEACTIVE
                         self.session.dispatch.after_rollback(self.session)


### PR DESCRIPTION
## Summary

Fixes two bugs in `lib/sqlalchemy/orm/session.py`:

- **#25** `SessionTransaction.commit`: wraps the per-connection `trans.commit()` loop in `try/except` so that a failure mid-loop still calls `self.close()`, preventing the session from being stranded in an unclosed/un-GC-able state
- **#29** `SessionTransaction.rollback`: moves the `try/except` inside the per-connection loop so that a failure on one connection does not abort the rollback for remaining connections; the first error is captured and re-raised after all connections have been attempted

## Test plan
- [ ] `python -m pytest test/orm/test_session.py -x -q`
- [ ] `python -m pytest test/orm/test_transaction.py -x -q`
- [ ] Verify no ORM transaction tests regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)