### PR TITLE
Synchronise sqlite DATETIME doc example (regexp and storage_format)

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -1128,7 +1128,7 @@ class DATETIME(_DateTimeMixin, sqltypes.DateTime):
             storage_format=(
                 "%(year)04d/%(month)02d/%(day)02d %(hour)02d:%(minute)02d:%(second)02d"
             ),
-            regexp=r"(\d+)/(\d+)/(\d+) (\d+)-(\d+)-(\d+)",
+            regexp=r"(\d+)/(\d+)/(\d+) (\d+):(\d+):(\d+)",
         )
 
     :param truncate_microseconds: when ``True`` microseconds will be truncated


### PR DESCRIPTION
### Description

This is to close #13462. There was a typo in the documentation where the `storage_format` was changed but the accompanying regular expression (`regexp`) was not.

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [x] A documentation / typographical / small typing error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
