### PR TITLE
fix: pass context.cursor to _handle_dbapi_exception on do_set_input_sizes failure

### DIFF
--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -1844,7 +1844,7 @@ class Connection(ConnectionEventsTarget, inspection.Inspectable["Inspector"]):
                     )
                 except BaseException as e:
                     self._handle_dbapi_exception(
-                        e, str(statement), parameters, None, context
+                        e, str(statement), parameters, context.cursor, context
                     )
 
         cursor, str_statement, parameters = (


### PR DESCRIPTION
## Summary

- **#27** `Connection._execute_compiled`: when `dialect.do_set_input_sizes()` raises, `_handle_dbapi_exception` was being called with `cursor=None` instead of `context.cursor`. The cursor is always available at this point (it was used to call `do_set_input_sizes`), so passing `None` prevented dialect cursor-cleanup logic from running and could cause a secondary `AttributeError` inside the exception handler that masked the original error.

## Test plan
- [ ] `python -m pytest test/engine/test_execute.py -x -q -k setinputsizes`
- [ ] `python -m pytest test/dialect/ -x -q` for affected dialects (Oracle, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)