### PR TITLE
docs: document @classmethod usage with @declared_attr for typing

### DIFF
--- a/doc/build/changelog/unreleased_20/9213.rst
+++ b/doc/build/changelog/unreleased_20/9213.rst
@@ -1,0 +1,10 @@
+.. change::
+    :tags: documentation, orm
+    :tickets: 9213
+
+    Updated the :class:`_orm.declared_attr` documentation to illustrate the
+    use of ``@classmethod`` in all examples, and added a tip explaining that
+    :pep:`484` typing tools require ``@classmethod`` to recognize
+    ``def foo(cls)`` as a classmethod.  This resolves typing errors such as
+    those occurring when referring to mapped attributes like ``cls.ph1`` in
+    ``__table_args__``.

--- a/doc/build/changelog/unreleased_21/9213.rst
+++ b/doc/build/changelog/unreleased_21/9213.rst
@@ -1,10 +1,10 @@
 .. change::
-    :tags: documentation, orm
+    :tags: documentation, typing
     :tickets: 9213
 
     Updated the :class:`_orm.declared_attr` documentation to illustrate the
     use of ``@classmethod`` in all examples, and added a tip explaining that
     :pep:`484` typing tools require ``@classmethod`` to recognize
-    ``def foo(cls)`` as a classmethod.  This resolves typing errors such as
-    those occurring when referring to mapped attributes like ``cls.ph1`` in
-    ``__table_args__``.
+    ``def foo(cls)`` as a classmethod.  Documented how to resolve typing
+    errors such as those occurring when referring to mapped attributes like
+    ``cls.ph1`` in ``__table_args__``.

--- a/lib/sqlalchemy/orm/decl_api.py
+++ b/lib/sqlalchemy/orm/decl_api.py
@@ -400,16 +400,33 @@ class declared_attr(interfaces._MappedAttribute[_T_co], _declared_attr_common):
         class Engineer(Employee):
             pass
 
+    :class:`_orm.declared_attr` can also be applied to non-directive
+    attributes such as :func:`_orm.column_property`::
+
+        class SomethingMixin:
+            x: Mapped[int]
+            y: Mapped[int]
+
+            @declared_attr
+            @classmethod
+            def x_plus_y(cls) -> Mapped[int]:
+                return column_property(cls.x + cls.y)
+
     .. tip::
 
        The examples above also apply the ``@classmethod`` decorator.  This is
        not required at runtime, however :pep:`484` typing tools have no way to
        recognize ``def foo(cls)`` as a classmethod unless ``@classmethod`` is
-       present.  Adding ``@classmethod`` allows typing tools to correctly infer
-       the ``cls`` parameter as the class, which is important when accessing
-       mapped attributes such as ``cls.ph1`` inside the body of the method.
-       :class:`_orm.declared_attr` supports both ``@declared_attr`` and
-       ``@declared_attr.directive`` being combined with ``@classmethod``.
+       present.  Adding ``@classmethod`` allows typing tools to correctly
+       infer the ``cls`` parameter as the class, which is important when
+       accessing mapped attributes such as ``cls.ph1`` inside the body of
+       the method.  :class:`_orm.declared_attr` supports both
+       ``@declared_attr`` and ``@declared_attr.directive`` being combined
+       with ``@classmethod``.
+
+    .. versionadded:: 2.0 - :class:`_orm.declared_attr` can accommodate a
+       function decorated with ``@classmethod`` to help with :pep:`484`
+       integration where needed.
 
 
     .. seealso::

--- a/lib/sqlalchemy/orm/decl_api.py
+++ b/lib/sqlalchemy/orm/decl_api.py
@@ -357,6 +357,7 @@ class declared_attr(interfaces._MappedAttribute[_T_co], _declared_attr_common):
             user_id: Mapped[int] = mapped_column(ForeignKey("user_table.id"))
 
             @declared_attr
+            @classmethod
             def user(cls) -> Mapped["User"]:
                 return relationship("User")
 
@@ -367,6 +368,7 @@ class declared_attr(interfaces._MappedAttribute[_T_co], _declared_attr_common):
 
         class CreateTableName:
             @declared_attr.directive
+            @classmethod
             def __tablename__(cls) -> str:
                 return cls.__name__.lower()
 
@@ -384,6 +386,7 @@ class declared_attr(interfaces._MappedAttribute[_T_co], _declared_attr_common):
             type: Mapped[str] = mapped_column(String(50))
 
             @declared_attr.directive
+            @classmethod
             def __mapper_args__(cls) -> Dict[str, Any]:
                 if cls.__name__ == "Employee":
                     return {
@@ -397,24 +400,16 @@ class declared_attr(interfaces._MappedAttribute[_T_co], _declared_attr_common):
         class Engineer(Employee):
             pass
 
-    :class:`_orm.declared_attr` supports decorating functions that are
-    explicitly decorated with ``@classmethod``. This is never necessary from a
-    runtime perspective, however may be needed in order to support :pep:`484`
-    typing tools that don't otherwise recognize the decorated function as
-    having class-level behaviors for the ``cls`` parameter::
+    .. tip::
 
-        class SomethingMixin:
-            x: Mapped[int]
-            y: Mapped[int]
-
-            @declared_attr
-            @classmethod
-            def x_plus_y(cls) -> Mapped[int]:
-                return column_property(cls.x + cls.y)
-
-    .. versionadded:: 2.0 - :class:`_orm.declared_attr` can accommodate a
-       function decorated with ``@classmethod`` to help with :pep:`484`
-       integration where needed.
+       The examples above also apply the ``@classmethod`` decorator.  This is
+       not required at runtime, however :pep:`484` typing tools have no way to
+       recognize ``def foo(cls)`` as a classmethod unless ``@classmethod`` is
+       present.  Adding ``@classmethod`` allows typing tools to correctly infer
+       the ``cls`` parameter as the class, which is important when accessing
+       mapped attributes such as ``cls.ph1`` inside the body of the method.
+       :class:`_orm.declared_attr` supports both ``@declared_attr`` and
+       ``@declared_attr.directive`` being combined with ``@classmethod``.
 
 
     .. seealso::

--- a/lib/sqlalchemy/orm/decl_api.py
+++ b/lib/sqlalchemy/orm/decl_api.py
@@ -404,16 +404,33 @@ class declared_attr(interfaces._MappedAttribute[_T_co], _declared_attr_common):
         class Engineer(Employee):
             pass
 
+    :class:`_orm.declared_attr` can also be applied to non-directive
+    attributes such as :func:`_orm.column_property`::
+
+        class SomethingMixin:
+            x: Mapped[int]
+            y: Mapped[int]
+
+            @declared_attr
+            @classmethod
+            def x_plus_y(cls) -> Mapped[int]:
+                return column_property(cls.x + cls.y)
+
     .. tip::
 
        The examples above also apply the ``@classmethod`` decorator.  This is
        not required at runtime, however :pep:`484` typing tools have no way to
        recognize ``def foo(cls)`` as a classmethod unless ``@classmethod`` is
-       present.  Adding ``@classmethod`` allows typing tools to correctly infer
-       the ``cls`` parameter as the class, which is important when accessing
-       mapped attributes such as ``cls.ph1`` inside the body of the method.
-       :class:`_orm.declared_attr` supports both ``@declared_attr`` and
-       ``@declared_attr.directive`` being combined with ``@classmethod``.
+       present.  Adding ``@classmethod`` allows typing tools to correctly
+       infer the ``cls`` parameter as the class, which is important when
+       accessing mapped attributes such as ``cls.ph1`` inside the body of
+       the method.  :class:`_orm.declared_attr` supports both
+       ``@declared_attr`` and ``@declared_attr.directive`` being combined
+       with ``@classmethod``.
+
+    .. versionadded:: 2.0 - :class:`_orm.declared_attr` can accommodate a
+       function decorated with ``@classmethod`` to help with :pep:`484`
+       integration where needed.
 
 
     .. seealso::

--- a/lib/sqlalchemy/orm/decl_api.py
+++ b/lib/sqlalchemy/orm/decl_api.py
@@ -361,6 +361,7 @@ class declared_attr(interfaces._MappedAttribute[_T_co], _declared_attr_common):
             user_id: Mapped[int] = mapped_column(ForeignKey("user_table.id"))
 
             @declared_attr
+            @classmethod
             def user(cls) -> Mapped["User"]:
                 return relationship("User")
 
@@ -371,6 +372,7 @@ class declared_attr(interfaces._MappedAttribute[_T_co], _declared_attr_common):
 
         class CreateTableName:
             @declared_attr.directive
+            @classmethod
             def __tablename__(cls) -> str:
                 return cls.__name__.lower()
 
@@ -388,6 +390,7 @@ class declared_attr(interfaces._MappedAttribute[_T_co], _declared_attr_common):
             type: Mapped[str] = mapped_column(String(50))
 
             @declared_attr.directive
+            @classmethod
             def __mapper_args__(cls) -> Dict[str, Any]:
                 if cls.__name__ == "Employee":
                     return {
@@ -401,24 +404,16 @@ class declared_attr(interfaces._MappedAttribute[_T_co], _declared_attr_common):
         class Engineer(Employee):
             pass
 
-    :class:`_orm.declared_attr` supports decorating functions that are
-    explicitly decorated with ``@classmethod``. This is never necessary from a
-    runtime perspective, however may be needed in order to support :pep:`484`
-    typing tools that don't otherwise recognize the decorated function as
-    having class-level behaviors for the ``cls`` parameter::
+    .. tip::
 
-        class SomethingMixin:
-            x: Mapped[int]
-            y: Mapped[int]
-
-            @declared_attr
-            @classmethod
-            def x_plus_y(cls) -> Mapped[int]:
-                return column_property(cls.x + cls.y)
-
-    .. versionadded:: 2.0 - :class:`_orm.declared_attr` can accommodate a
-       function decorated with ``@classmethod`` to help with :pep:`484`
-       integration where needed.
+       The examples above also apply the ``@classmethod`` decorator.  This is
+       not required at runtime, however :pep:`484` typing tools have no way to
+       recognize ``def foo(cls)`` as a classmethod unless ``@classmethod`` is
+       present.  Adding ``@classmethod`` allows typing tools to correctly infer
+       the ``cls`` parameter as the class, which is important when accessing
+       mapped attributes such as ``cls.ph1`` inside the body of the method.
+       :class:`_orm.declared_attr` supports both ``@declared_attr`` and
+       ``@declared_attr.directive`` being combined with ``@classmethod``.
 
 
     .. seealso::

--- a/test/typing/plain_files/orm/declared_attr_classmethod.py
+++ b/test/typing/plain_files/orm/declared_attr_classmethod.py
@@ -1,0 +1,39 @@
+# Regression tests for the declared_attr typing issue reported in #9213.
+
+import typing
+from typing import Optional
+from typing import assert_type
+
+import sqlalchemy as sa
+from sqlalchemy import Index
+from sqlalchemy.orm import declarative_mixin
+from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import declared_attr
+from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+@declarative_mixin
+class _Rhyme:
+    __tablename__: str
+
+    ph1: Mapped[int]
+    ph2: Mapped[Optional[int]]
+
+    @declared_attr.directive
+    @classmethod
+    def __table_args__(cls) -> tuple[Index, ...]:
+        return (sa.Index(cls.__tablename__ + "_ph1_ph2", cls.ph1, cls.ph2),)
+
+
+class Rhyme(_Rhyme, Base):
+    __tablename__ = "rhyme"
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+
+if typing.TYPE_CHECKING:
+    assert_type(Rhyme.__tablename__, str)

--- a/test/typing/plain_files/orm/declared_attr_classmethod.py
+++ b/test/typing/plain_files/orm/declared_attr_classmethod.py
@@ -6,7 +6,6 @@ from typing import assert_type
 
 import sqlalchemy as sa
 from sqlalchemy import Index
-from sqlalchemy.orm import declarative_mixin
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm import declared_attr
 from sqlalchemy.orm import Mapped
@@ -17,7 +16,6 @@ class Base(DeclarativeBase):
     pass
 
 
-@declarative_mixin
 class _Rhyme:
     __tablename__: str
 


### PR DESCRIPTION
Fixes #9213

Updates the `declared_attr` and `declared_attr.directive` docstring examples to use `@classmethod` so mypy recognizes the `cls` argument. Adds a short tip and a typing regression test for the `Index` / `__table_args__` case.

No runtime behavior changes.
