### PR TITLE
escape quotes in mssql uuid literal renderer

### DIFF
--- a/doc/build/changelog/unreleased_20/13448.rst
+++ b/doc/build/changelog/unreleased_20/13448.rst
@@ -1,0 +1,14 @@
+.. change::
+    :tags: bug, mssql
+    :tickets: 13448
+
+    Fixed quoting bug in the SQL Server implementation of the
+    :class:`_sqltypes.Uuid` datatype, where the literal renderer used for the
+    native ``UNIQUEIDENTIFIER`` form collapsed doubled single quotes into a
+    single quote rather than escaping single quotes.  As the value passed to
+    the renderer is an ordinary string when ``as_uuid=False`` is in use, a
+    quote within it would end the rendered literal early; this applies to
+    ``literal_binds`` compilation as well as to parameters marked
+    ``literal_execute=True``.  Quotes are now escaped in the same way as for
+    the generic :class:`_sqltypes.Uuid` datatype.  Pull request courtesy
+    dxbjavid.

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -1561,7 +1561,7 @@ class MSUUid(sqltypes.Uuid):
         if self.native_uuid:
 
             def process(value):
-                return f"""'{str(value).replace("''", "'")}'"""
+                return f"""'{str(value).replace("'", "''")}'"""
 
             return process
         else:

--- a/test/dialect/mssql/test_types.py
+++ b/test/dialect/mssql/test_types.py
@@ -2,6 +2,7 @@ import codecs
 import datetime
 import decimal
 import os
+import uuid
 
 import sqlalchemy as sa
 from sqlalchemy import Boolean
@@ -1465,6 +1466,25 @@ class StringRoundTripTest(fixtures.TestBase):
         else:
             fetchtype.fail()
         eq_(received, data)
+
+
+class UuidLiteralTest(fixtures.TestBase, AssertsCompiledSQL):
+    __dialect__ = mssql.dialect()
+
+    def test_uuid_literal(self):
+        value = uuid.UUID("1e4fbb1b-7e37-4e0f-9e2b-1e6bb0d0f0a1")
+        self.assert_compile(
+            column("x", sa.Uuid()) == value,
+            "x = '1e4fbb1b-7e37-4e0f-9e2b-1e6bb0d0f0a1'",
+            literal_binds=True,
+        )
+
+    def test_uuid_string_literal_escapes_quote(self):
+        self.assert_compile(
+            column("x", sa.Uuid(as_uuid=False)) == "a'b",
+            "x = 'a''b'",
+            literal_binds=True,
+        )
 
 
 class UniqueIdentifierTest(test_types.UuidTest):


### PR DESCRIPTION
### Description

`MSUUid.literal_processor` renders the native `UNIQUEIDENTIFIER` form with `replace("''", "'")`, which collapses doubled quotes rather than escaping single ones, so it does the opposite of the generic `sqltypes.Uuid.literal_processor` it overrides. With `as_uuid=False` the value is a plain string rather than a `UUID` object, so a quote inside it ends the rendered literal and the rest is parsed as SQL, both under `literal_binds` and for parameters marked `literal_execute=True`, which renders at execution time. Reversing the two arguments to `replace()` brings it back in line with the base type; a full example and the before/after output are in #13448.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
