### PR TITLE
Fix bare except clauses in util/langhelpers.py

### DIFF
--- a/lib/sqlalchemy/util/langhelpers.py
+++ b/lib/sqlalchemy/util/langhelpers.py
@@ -1937,7 +1937,7 @@ def _warnings_warn(
         # being called from less than 3 (or given) stacklevels, weird,
         # but don't crash
         stacklevel = 0
-    except:
+    except Exception:
         # _getframe() doesn't work, weird interpreter issue, weird,
         # ok, but don't crash
         stacklevel = 0
@@ -1992,7 +1992,7 @@ def only_once(
             once_fn = once.pop()
             try:
                 return once_fn(*arg, **kw)
-            except:
+            except Exception:
                 if retry_on_exception:
                     once.insert(0, once_fn)
                 raise


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `lib/sqlalchemy/util/langhelpers.py`.

Two locations fixed:
1. `sys._getframe()` fallback: the bare `except:` after `except ValueError:` handles a "weird interpreter issue" where `_getframe` doesn't work. Changed to `except Exception:` to avoid masking `SystemExit`/`KeyboardInterrupt`.
2. `once_fn` retry logic: bare `except:` re-raises after optionally reinserting the function. Changed to `except Exception:` for the same reason.