### PR TITLE
escape backslashes in mysql enum/set value rendering

### DIFF
--- a/doc/build/changelog/unreleased_20/13466.rst
+++ b/doc/build/changelog/unreleased_20/13466.rst
@@ -1,0 +1,13 @@
+.. change::
+    :tags: bug, mysql
+    :tickets: 13466
+
+    Fixed bug in the MySQL dialect where the values of a :class:`.mysql.ENUM`
+    or :class:`.mysql.SET` type were rendered into ``CREATE TABLE`` DDL with
+    single quotes doubled but backslashes left unescaped. Under MySQL's default
+    ``sql_mode`` a backslash acts as an escape character, so a value containing
+    a backslash was emitted incorrectly and a value ending in a backslash would
+    escape the closing quote and break out of the string literal. Backslashes
+    are now escaped as well when the server does not have ``NO_BACKSLASH_ESCAPES``
+    enabled, matching the handling already used for ordinary string literals.
+    Pull request courtesy dxbjavid.

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2677,11 +2677,12 @@ class MySQLTypeCompiler(
     def _visit_enumerated_values(
         self, name: str, type_: _StringType, enumerated_values: Sequence[str]
     ) -> str:
+        preparer = self.dialect.identifier_preparer
         quoted_enums = []
         for e in enumerated_values:
-            if self.dialect.identifier_preparer._double_percents:
+            if preparer._double_percents:
                 e = e.replace("%", "%%")
-            quoted_enums.append("'%s'" % e.replace("'", "''"))
+            quoted_enums.append(preparer._format_string_literal(e))
         return self._extend_string(
             type_, {}, "%s(%s)" % (name, ",".join(quoted_enums))
         )
@@ -2718,6 +2719,21 @@ class MySQLIdentifierPreparer(
         """Unilaterally identifier-quote any number of strings."""
 
         return tuple([self.quote_identifier(i) for i in ids if i is not None])
+
+    def _format_string_literal(self, value: str) -> str:
+        """Render a plain string value as a SQL string literal.
+
+        Used for places such as ENUM and SET member values that are emitted
+        into DDL as string literals rather than identifiers. Single quotes are
+        doubled and, unless the server runs with ``NO_BACKSLASH_ESCAPES``,
+        backslashes are escaped as well, matching the handling in
+        :meth:`.MySQLCompiler.render_literal_value`.
+
+        """
+        value = value.replace("'", "''")
+        if self.dialect._backslash_escapes:
+            value = value.replace("\\", "\\\\")
+        return "'%s'" % value
 
 
 class MySQLDialect(_mariadb_shim.MariaDBShim, default.DefaultDialect):

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2678,11 +2678,10 @@ class MySQLTypeCompiler(
         self, name: str, type_: _StringType, enumerated_values: Sequence[str]
     ) -> str:
         preparer = self.dialect.identifier_preparer
-        quoted_enums = []
-        for e in enumerated_values:
-            if preparer._double_percents:
-                e = e.replace("%", "%%")
-            quoted_enums.append(preparer._format_string_literal(e))
+        quoted_enums = [
+            preparer._format_string_literal(e)  # type: ignore[attr-defined]
+            for e in enumerated_values
+        ]
         return self._extend_string(
             type_, {}, "%s(%s)" % (name, ",".join(quoted_enums))
         )
@@ -2727,12 +2726,15 @@ class MySQLIdentifierPreparer(
         into DDL as string literals rather than identifiers. Single quotes are
         doubled and, unless the server runs with ``NO_BACKSLASH_ESCAPES``,
         backslashes are escaped as well, matching the handling in
-        :meth:`.MySQLCompiler.render_literal_value`.
+        :meth:`.MySQLCompiler.render_literal_value`. Percent signs are doubled
+        when the paramstyle requires it, as elsewhere in the preparer.
 
         """
         value = value.replace("'", "''")
-        if self.dialect._backslash_escapes:
+        if self.dialect._backslash_escapes:  # type: ignore[attr-defined]
             value = value.replace("\\", "\\\\")
+        if self._double_percents:
+            value = value.replace("%", "%%")
         return "'%s'" % value
 
 

--- a/test/dialect/mysql/test_types.py
+++ b/test/dialect/mysql/test_types.py
@@ -338,6 +338,25 @@ class TypeCompileTest(fixtures.TestBase, AssertsCompiledSQL):
         self.assert_compile(type_, expected)
 
     @testing.combinations(
+        (mysql.ENUM("a", "b\\"), "ENUM('a','b\\\\')"),
+        (mysql.SET("a\\", "b"), "SET('a\\\\','b')"),
+        (mysql.ENUM("O'Brien", "x\\y"), "ENUM('O''Brien','x\\\\y')"),
+        argnames="type_, expected",
+    )
+    def test_enum_set_backslash_escaping(self, type_, expected):
+        # values containing a backslash must be escaped the same way
+        # render_literal_value escapes them; a trailing backslash otherwise
+        # escapes the closing quote and breaks out of the literal under the
+        # default sql_mode (backslash escapes on)
+        self.assert_compile(type_, expected)
+
+    def test_enum_no_backslash_escapes(self):
+        # NO_BACKSLASH_ESCAPES: backslash is an ordinary character, leave it
+        dialect = mysql.MySQLDialect()
+        dialect._backslash_escapes = False
+        self.assert_compile(mysql.ENUM("b\\"), "ENUM('b\\')", dialect=dialect)
+
+    @testing.combinations(
         (BOOLEAN(), "BOOL"),
         (Boolean(), "BOOL"),
         (mysql.TINYINT(1), "TINYINT(1)"),

--- a/test/dialect/mysql/test_types.py
+++ b/test/dialect/mysql/test_types.py
@@ -356,6 +356,15 @@ class TypeCompileTest(fixtures.TestBase, AssertsCompiledSQL):
         dialect._backslash_escapes = False
         self.assert_compile(mysql.ENUM("b\\"), "ENUM('b\\')", dialect=dialect)
 
+    @testing.combinations(True, False, argnames="double_percents")
+    def test_enum_set_double_percents(self, double_percents):
+        # percent signs in member values are doubled only when the
+        # paramstyle in use requires it
+        dialect = mysql.MySQLDialect()
+        dialect.identifier_preparer._double_percents = double_percents
+        expected = "ENUM('a%%b')" if double_percents else "ENUM('a%b')"
+        self.assert_compile(mysql.ENUM("a%b"), expected, dialect=dialect)
+
     @testing.combinations(
         (BOOLEAN(), "BOOL"),
         (Boolean(), "BOOL"),


### PR DESCRIPTION
### Description

`MySQLTypeCompiler._visit_enumerated_values` renders ENUM and SET values by doubling single quotes but leaves backslashes untouched, so under the default sql_mode where a backslash is an escape character a value containing one is emitted wrongly, and a value ending in a backslash escapes the closing quote and breaks out of the string literal in the generated DDL. `render_literal_value` already doubles backslashes for ordinary string literals whenever the server is not in `NO_BACKSLASH_ESCAPES` mode, so this applies the same handling to enum and set values; ordinary values compile identically.

Before:

    >>> from sqlalchemy.dialects import mysql
    >>> print(mysql.ENUM("a", "b\\").compile(dialect=mysql.dialect()))
    ENUM('a','b\')

the trailing backslash swallows the closing quote. After the change it renders `ENUM('a','b\\')`, and the value is left as-is when the server has `NO_BACKSLASH_ESCAPES` set.

A compile-level regression test and a changelog entry are included.

### Checklist

This pull request is:

- [x] A short code fix
	- tests are included; a reproducible demonstration is shown above.

**Have a nice day!**
