### PR TITLE
docs: add async-specific note to expire/expire_all proxied docstrings

### DIFF
--- a/lib/sqlalchemy/ext/asyncio/session.py
+++ b/lib/sqlalchemy/ext/asyncio/session.py
@@ -1220,6 +1220,8 @@ class AsyncSession(ReversibleProxy[Session]):
             Proxied for the :class:`_orm.Session` class on
             behalf of the :class:`_asyncio.AsyncSession` class.
 
+        .. tip:: Accessing an expired attribute on an AsyncSession-managed object will attempt to follow the lazy loading path, which is not supported implicitly under asyncio. See :ref:`asyncio_orm_avoid_lazyloads` for background, and consider using :meth:`_asyncio.AsyncSession.refresh` or the :class:`_asyncio.AsyncAttrs` mixin instead.
+
         Marks the attributes of an instance as out of date. When an expired
         attribute is next accessed, a query will be issued to the
         :class:`.Session` object's current transactional context in order to
@@ -1265,6 +1267,8 @@ class AsyncSession(ReversibleProxy[Session]):
 
             Proxied for the :class:`_orm.Session` class on
             behalf of the :class:`_asyncio.AsyncSession` class.
+
+        .. tip:: Accessing an expired attribute on an AsyncSession-managed object will attempt to follow the lazy loading path, which is not supported implicitly under asyncio. See :ref:`asyncio_orm_avoid_lazyloads` for background, and consider using :meth:`_asyncio.AsyncSession.refresh` or the :class:`_asyncio.AsyncAttrs` mixin instead.
 
         When any attributes on a persistent instance is next accessed,
         a query will be issued using the

--- a/tools/generate_proxy_methods.py
+++ b/tools/generate_proxy_methods.py
@@ -70,8 +70,27 @@ from sqlalchemy.util.langhelpers import format_argspec_plus
 from sqlalchemy.util.langhelpers import inject_docstring_text
 from sqlalchemy.util.tool_support import code_writer_cmd
 
-is_posix = os.name == "posix"
+# Additional async-specific notes to append to certain proxied methods'
+# docstrings, since these methods behave differently when called through
+# an async proxy (e.g. AsyncSession) versus their sync original.
+ASYNC_METHOD_NOTES: Dict[str, str] = {
+    "expire_all": (
+        ".. tip:: Accessing an expired attribute on an AsyncSession-managed "
+        "object will attempt to follow the lazy loading path, which is not "
+        "supported implicitly under asyncio. See :ref:`asyncio_orm_avoid_lazyloads` "
+        "for background, and consider using :meth:`_asyncio.AsyncSession.refresh` "
+        "or the :class:`_asyncio.AsyncAttrs` mixin instead."
+    ),
+    "expire": (
+        ".. tip:: Accessing an expired attribute on an AsyncSession-managed "
+        "object will attempt to follow the lazy loading path, which is not "
+        "supported implicitly under asyncio. See :ref:`asyncio_orm_avoid_lazyloads` "
+        "for background, and consider using :meth:`_asyncio.AsyncSession.refresh` "
+        "or the :class:`_asyncio.AsyncAttrs` mixin instead."
+    ),
+}
 
+is_posix = os.name == "posix"
 
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -185,6 +204,7 @@ def process_class(
     attributes: Iterable[str],
     use_intermediate_variable: Iterable[str],
     cls: Type[Any],
+    is_async: bool = False,
 ):
     sphinx_symbol_match = re.match(r":class:`(.+)`", target_cls_sphinx_name)
     if not sphinx_symbol_match:
@@ -239,6 +259,9 @@ def process_class(
 
         caller_argspec = format_argspec_plus(spec, grouped=False)
 
+
+        extra_note = ASYNC_METHOD_NOTES.get(name, "") if is_async else ""
+
         metadata = {
             "name": fn.__name__,
             "async": "async " if iscoroutine else "",
@@ -256,7 +279,8 @@ def process_class(
                         f"    Proxied for the {target_cls_sphinx_name} "
                         "class on \n"
                         f"    behalf of the {proxy_cls_sphinx_name} "
-                        "class.",
+                        "class."
+                        + (f"\n\n{extra_note}" if extra_note else ""),
                         "    ",
                     ),
                     1,
@@ -264,7 +288,6 @@ def process_class(
                 "    ",
             ).lstrip(),
         }
-
         if fn.__name__ in require_intermediate:
             metadata["line_prefix"] = "result ="
             metadata["after_line"] = "return result\n"
@@ -403,7 +426,7 @@ def process_module(modname: str, filename: str, cmd: code_writer_cmd) -> str:
                     f" tools/{os.path.basename(__file__)}\n\n"
                 )
 
-                process_class(buf, *args)
+                process_class(buf, *args, is_async="asyncio" in modname)
             if line.startswith(f"    # END PROXY METHODS {current_clsname}"):
                 in_block = False
 


### PR DESCRIPTION
### Description
Follow-up to #13443, adds a .. tip:: note to AsyncSession.expire_all() and AsyncSession.expire()'s generated docstrings, describing the lazy-loading-under-async behavior per @zzzeek's guidance, without naming MissingGreenlet directly.

This required a small addition to tools/generate_proxy_methods.py since the async proxy docstrings are generated from the sync originals, and there wasn't previously a way to inject method-specific extra notes during that generation step. Added an ASYNC_METHOD_NOTES dict keyed by method name, only applied when generating for asyncio modules (scoped_session's sync-to-sync proxying is unaffected).

Ran python tools/generate_proxy_methods.py --module sqlalchemy.ext.asyncio.session locally to confirm the generated diff is clean and minimal.

### Checklist
This pull request is:
- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
- [ ] A new feature implementation