### PR TITLE
test(mysql): cover ordered from-select upserts

### DIFF
--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -1583,7 +1583,7 @@ class InsertOnDuplicateTest(fixtures.TestBase, AssertsCompiledSQL):
     def test_from_select(self, version: Variation):
         stmt = insert(self.table).from_select(
             ["id", "bar"],
-            select(self.table.c.id, literal("bar2")),
+            select(self.table.c.id, literal("bar2")).order_by(self.table.c.id),
         )
         stmt = stmt.on_duplicate_key_update(
             bar=stmt.inserted.bar, baz=stmt.inserted.baz
@@ -1591,7 +1591,7 @@ class InsertOnDuplicateTest(fixtures.TestBase, AssertsCompiledSQL):
 
         expected_sql = (
             "INSERT INTO foos (id, bar) SELECT foos.id, %s AS anon_1 "
-            "FROM foos "
+            "FROM foos ORDER BY foos.id "
             "ON DUPLICATE KEY UPDATE bar = VALUES(bar), baz = VALUES(baz)"
         )
         if version.all_others:


### PR DESCRIPTION
### Description

Extends the MySQL `INSERT ... FROM SELECT ... ON DUPLICATE KEY UPDATE`
compiler regression test with the ordered-select shape reported in #10675.
This verifies that enabling MySQL 8's row-alias behavior does not append an
invalid `AS new` after the `ORDER BY` clause and continues to use `VALUES()`
for the update expressions.

Fixes #10675

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
