### PR TITLE
Escape single quotes in PostgreSQL nextval() string literals

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -2371,7 +2371,9 @@ class PGCompiler(compiler.SQLCompiler):
         return f"power{self.function_argspec(fn)}"
 
     def visit_sequence(self, seq, **kw):
-        return "nextval('%s')" % self.preparer.format_sequence(seq)
+        return "nextval('%s')" % self.preparer.format_sequence(seq).replace(
+            "'", "''"
+        )
 
     def limit_clause(self, select, **kw):
         text = ""
@@ -3449,7 +3451,9 @@ class PGExecutionContext(default.DefaultExecutionContext):
         return self._execute_scalar(
             (
                 "select nextval('%s')"
-                % self.identifier_preparer.format_sequence(seq)
+                % self.identifier_preparer.format_sequence(seq).replace(
+                    "'", "''"
+                )
             ),
             type_,
         )
@@ -3486,13 +3490,15 @@ class PGExecutionContext(default.DefaultExecutionContext):
                 else:
                     effective_schema = None
 
-                if effective_schema is not None:
-                    exc = 'select nextval(\'"%s"."%s"\')' % (
-                        effective_schema,
-                        seq_name,
+                # Route through the identifier preparer (like fire_sequence)
+                # and escape single quotes for the nextval('...') string
+                # literal so names containing "'" cannot break out of it.
+                seq = schema.Sequence(seq_name, schema=effective_schema)
+                exc = "select nextval('%s')" % (
+                    self.identifier_preparer.format_sequence(seq).replace(
+                        "'", "''"
                     )
-                else:
-                    exc = "select nextval('\"%s\"')" % (seq_name,)
+                )
 
                 return self._execute_scalar(exc, column.type)
 

--- a/test/dialect/postgresql/test_compiler.py
+++ b/test/dialect/postgresql/test_compiler.py
@@ -111,6 +111,16 @@ class SequenceTest(fixtures.TestBase, AssertsCompiledSQL):
             == '"Some_Schema"."My_Seq"'
         )
 
+    def test_nextval_escapes_single_quotes_in_name(self):
+        """nextval('...') must escape ' in the formatted identifier literal."""
+        seq = Sequence("s') UNION SELECT current_setting('is_superuser'); --")
+        self.assert_compile(
+            seq.next_value(),
+            "nextval('\"s'') UNION SELECT current_setting(''is_superuser''); "
+            "--\"')",
+        )
+        self.assert_compile(Sequence("my_seq").next_value(), "nextval('my_seq')")
+
     @testing.combinations(
         (None, ""),
         (Integer, "AS INTEGER "),


### PR DESCRIPTION
﻿## Summary
- Escape `'` as `''` when embedding `format_sequence()` output in `nextval('...')` (`visit_sequence`, `fire_sequence`).
- Route `get_insert_default` through the identifier preparer the same way as `fire_sequence`.

## Test plan
- [x] `pytest test/dialect/postgresql/test_compiler.py::SequenceTest`
- [x] Compiling a Sequence name containing `'` no longer breaks out of the string literal

Fixes #13429
