### PR TITLE
escape single quotes in postgresql nextval() identifier rendering

### DIFF
--- a/doc/build/changelog/unreleased_20/13429.rst
+++ b/doc/build/changelog/unreleased_20/13429.rst
@@ -10,6 +10,8 @@
     ``schema_translate_map`` supplying such a schema name, or an explicit
     :class:`.Sequence` whose name carries a quote, previously produced a
     malformed statement in which the remainder of the name was interpreted as
-    SQL.  ``get_insert_default`` now also routes the sequence name through the
-    identifier preparer, matching the sibling ``fire_sequence`` method.  Pull
-    request courtesy dxbjavid.
+    SQL.  The sequence name for an implicit SERIAL sequence, which has no
+    :class:`.Sequence` object behind it, is now rendered through the identifier
+    preparer as well, matching the sibling ``fire_sequence`` method; as a
+    result an ordinary lower case name is no longer redundantly double quoted.
+    Pull request courtesy dxbjavid.

--- a/doc/build/changelog/unreleased_20/13429.rst
+++ b/doc/build/changelog/unreleased_20/13429.rst
@@ -1,0 +1,15 @@
+.. change::
+    :tags: bug, postgresql
+    :tickets: 13429
+
+    Fixed quoting in the PostgreSQL ``nextval()`` rendering used for sequence
+    default expressions and for server-side autoincrement pre-execution, so
+    that a single quote occurring in a sequence, table or schema name is
+    escaped rather than terminating the surrounding string literal.  In
+    particular :meth:`_engine.Connection.execution_options` with a
+    ``schema_translate_map`` supplying such a schema name, or an explicit
+    :class:`.Sequence` whose name carries a quote, previously produced a
+    malformed statement in which the remainder of the name was interpreted as
+    SQL.  ``get_insert_default`` now also routes the sequence name through the
+    identifier preparer, matching the sibling ``fire_sequence`` method.  Pull
+    request courtesy dxbjavid.

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2295,8 +2295,8 @@ class PGCompiler(compiler.SQLCompiler):
         return f"power{self.function_argspec(fn)}"
 
     def visit_sequence(self, seq, **kw):
-        return "nextval('%s')" % self.preparer.format_sequence(seq).replace(
-            "'", "''"
+        return "nextval(%s)" % self.preparer.format_sequence_string_literal(
+            seq
         )
 
     def limit_clause(self, select, **kw):
@@ -3156,8 +3156,42 @@ class PGTypeCompiler(compiler.GenericTypeCompiler):
         return "JSONPATH"
 
 
+class _CompilerSequence:
+    """Minimal stand-in for :class:`.Sequence`.
+
+    Used for the implicit sequence behind a SERIAL column, where no
+    :class:`.Sequence` object exists but a name still has to be rendered
+    through :meth:`.IdentifierPreparer.format_sequence`.
+
+    """
+
+    __slots__ = ("name", "schema")
+
+    # the schema handed to us has already been resolved against the
+    # schema translate map, so don't let format_sequence() translate it
+    # a second time
+    _use_schema_map = False
+
+    def __init__(self, name, schema=None):
+        self.name = name
+        self.schema = schema
+
+
 class PGIdentifierPreparer(compiler.IdentifierPreparer):
     reserved_words = RESERVED_WORDS
+
+    def format_sequence_string_literal(self, sequence, use_schema=True):
+        """Render a sequence name as a SQL string literal.
+
+        ``nextval()`` and friends take the sequence as a string rather than
+        as an identifier, so the quoted identifier produced by
+        :meth:`.format_sequence` has to be escaped a second time for the
+        enclosing literal.
+
+        """
+        return "'%s'" % self.format_sequence(sequence, use_schema).replace(
+            "'", "''"
+        )
 
     def _unquote_identifier(self, value):
         if value[0] == self.initial_quote:
@@ -3360,10 +3394,8 @@ class PGExecutionContext(default.DefaultExecutionContext):
     def fire_sequence(self, seq, type_):
         return self._execute_scalar(
             (
-                "select nextval('%s')"
-                % self.identifier_preparer.format_sequence(seq).replace(
-                    "'", "''"
-                )
+                "select nextval(%s)"
+                % self.identifier_preparer.format_sequence_string_literal(seq)
             ),
             type_,
         )
@@ -3400,17 +3432,12 @@ class PGExecutionContext(default.DefaultExecutionContext):
                 else:
                     effective_schema = None
 
-                if effective_schema is not None:
-                    ident = "%s.%s" % (
-                        self.identifier_preparer.quote_identifier(
-                            effective_schema
-                        ),
-                        self.identifier_preparer.quote_identifier(seq_name),
+                exc = (
+                    "select nextval(%s)"
+                    % self.identifier_preparer.format_sequence_string_literal(
+                        _CompilerSequence(seq_name, effective_schema)
                     )
-                else:
-                    ident = self.identifier_preparer.quote_identifier(seq_name)
-
-                exc = "select nextval('%s')" % ident.replace("'", "''")
+                )
 
                 return self._execute_scalar(exc, column.type)
 

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2295,7 +2295,9 @@ class PGCompiler(compiler.SQLCompiler):
         return f"power{self.function_argspec(fn)}"
 
     def visit_sequence(self, seq, **kw):
-        return "nextval('%s')" % self.preparer.format_sequence(seq)
+        return "nextval('%s')" % self.preparer.format_sequence(seq).replace(
+            "'", "''"
+        )
 
     def limit_clause(self, select, **kw):
         text = ""
@@ -3359,7 +3361,9 @@ class PGExecutionContext(default.DefaultExecutionContext):
         return self._execute_scalar(
             (
                 "select nextval('%s')"
-                % self.identifier_preparer.format_sequence(seq)
+                % self.identifier_preparer.format_sequence(seq).replace(
+                    "'", "''"
+                )
             ),
             type_,
         )
@@ -3397,12 +3401,16 @@ class PGExecutionContext(default.DefaultExecutionContext):
                     effective_schema = None
 
                 if effective_schema is not None:
-                    exc = 'select nextval(\'"%s"."%s"\')' % (
-                        effective_schema,
-                        seq_name,
+                    ident = "%s.%s" % (
+                        self.identifier_preparer.quote_identifier(
+                            effective_schema
+                        ),
+                        self.identifier_preparer.quote_identifier(seq_name),
                     )
                 else:
-                    exc = "select nextval('\"%s\"')" % (seq_name,)
+                    ident = self.identifier_preparer.quote_identifier(seq_name)
+
+                exc = "select nextval('%s')" % ident.replace("'", "''")
 
                 return self._execute_scalar(exc, column.type)
 

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -160,7 +160,7 @@ class SequenceTest(fixtures.TestBase, AssertsCompiledSQL):
         # the schema is resolved by the execution context before it reaches
         # _CompilerSequence, so it must not be translated a second time
         preparer = postgresql.dialect().identifier_preparer
-        preparer = preparer._with_schema_translate({"foo": "bar"})
+        preparer = preparer._with_schema_translate({"bar": "foo"})
         eq_(
             preparer.format_sequence_string_literal(
                 _CompilerSequence("my_seq", "bar")

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -124,6 +124,20 @@ class SequenceTest(fixtures.TestBase, AssertsCompiledSQL):
             dialect=postgresql.dialect(),
         )
 
+    def test_nextval_quote_escaping(self):
+        # a single quote in a sequence or schema name must be escaped so it
+        # can't terminate the nextval() string literal early
+        self.assert_compile(
+            Sequence("some'seq").next_value(),
+            "nextval('\"some''seq\"')",
+            dialect=postgresql.dialect(),
+        )
+        self.assert_compile(
+            Sequence("some'seq", schema="my'schema").next_value(),
+            "nextval('\"my''schema\".\"some''seq\"')",
+            dialect=postgresql.dialect(),
+        )
+
 
 class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
     __dialect__ = postgresql.dialect()

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -60,6 +60,7 @@ from sqlalchemy.dialects.postgresql import Range
 from sqlalchemy.dialects.postgresql import REGCONFIG
 from sqlalchemy.dialects.postgresql import TSQUERY
 from sqlalchemy.dialects.postgresql import TSRANGE
+from sqlalchemy.dialects.postgresql.base import _CompilerSequence
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 from sqlalchemy.dialects.postgresql.ranges import MultiRange
@@ -136,6 +137,35 @@ class SequenceTest(fixtures.TestBase, AssertsCompiledSQL):
             Sequence("some'seq", schema="my'schema").next_value(),
             "nextval('\"my''schema\".\"some''seq\"')",
             dialect=postgresql.dialect(),
+        )
+
+    @testing.combinations(
+        ("my_seq", None, "'my_seq'"),
+        ("my_seq", "my_schema", "'my_schema.my_seq'"),
+        ("My_Seq", "Some_Schema", '\'"Some_Schema"."My_Seq"\''),
+        ("some'seq", "my'schema", "'\"my''schema\".\"some''seq\"'"),
+    )
+    def test_format_sequence_string_literal(self, name, schema_, expected):
+        # the implicit sequence of a SERIAL column has no Sequence object,
+        # so it goes through _CompilerSequence
+        preparer = postgresql.dialect().identifier_preparer
+        eq_(
+            preparer.format_sequence_string_literal(
+                _CompilerSequence(name, schema_)
+            ),
+            expected,
+        )
+
+    def test_compiler_sequence_ignores_schema_translate(self):
+        # the schema is resolved by the execution context before it reaches
+        # _CompilerSequence, so it must not be translated a second time
+        preparer = postgresql.dialect().identifier_preparer
+        preparer = preparer._with_schema_translate({"foo": "bar"})
+        eq_(
+            preparer.format_sequence_string_literal(
+                _CompilerSequence("my_seq", "bar")
+            ),
+            "'bar.my_seq'",
         )
 
 


### PR DESCRIPTION
### Description

The PostgreSQL dialect renders `nextval('...')` in a few places by dropping the
sequence identifier straight into a single-quoted SQL string literal, and it
never escapes the single quote. A `'` in a sequence, table or schema name
therefore closes the literal early and whatever follows in the name is read as
SQL. `visit_sequence` reproduces with no database (full example in #13429), and
`get_insert_default` is reachable through a `schema_translate_map` schema name,
which in schema-per-tenant setups is quite often derived from request context.

The affected spots are `visit_sequence`, `fire_sequence` and
`get_insert_default` in `dialects/postgresql/base.py`. The first two already
quote the identifier via `format_sequence` but leave the surrounding quote
alone; `get_insert_default` did not route the name through the identifier
preparer at all, unlike its sibling `fire_sequence`. I've escaped the quote in
the rendered literal and made `get_insert_default` quote the name the same way
`fire_sequence` does. Ordinary unquoted names compile exactly as before, and
the added test covers the escaping.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
- [x] A short code fix
	- Fixes: #13429, which has a complete runnable example
	- regression test added in `test/dialect/postgresql/test_compiler.py`
- [ ] A new feature implementation

**Have a nice day!**
