### PR TITLE
Fix oracledb async dialect entering cursors synchronously

### DIFF
--- a/doc/build/changelog/unreleased_21/13420.rst
+++ b/doc/build/changelog/unreleased_21/13420.rst
@@ -1,0 +1,14 @@
+.. change::
+    :tags: bug, oracle
+    :tickets: 13420
+
+    Fixed issue where the oracledb async dialect's cursor wrapper entered
+    the underlying driver cursor using the synchronous ``__enter__()``
+    method rather than the asynchronous ``__aenter__()`` method. This
+    silently bypassed third-party async cursor wrappers, such as those used
+    by instrumentation libraries, that implement only the async context
+    manager protocol. The dialect now relies on the base async cursor
+    implementation, which correctly awaits ``__aenter__()``. As
+    ``__aenter__()`` was added to oracledb's ``AsyncCursor`` in oracledb
+    2.0.1, the minimum oracledb version supported by the async dialect has
+    been raised from 2.0.0 to 2.0.1.

--- a/lib/sqlalchemy/dialects/oracle/oracledb.py
+++ b/lib/sqlalchemy/dialects/oracle/oracledb.py
@@ -747,12 +747,6 @@ class AsyncAdapt_oracledb_cursor(AsyncAdapt_dbapi_cursor):
     def setinputsizes(self, *args: Any, **kwargs: Any) -> Any:
         return self._cursor.setinputsizes(*args, **kwargs)
 
-    def _aenter_cursor(self, cursor: AsyncCursor) -> AsyncCursor:
-        try:
-            return cursor.__enter__()
-        except Exception as error:
-            self._adapt_connection._handle_exception(error)
-
     async def _execute_async(self, operation, parameters):
         # override to not use mutex, oracledb already has a mutex
 
@@ -893,7 +887,9 @@ class OracleDialectAsync_oracledb(OracleDialect_oracledb):
     supports_statement_cache = True
     execution_ctx_cls = OracleExecutionContextAsync_oracledb
 
-    _min_version = (2,)
+    # oracledb added AsyncCursor.__aenter__() in version 2.0.1, which is
+    # required by _aenter_cursor() in AsyncAdapt_dbapi_cursor
+    _min_version = (2, 0, 1)
 
     # thick_mode mode is not supported by asyncio, oracledb will raise
     @classmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ mysql-connector = ["mysql-connector-python"]
 mariadb-connector = ["mariadb>=1.0.1,!=1.1.2,!=1.1.5,!=1.1.10"]
 oracle = ["oracledb>=1.0.1"]
 oracle-cxoracle = ["cx_oracle>=8"]
-oracle-oracledb = ["oracledb>=1.0.1"]
+oracle-oracledb = ["oracledb>=2.0.1"]
 postgresql = ["psycopg>=3.0.7,!=3.1.15"]
 postgresql-pg8000 = ["pg8000>=1.29.3"]
 postgresql-asyncpg = [

--- a/test/dialect/oracle/test_dialect.py
+++ b/test/dialect/oracle/test_dialect.py
@@ -29,6 +29,7 @@ from sqlalchemy.testing import assert_raises
 from sqlalchemy.testing import assert_raises_message
 from sqlalchemy.testing import AssertsCompiledSQL
 from sqlalchemy.testing import AssertsExecutionResults
+from sqlalchemy.testing import async_test
 from sqlalchemy.testing import config
 from sqlalchemy.testing import engines
 from sqlalchemy.testing import eq_
@@ -41,6 +42,7 @@ from sqlalchemy.testing.schema import Column
 from sqlalchemy.testing.schema import pep435_enum
 from sqlalchemy.testing.schema import Table
 from sqlalchemy.testing.suite import test_select
+from sqlalchemy.util import greenlet_spawn
 
 
 class CxOracleDialectTest(fixtures.TestBase):
@@ -108,6 +110,46 @@ class OracleDbDialectTest(fixtures.TestBase):
     def test_async_version(self):
         e = create_engine("oracle+oracledb_async://")
         is_true(isinstance(e.dialect, oracledb.OracleDialectAsync_oracledb))
+
+    def test_async_minimum_version(self):
+        with expect_raises_message(
+            exc.InvalidRequestError,
+            r"oracledb version \(2, 0, 1\) and above are supported",
+        ):
+            oracledb.OracleDialectAsync_oracledb(dbapi=Mock(version="2.0.0"))
+
+        dialect = oracledb.OracleDialectAsync_oracledb(
+            dbapi=Mock(version="2.0.1")
+        )
+        eq_(dialect.oracledb_ver, (2, 0, 1))
+
+    @async_test
+    async def test_async_cursor_enters_asynchronously(self):
+        """test #13420"""
+
+        adapt_connection = Mock()
+
+        underlying_cursor = Mock()
+
+        async def aenter(*arg, **kw):
+            return underlying_cursor
+
+        underlying_cursor.__aenter__ = Mock(side_effect=aenter)
+        underlying_cursor.__enter__ = Mock(
+            side_effect=AssertionError("sync __enter__ should not be called")
+        )
+
+        adapt_connection._connection.cursor = Mock(
+            return_value=underlying_cursor
+        )
+
+        cursor = await greenlet_spawn(
+            oracledb.AsyncAdapt_oracledb_cursor, adapt_connection
+        )
+
+        is_(cursor._cursor, underlying_cursor)
+        underlying_cursor.__aenter__.assert_called_once()
+        underlying_cursor.__enter__.assert_not_called()
 
 
 class OracledbMode(fixtures.TestBase):


### PR DESCRIPTION
`AsyncAdapt_oracledb_cursor._aenter_cursor()` called the synchronous `cursor.__enter__()` instead of awaiting `cursor.__aenter__()`, silently bypassing third-party async cursor wrappers (e.g. instrumentation libraries) that implement only the async context manager protocol. Removed the incorrect override so the cursor now uses the correct `await_(cursor.__aenter__())` implementation inherited from `AsyncAdapt_dbapi_cursor`.

Since __aenter__() was only added to oracledb's AsyncCursor in version 2.0.1, the async dialect's minimum supported oracledb version is raised from 2.0.0 to 2.0.1 accordingly.

Fixes: #13420

<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- #13420
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
