### PR TITLE
Fix get_schema_names() dropping user schemas with a pg prefix

### DIFF
--- a/doc/build/changelog/unreleased_21/13471.rst
+++ b/doc/build/changelog/unreleased_21/13471.rst
@@ -1,0 +1,11 @@
+.. change::
+    :tags: bug, postgresql
+    :tickets: 13471
+
+    Fixed bug in :meth:`_reflection.Inspector.get_schema_names` for
+    PostgreSQL where the query used to exclude system schemas relied on
+    ``NOT LIKE 'pg_%'``, which treats the underscore as a SQL ``LIKE``
+    wildcard rather than a literal character. This caused user-created
+    schemas that happen to start with "pg" followed by any other
+    character, such as ``pgsql`` or ``pgstats``, to be silently excluded
+    along with actual system schemas like ``pg_catalog``.

--- a/doc/build/changelog/unreleased_21/13472.rst
+++ b/doc/build/changelog/unreleased_21/13472.rst
@@ -1,6 +1,6 @@
 .. change::
     :tags: bug, postgresql
-    :tickets: 13472, 13471
+    :tickets: 13472
 
     Fixed bug in :meth:`_reflection.Inspector.get_schema_names` for
     PostgreSQL where the query used to exclude system schemas relied on

--- a/doc/build/changelog/unreleased_21/13472.rst
+++ b/doc/build/changelog/unreleased_21/13472.rst
@@ -1,6 +1,6 @@
 .. change::
     :tags: bug, postgresql
-    :tickets: 13471
+    :tickets: 13472, 13471
 
     Fixed bug in :meth:`_reflection.Inspector.get_schema_names` for
     PostgreSQL where the query used to exclude system schemas relied on

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -4003,7 +4003,11 @@ class PGDialect(default._BackendsMultiReflection, default.DefaultDialect):
     def get_schema_names(self, connection, **kw):
         query = (
             select(pg_catalog.pg_namespace.c.nspname)
-            .where(pg_catalog.pg_namespace.c.nspname.not_like("pg_%"))
+            .where(
+                ~pg_catalog.pg_namespace.c.nspname.startswith(
+                    "pg_", autoescape=True
+                )
+            )
             .order_by(pg_catalog.pg_namespace.c.nspname)
         )
         return connection.scalars(query).all()

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -969,6 +969,24 @@ class MiscBackendTest(
         assert t2.c.date1.type.timezone is True
         assert t2.c.date2.type.timezone is False
 
+    def test_get_schema_names_only_excludes_pg_prefix(self, connection):
+        """reported downstream in apache/superset#30678
+
+        ``get_schema_names()`` previously excluded schemas via
+        ``NOT LIKE 'pg_%'``, but ``_`` is a single-character LIKE
+        wildcard, so the pattern matched "pg" followed by any one
+        character, not just a literal ``pg_`` prefix.  A user-created
+        schema like ``pgfoo`` was silently dropped even though only
+        schemas literally prefixed with ``pg_`` (``pg_catalog``,
+        ``pg_toast``, etc.) are reserved by PostgreSQL itself.
+        """
+        connection.execute(DDL("CREATE SCHEMA pgfoo_test_schema"))
+        try:
+            insp = inspect(connection)
+            is_true("pgfoo_test_schema" in insp.get_schema_names())
+        finally:
+            connection.execute(DDL("DROP SCHEMA pgfoo_test_schema"))
+
     @testing.requires.psycopg2_compatibility
     def test_psycopg2_version(self):
         v = testing.db.dialect.psycopg2_version


### PR DESCRIPTION
### Description

`PGDialect.get_schema_names()` excludes system schemas with `nspname NOT LIKE 'pg_%'` (still the same pattern on `main`, via `.not_like("pg_%")`). In SQL `LIKE`, `_` is a single-character wildcard, so this matches "pg" plus any one character plus anything, not the literal `pg_` prefix that real Postgres system schemas actually use (`pg_catalog`, `pg_toast`, etc). Any user-created schema that happens to start with `pg` plus one more character (`pgsql`, `pgstats`, `pgfoo`...) gets silently dropped from `get_schema_names()`.

This showed up downstream in Apache Superset, where users with schemas like `pgsql`/`pgstats` found them missing from the schema picker with no error: apache/superset#30678. Superset ended up working around it with its own `get_schema_names` override (apache/superset#42312) rather than fixing it at the source.

The fix swaps the `LIKE` pattern for `~nspname.startswith("pg_", autoescape=True)`, which properly escapes the wildcard character instead of just narrowing it.

Added a test in `MiscBackendTest` that creates a schema named `pgfoo_test_schema` and asserts it isn't filtered out. Confirmed it fails against the current code and passes with the fix (verified against a disposable local Postgres instance, and pre-commit/black/flake8 all pass).

Fixes: #13472

### Checklist

This pull request is:

- [x] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.