### PR TITLE
Document dataclass caveats for Declarative Dataclass Mapping

### DIFF
--- a/doc/build/orm/dataclasses.rst
+++ b/doc/build/orm/dataclasses.rst
@@ -619,6 +619,113 @@ variable may be generated::
    even though the purpose of this attribute was only to allow legacy
    ORM typed mappings to continue to function.
 
+.. _orm_declarative_dc_caveats:
+
+Dataclass Caveats
+^^^^^^^^^^^^^^^^^
+
+Declarative Dataclass Mapping produces a real Python dataclass, so the rules of
+the dataclasses_ module apply in addition to those of the ORM. The sections
+below collect the behaviors that most frequently cause surprise.
+
+Fields without defaults may not follow fields with defaults
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Python dataclasses generate a positional ``__init__()`` method, which means a
+field without a default may not be declared after one that has a default. As
+mapped attributes participate in that same ordering, the mapping below fails::
+
+    class Base(MappedAsDataclass, DeclarativeBase):
+        pass
+
+
+    class User(Base):
+        __tablename__ = "user"
+
+        id: Mapped[int] = mapped_column(primary_key=True, init=False)
+        name: Mapped[str] = mapped_column(default="default_name")
+
+        # raises: non-default argument 'email' follows default argument
+        email: Mapped[str] = mapped_column()
+
+The error originates in the dataclasses_ module and is raised as
+:class:`.InvalidRequestError` when the class is transformed. There are two ways
+to resolve it: declare the fields that have no default first, or make the
+arguments keyword-only using ``kw_only=True``, in which case ordering no longer
+matters::
+
+    class Base(MappedAsDataclass, DeclarativeBase, kw_only=True):
+        pass
+
+Keyword-only fields are particularly useful for attributes contributed by
+mixins and abstract superclasses, since a mixin cannot know where its fields
+will land in the ordering of the classes that use it.
+
+.. seealso::
+
+    :ref:`orm_declarative_dc_mixins`
+
+``kw_only`` is inherited at runtime, but not by type checkers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When ``kw_only=True`` is set on a superclass, SQLAlchemy applies it to
+subclasses as well, so the generated ``__init__()`` method accepts the
+subclass' own fields as keyword arguments. Type checkers implementing
+:pep:`681` treat class-level arguments as applying only to the class where they
+appear, so a checker may report a call as invalid even though it succeeds at
+runtime. Setting ``kw_only=True`` directly on the subclass resolves the
+disagreement.
+
+.. seealso::
+
+    `#9493 <https://github.com/sqlalchemy/sqlalchemy/issues/9493>`_ - tracking
+    issue for this behavior
+
+``asdict()`` recurses infinitely across bidirectional relationships
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`dataclasses.asdict()
+<https://docs.python.org/3/library/dataclasses.html#dataclasses.asdict>`_ walks
+nested dataclasses recursively and has no concept of a cycle. A pair of classes
+linked with :paramref:`_orm.relationship.back_populates` therefore refers back
+to itself, and calling ``asdict()`` on such an object raises ``RecursionError``.
+This affects unloaded, eagerly loaded and transient objects alike, as the cycle
+exists in the object graph rather than in the loading behavior. ``astuple()``
+has the same limitation.
+
+There is no ORM-level workaround, as the cause is in the dataclasses_ module
+itself, which offers no way to omit a field from ``asdict()``. Write an explicit
+serialization function that converts only the attributes needed and does not
+follow the reverse side of the relationship.
+
+.. seealso::
+
+    `python/cpython#94345 <https://github.com/python/cpython/issues/94345>`_ -
+    upstream issue for the underlying behavior
+
+Dataclass defaults and subsequent ORM operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A dataclass default causes the corresponding attribute to be **set** on a newly
+constructed object, and the ORM treats an attribute that is set, including one
+set to ``None`` or to an empty collection, differently from one that was never
+set at all. In SQLAlchemy 2.0 this means a default can take precedence over
+data that is already in the database. The most consequential case is
+:meth:`_orm.Session.merge`, where a collection given
+:paramref:`_orm.relationship.default_factory` is treated as loaded and empty,
+and merging an object constructed by ``__init__()`` will disassociate the rows
+that the database already holds.
+
+.. versionchanged:: 2.1  Implicit ``default`` and collection-based
+   ``default_factory`` values are no longer populated into ``__dict__``, so an
+   attribute that was not explicitly passed to ``__init__()`` is left absent and
+   no longer overwrites existing data. See :ref:`change_12168` for a full
+   description of the change.
+
+When running under 2.0, construct the object with the values that should be
+persisted rather than relying on the defaults, or set the attributes explicitly
+before merging.
+
 .. _dataclasses_pydantic:
 
 Integrating with Alternate Dataclass Providers such as Pydantic


### PR DESCRIPTION
Adds a **Dataclass Caveats** section to `doc/build/orm/dataclasses.rst`, addressing #9410. It sits at the end of the Declarative Dataclass Mapping material, just before the Pydantic section.

Rather than transcribing the 2023 checklist in the issue, I ran each item against **2.0.51** and **2.1.0b3** and documented what those versions actually do. That changed the content in several places, so the notes below explain what is in the PR and what deliberately is not.

**Documented (four items, each reproduced on both versions):**

- **Field ordering** — a field without a default declared after one with a default. Raises `InvalidRequestError` wrapping the stdlib `TypeError("non-default argument 'email' follows default argument 'name'")`. Both fixes are shown and both were tested: reorder the fields, or use `kw_only=True`.
- **`kw_only` and type checkers** — reframed from the issue's wording. `kw_only=True` on a superclass *is* applied to subclasses at runtime (`id` lands in `kwonlyargs` on both 2.0 and 2.1), so this is not a runtime bug. The mismatch is with PEP 681 checkers, which scope the argument to the declaring class. Links to #9493.
- **`asdict()` recursion** — a `back_populates` pair makes the object graph cyclic and `asdict()` has no cycle detection. Confirmed `RecursionError` on both versions and in all three states (unloaded, eagerly loaded, transient); `astuple()` behaves the same. Links to python/cpython#94345, still open.
- **Dataclass defaults and ORM operations** — the `Session.merge` case. On 2.0 a collection with `default_factory` is treated as loaded-and-empty, and merging an object built by `__init__()` disassociates rows the database already holds; in my test both child rows had their foreign key set to NULL. On 2.1 the same test leaves them intact, so this carries a `.. versionchanged:: 2.1` pointing at `:ref:`change_12168`` rather than re-explaining the mechanism.

**Deliberately not included:**

- **`declared_attr` on a mixin (item 2)** — already covered by :ref:`orm_declarative_dc_mixins`, which has a tip on this and links to :ref:`error_dcmx`. On 2.1 the error message itself names the fix. Linked instead of duplicated.
- **Base-class ordering** — a [2023 comment on the issue](https://github.com/sqlalchemy/sqlalchemy/issues/9410#issuecomment-1754645818) reports that `DeclarativeBase, MappedAsDataclass` fails where the reverse order works. It does not reproduce: both orders produce a working dataclass on 2.0.51 and 2.1.0b3. Left out rather than documenting a limitation that no longer exists — worth a look if it was fixed silently.
- **#9930 / non-mapped field defaults on load** — tracked separately, and it seemed out of scope for a caveats section on the mapping feature itself.

**Open questions for you:**

- Placement: I put it before the Pydantic section, on the assumption caveats close out the native-dataclass material. Happy to move it.
- Should any of this also land on the `rel_2_0` doc branch? The field-ordering and `asdict()` items apply there unchanged, and the merge item is arguably most useful to 2.0 readers.

**Verification:** full `sphinx -b html` build adds no new warnings (the section previously tripped four "title underline too short" warnings, now fixed; the four remaining warnings in the build are pre-existing in `changelog_07.rst`, `migration_21.rst` and ambiguous Python xrefs). Every cross-reference resolves, checked in the built HTML — including `:ref:`change_12168``, `:paramref:` targets and the two stdlib links. Note that `conf.py` has no `intersphinx_mapping`, so I used the file's existing `dataclasses_` named target and explicit URLs instead of `:mod:`/`:func:` roles, which render unlinked here. `tools/format_docs_code.py --check` passes.

I used an AI assistant while working on this. The prose is my own and every behaviour claim above was verified by running it against both versions rather than taken from the issue text.
