### PR TITLE
Homogenize @declared_attr parameter name

### DIFF
--- a/doc/build/orm/declarative_mixins.rst
+++ b/doc/build/orm/declarative_mixins.rst
@@ -51,7 +51,7 @@ An example of some commonly mixed-in idioms is below::
         log_record_id: Mapped[int] = mapped_column(ForeignKey("logrecord.id"))
 
         @declared_attr
-        def log_record(self) -> Mapped["LogRecord"]:
+        def log_record(cls) -> Mapped["LogRecord"]:
             return relationship("LogRecord")
 
 
@@ -184,7 +184,7 @@ below illustrates some of the previous section's example in terms of the
         log_record_id: Mapped[int] = mapped_column(ForeignKey("logrecord.id"))
 
         @declared_attr
-        def log_record(self) -> Mapped["LogRecord"]:
+        def log_record(cls) -> Mapped["LogRecord"]:
             return relationship("LogRecord")
 
 
@@ -239,7 +239,7 @@ example below::
         log_record_id = mapped_column(ForeignKey("logrecord.id"))
 
         @declared_attr
-        def log_record(self):
+        def log_record(cls):
             return relationship("LogRecord")
 
 

--- a/test/orm/declarative/test_mixin.py
+++ b/test/orm/declarative/test_mixin.py
@@ -1080,7 +1080,7 @@ class DeclarativeMixinTest(DeclarativeTestBase):
             __tablename__ = "test"
 
             @declared_attr
-            def __table_args__(self):
+            def __table_args__(cls):
                 info = {}
                 args = dict(info=info)
                 info.update(MyMixin1.__table_args__["info"])
@@ -1221,7 +1221,7 @@ class DeclarativeMixinTest(DeclarativeTestBase):
                 return {"mysql_engine": "InnoDB"}
 
             @declared_attr
-            def id(self):
+            def id(cls):
                 return Column(Integer, primary_key=True)
 
         Base = declarative_base(cls=Base)
@@ -1549,7 +1549,7 @@ class DeclarativeMixinTest(DeclarativeTestBase):
     def test_honor_class_mro_one(self):
         class HasXMixin:
             @declared_attr
-            def x(self):
+            def x(cls):
                 return Column(Integer)
 
         class Parent(HasXMixin, Base):
@@ -1565,7 +1565,7 @@ class DeclarativeMixinTest(DeclarativeTestBase):
     def test_honor_class_mro_two(self):
         class HasXMixin:
             @declared_attr
-            def x(self):
+            def x(cls):
                 return Column(Integer)
 
         class Parent(HasXMixin, Base):

--- a/test/orm/declarative/test_tm_future_annotations_sync.py
+++ b/test/orm/declarative/test_tm_future_annotations_sync.py
@@ -3354,33 +3354,33 @@ class MixinTest(fixtures.TestBase, testing.AssertsCompiledSQL):
             id: Mapped[int] = mapped_column(primary_key=True)
 
             @declared_attr
-            def users(self) -> Mapped[List[User]]:
+            def users(cls) -> Mapped[List[User]]:
                 return relationship(User)
 
             if use_directive:
                 if use_annotation:
 
                     @declared_attr.directive
-                    def user_ids(self) -> AssociationProxy[List[int]]:
+                    def user_ids(cls) -> AssociationProxy[List[int]]:
                         return association_proxy("users", "id")
 
                 else:
 
                     @declared_attr.directive
-                    def user_ids(self):
+                    def user_ids(cls):
                         return association_proxy("users", "id")
 
             else:
                 if use_annotation:
 
                     @declared_attr
-                    def user_ids(self) -> AssociationProxy[List[int]]:
+                    def user_ids(cls) -> AssociationProxy[List[int]]:
                         return association_proxy("users", "id")
 
                 else:
 
                     @declared_attr
-                    def user_ids(self):
+                    def user_ids(cls):
                         return association_proxy("users", "id")
 
         class Thing(Mixin, decl_base):

--- a/test/orm/declarative/test_typed_mapping.py
+++ b/test/orm/declarative/test_typed_mapping.py
@@ -3345,33 +3345,33 @@ class MixinTest(fixtures.TestBase, testing.AssertsCompiledSQL):
             id: Mapped[int] = mapped_column(primary_key=True)
 
             @declared_attr
-            def users(self) -> Mapped[List[User]]:
+            def users(cls) -> Mapped[List[User]]:
                 return relationship(User)
 
             if use_directive:
                 if use_annotation:
 
                     @declared_attr.directive
-                    def user_ids(self) -> AssociationProxy[List[int]]:
+                    def user_ids(cls) -> AssociationProxy[List[int]]:
                         return association_proxy("users", "id")
 
                 else:
 
                     @declared_attr.directive
-                    def user_ids(self):
+                    def user_ids(cls):
                         return association_proxy("users", "id")
 
             else:
                 if use_annotation:
 
                     @declared_attr
-                    def user_ids(self) -> AssociationProxy[List[int]]:
+                    def user_ids(cls) -> AssociationProxy[List[int]]:
                         return association_proxy("users", "id")
 
                 else:
 
                     @declared_attr
-                    def user_ids(self):
+                    def user_ids(cls):
                         return association_proxy("users", "id")
 
         class Thing(Mixin, decl_base):

--- a/test/typing/plain_files/ext/association_proxy/association_proxy_three.py
+++ b/test/typing/plain_files/ext/association_proxy/association_proxy_three.py
@@ -21,11 +21,11 @@ class Milestone:
     id: Mapped[int] = mapped_column(primary_key=True)
 
     @declared_attr
-    def users(self) -> Mapped[List["User"]]:
+    def users(cls) -> Mapped[List["User"]]:
         return relationship("User")
 
     @declared_attr
-    def user_ids(self) -> AssociationProxy[List[int]]:
+    def user_ids(cls) -> AssociationProxy[List[int]]:
         return association_proxy("users", "id")
 
 


### PR DESCRIPTION
Homogenize the parameter name of the methods decorated by `@declared_attr.*`. 

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed

