### PR TITLE
Add support for multiple on-conflict clauses in inserts on SQLite

### DIFF
--- a/doc/build/changelog/unreleased_21/13113.rst
+++ b/doc/build/changelog/unreleased_21/13113.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: dml, sqlite, usecase
+    :tickets: 13113
+
+    Add support for multiple on-conflict clauses in inserts for sqlite database.
+    Now you can use two or more `on conflict do update` or `on conflict do nothing`
+    clauses in a single statement

--- a/doc/build/changelog/unreleased_21/13113.rst
+++ b/doc/build/changelog/unreleased_21/13113.rst
@@ -2,6 +2,7 @@
     :tags: dml, sqlite, usecase
     :tickets: 13113
 
-    Add support for multiple on-conflict clauses in inserts for sqlite database.
+    Add support for multiple on-conflict clauses in inserts for sqlite database
+    :func:`sqlalchemy.dialects.sqlite.insert`.
     Now you can use two or more `on conflict do update` or `on conflict do nothing`
-    clauses in a single statement
+    clauses in a single statement. Pull request courtesy Diemid Berozkin

--- a/lib/sqlalchemy/dialects/sqlite/dml.py
+++ b/lib/sqlalchemy/dialects/sqlite/dml.py
@@ -110,7 +110,6 @@ class Insert(StandardInsert):
         },
     )
 
-    @_on_conflict_exclusive
     def on_conflict_do_update(
         self,
         index_elements: _OnConflictIndexElementsT = None,
@@ -161,7 +160,6 @@ class Insert(StandardInsert):
             OnConflictDoUpdate(index_elements, index_where, set_, where)
         )
 
-    @_on_conflict_exclusive
     def on_conflict_do_nothing(
         self,
         index_elements: _OnConflictIndexElementsT = None,
@@ -222,7 +220,7 @@ class OnConflictClause(SyntaxExtension, ClauseElement):
 
     def apply_to_insert(self, insert_stmt: StandardInsert) -> None:
         insert_stmt.apply_syntax_extension_point(
-            self.append_replacing_same_type, "post_values"
+            lambda ex: [*ex, self], "post_values"
         )
 
 

--- a/lib/sqlalchemy/dialects/sqlite/dml.py
+++ b/lib/sqlalchemy/dialects/sqlite/dml.py
@@ -21,7 +21,6 @@ from ...sql import coercions
 from ...sql import roles
 from ...sql import schema
 from ...sql._typing import _DMLTableArgument
-from ...sql.base import _exclusive_against
 from ...sql.base import ColumnCollection
 from ...sql.base import ReadOnlyColumnCollection
 from ...sql.base import SyntaxExtension
@@ -102,14 +101,6 @@ class Insert(StandardInsert):
         """
         return alias(self.table, name="excluded").columns
 
-    _on_conflict_exclusive = _exclusive_against(
-        "_post_values_clause",
-        msgs={
-            "_post_values_clause": "This Insert construct already has "
-            "an ON CONFLICT clause established"
-        },
-    )
-
     def on_conflict_do_update(
         self,
         index_elements: _OnConflictIndexElementsT = None,
@@ -119,6 +110,8 @@ class Insert(StandardInsert):
     ) -> Self:
         r"""
         Specifies a DO UPDATE SET action for ON CONFLICT clause.
+
+        Multiple clauses can be added, and they are evaluated in order
 
         :param index_elements:
          A sequence consisting of string column names, :class:`_schema.Column`
@@ -167,6 +160,10 @@ class Insert(StandardInsert):
     ) -> Self:
         """
         Specifies a DO NOTHING action for ON CONFLICT clause.
+
+        This clause may be used together with :func:`on_conflict_do_update()`
+        but only one :func:`on_conflict_do_nothing()` may be specified,
+        and it must be the last one
 
         :param index_elements:
          A sequence consisting of string column names, :class:`_schema.Column`

--- a/test/dialect/sqlite/test_on_conflict.py
+++ b/test/dialect/sqlite/test_on_conflict.py
@@ -81,26 +81,6 @@ class OnConflictTest(fixtures.TablesTest):
         with expect_raises(ValueError):
             insert(self.tables.users).on_conflict_do_update()
 
-    def test_on_conflict_do_no_call_twice(self):
-        users = self.tables.users
-
-        for stmt in (
-            insert(users).on_conflict_do_nothing(),
-            insert(users).on_conflict_do_update(
-                index_elements=[users.c.id], set_=dict(name="foo")
-            ),
-        ):
-            for meth in (
-                stmt.on_conflict_do_nothing,
-                stmt.on_conflict_do_update,
-            ):
-                with testing.expect_raises_message(
-                    exc.InvalidRequestError,
-                    "This Insert construct already has an "
-                    "ON CONFLICT clause established",
-                ):
-                    meth()
-
     def test_on_conflict_do_nothing(self, connection):
         users = self.tables.users
 
@@ -771,4 +751,87 @@ class OnConflictTest(fixtures.TablesTest):
                 sql.select(t.c.name, t.c.data).order_by(t.c.name)
             ).fetchall(),
             expected_updated,
+        )
+
+    def test_on_conflict_do_update_multiple_clauses(self, connection):
+        users = self.tables.users_xtra
+
+        self._exotic_targets_fixture(connection)
+
+        i = (
+            insert(users)
+            .on_conflict_do_update(
+                index_elements=["login_email"],
+                set_=dict(login_email="nord1@gmail.com"),
+            )
+            .on_conflict_do_update(
+                index_elements=[users.c.id],
+                set_=dict(name="name3"),
+            )
+            .values()
+        )
+
+        connection.execute(
+            i,
+            [
+                dict(
+                    id=1,
+                    name="name1",
+                    login_email="name1@gmail.com",
+                    lets_index_this="not",
+                ),
+                dict(
+                    id=2,
+                    name="name2",
+                    login_email="name3@gmail.com",
+                    lets_index_this="not",
+                ),
+            ],
+        )
+        eq_(
+            connection.execute(users.select()).fetchall(),
+            [
+                (1, "name1", "nord1@gmail.com", "not"),
+                (2, "name3", "name2@gmail.com", "not"),
+            ],
+        )
+
+    def test_on_conflict_do_nothing_multiple_clauses(self, connection):
+        users = self.tables.users_xtra
+
+        self._exotic_targets_fixture(connection)
+
+        i = (
+            insert(users)
+            .on_conflict_do_update(
+                index_elements=["login_email"],
+                set_=dict(login_email="nord1@gmail.com"),
+            )
+            .on_conflict_do_nothing(index_elements=[users.c.id])
+            .values()
+        )
+
+        connection.execute(
+            i,
+            [
+                dict(
+                    id=1,
+                    name="name1",
+                    login_email="name1@gmail.com",
+                    lets_index_this="not",
+                ),
+                dict(
+                    id=2,
+                    name="name2",
+                    login_email="name3@gmail.com",
+                    lets_index_this="not",
+                ),
+            ],
+        )
+        eq_(
+            connection.execute(users.select()).fetchall(),
+            [
+                (1, "name1", "nord1@gmail.com", "not"),
+                (2, "name2", "name2@gmail.com", "not"),
+            ],
         )


### PR DESCRIPTION
Multiple on-conflict clauses support for SQLite

Fixes: #13113

### Description
Follows up to [#13113](https://github.com/sqlalchemy/sqlalchemy/issues/13113)
Add support for multiple on-conflict clauses in insert statements for SQLite database
As [CaselIT](https://github.com/CaselIT) proposed, this required a small change in `apply_to_insert()` function. I've replaced `self.append_replacing_same_type` to `lambda ex: [*ex, self]` and removed `@_on_conflict_exclusive` from `on_conflict_do_update()` and `on_conflict_do_nothing()` methods

This pull request is:
- [ ] A new feature implementation
    - Tests included

**Have a nice day!**