### PR TITLE
Use identifier preparer for string type collations

### DIFF
--- a/doc/build/changelog/unreleased_21/9693.rst
+++ b/doc/build/changelog/unreleased_21/9693.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: usecase, schema, postgresql
+    :tickets: 9693
+
+    Adjusted string type collation rendering to use the dialect identifier
+    preparer rather than unconditional quoting. This allows PostgreSQL
+    schema-qualified collation names to be passed using
+    :class:`.quoted_name` with ``quote=False``.

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -7687,7 +7687,9 @@ class GenericTypeCompiler(TypeCompiler):
         if length:
             text += f"({length})"
         if collation:
-            text += f' COLLATE "{collation}"'
+            text += (
+                f" COLLATE {self.dialect.identifier_preparer.quote(collation)}"
+            )
         return text
 
     def visit_CHAR(self, type_: sqltypes.CHAR, **kw: Any) -> str:

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -237,6 +237,10 @@ class String(Concatenable, TypeEngine[str]):
             >>> print(select(cast("some string", String(collation="utf8"))))
             {printsql}SELECT CAST(:param_1 AS VARCHAR COLLATE utf8) AS anon_1
 
+          For backends that support qualified collation names, a
+          :class:`.quoted_name` with ``quote=False`` may be used to render the
+          qualified name without applying quotes to the separator.
+
           .. note::
 
             In most cases, the :class:`.Unicode` or :class:`.UnicodeText`

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -78,6 +78,7 @@ from sqlalchemy.sql import ddl
 from sqlalchemy.sql import elements
 from sqlalchemy.sql import null
 from sqlalchemy.sql import operators
+from sqlalchemy.sql import quoted_name
 from sqlalchemy.sql import sqltypes
 from sqlalchemy.sql import table
 from sqlalchemy.sql import type_api
@@ -3492,7 +3493,7 @@ class ExpressionTest(
         (lambda c1: c1.like("qpr"), "q LIKE :q_1->BINDCAST->[TEXT]"),
         (
             lambda c2: c2.like("qpr"),
-            'q LIKE :q_1->BINDCAST->[TEXT COLLATE "xyz"]',
+            "q LIKE :q_1->BINDCAST->[TEXT COLLATE xyz]",
         ),
         (
             # new behavior, a type with no collation passed into collate()
@@ -3500,11 +3501,11 @@ class ExpressionTest(
             # on the right side bind-cast. previous to #11576 we'd only
             # get TEXT for the bindcast.
             lambda c1: collate(c1, "abc").like("qpr"),
-            '(q COLLATE abc) LIKE :param_1->BINDCAST->[TEXT COLLATE "abc"]',
+            "(q COLLATE abc) LIKE :param_1->BINDCAST->[TEXT COLLATE abc]",
         ),
         (
             lambda c2: collate(c2, "abc").like("qpr"),
-            '(q COLLATE abc) LIKE :param_1->BINDCAST->[TEXT COLLATE "abc"]',
+            "(q COLLATE abc) LIKE :param_1->BINDCAST->[TEXT COLLATE abc]",
         ),
         argnames="testcase,expected",
     )
@@ -3549,7 +3550,7 @@ class ExpressionTest(
         )
         self.assert_compile(
             c2.like("qpr"),
-            'q LIKE :q_1->BINDCAST->[TEXT COLLATE "xyz"]',
+            "q LIKE :q_1->BINDCAST->[TEXT COLLATE xyz]",
             dialect=renders_bind_cast,
         )
 
@@ -4032,6 +4033,17 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def test_text_collation(self):
         self.assert_compile(Text(collation="FOO"), 'TEXT COLLATE "FOO"')
+
+    def test_text_collation_identifier_preparer(self):
+        self.assert_compile(Text(collation="foo"), "TEXT COLLATE foo")
+        self.assert_compile(
+            Text(collation=quoted_name("foo", quote=True)),
+            'TEXT COLLATE "foo"',
+        )
+        self.assert_compile(
+            Text(collation=quoted_name("schema_name.collation_name", False)),
+            "TEXT COLLATE schema_name.collation_name",
+        )
 
     def test_default_compile_pg_inet(self):
         self.assert_compile(


### PR DESCRIPTION
﻿### Description

Fixes #9693.

String type collation rendering currently hardcodes quoted collation names, so a PostgreSQL schema-qualified collation such as `schema.collation` is treated as one quoted identifier. This changes string type collation rendering to use the dialect identifier preparer, matching the existing `collate()` operator path and allowing `quoted_name("schema.collation", quote=False)` for qualified names.

This follows the smaller direction discussed in #9693 and #12697 rather than adding a new `collation_schema` attribute or reflection machinery.

### Tests

- `python -m pytest test/sql/test_types.py -k "collation or collate_type_interaction" -q`
- `python -m pytest test/sql/test_types.py -q`
- `python -m pytest test/sql/test_compiler.py -k collate -q`
- `python -m pytest test/dialect/postgresql/test_compiler.py -k "collation or domain or inherits" -q`
- `python -m pytest test/dialect/postgresql/test_types.py::ArrayTest -q`
- `python -m black --check lib/sqlalchemy/sql/compiler.py lib/sqlalchemy/sql/sqltypes.py test/sql/test_types.py`
- `python -m ruff check lib/sqlalchemy/sql/compiler.py lib/sqlalchemy/sql/sqltypes.py`
- `python -m ruff check --ignore E711 test/sql/test_types.py`
- `git diff --cached --check`
- local PostgreSQL smoke test with a temporary schema, collation, and table using `Text(collation=quoted_name(..., quote=False))`