### PR TITLE
Widen any_()/all_() typing to accept literal values

### DIFF
--- a/lib/sqlalchemy/sql/_elements_constructors.py
+++ b/lib/sqlalchemy/sql/_elements_constructors.py
@@ -69,7 +69,9 @@ if typing.TYPE_CHECKING:
 _T = TypeVar("_T")
 
 
-def all_(expr: _ColumnExpressionArgument[_T]) -> CollectionAggregate[bool]:
+def all_(
+    expr: _ColumnExpressionOrLiteralArgument[_T],
+) -> CollectionAggregate[bool]:
     """Produce an ALL expression.
 
     For dialects such as that of PostgreSQL, this operator applies
@@ -252,7 +254,9 @@ if not TYPE_CHECKING:
         return BooleanClauseList.and_(*clauses)
 
 
-def any_(expr: _ColumnExpressionArgument[_T]) -> CollectionAggregate[bool]:
+def any_(
+    expr: _ColumnExpressionOrLiteralArgument[_T],
+) -> CollectionAggregate[bool]:
     """Produce an ANY expression.
 
     For dialects such as that of PostgreSQL, this operator applies

--- a/test/typing/plain_files/sql/operators.py
+++ b/test/typing/plain_files/sql/operators.py
@@ -4,6 +4,8 @@ from typing import Any
 from typing import assert_type
 from typing import List
 
+from sqlalchemy import all_ as all_fn
+from sqlalchemy import any_ as any_fn
 from sqlalchemy import ARRAY
 from sqlalchemy import BigInteger
 from sqlalchemy import column
@@ -138,6 +140,13 @@ nulls_first: "ColumnElement[int]" = A.id.nulls_first()
 nulls_last: "ColumnElement[int]" = A.id.nulls_last()
 collate: "ColumnElement[str]" = A.string.collate("somelang")
 distinct: "ColumnElement[int]" = A.id.distinct()
+
+# any_()/all_() functions also accept plain literal sequences, which get
+# coerced to a bind parameter at runtime (not just column expressions)
+any_fn_col: "ColumnElement[bool]" = A.string == any_fn(A.arr)
+any_fn_list: "ColumnElement[bool]" = A.string == any_fn(["a", "b"])
+all_fn_col: "ColumnElement[bool]" = A.string == all_fn(A.arr)
+all_fn_list: "ColumnElement[bool]" = A.string == all_fn(["a", "b"])
 
 
 # custom ops


### PR DESCRIPTION
This pull request is:

- [x] A short code fix
	- includes issue number and tests
	- `Fixes: #13357` is in the commit message

### Description

`any_()` and `all_()` accept plain Python values at runtime (e.g. a
list), same as `between()` and a few other constructors in
`_elements_constructors.py` — they all go through
`coercions.expect(roles.ExpressionElementRole, ...)`, which handles
literal coercion. But `any_()`/`all_()` were typed with
`_ColumnExpressionArgument`, which doesn't include plain literals,
only `between()` and similar were typed with
`_ColumnExpressionOrLiteralArgument`. So mypy rejects
`any_(["a", "b"])` even though it runs fine and is a normal way to use
it against an `ARRAY` column.

Changed both signatures to `_ColumnExpressionOrLiteralArgument` to
match. Added a couple of typing-test lines covering the list case
alongside the existing column-expression one.

Fixes: #13357