### PR TITLE
Render MySQL VALUES rows with ROW constructors

### DIFF
--- a/doc/build/changelog/unreleased_20/10310.rst
+++ b/doc/build/changelog/unreleased_20/10310.rst
@@ -1,0 +1,9 @@
+.. change::
+    :tags: bug, mysql
+    :tickets: 10310
+
+    Fixed compilation of the :class:`_sql.Values` construct for MySQL to
+    render each row using the required ``ROW()`` constructor syntax.  This
+    syntax is required by the MySQL ``VALUES`` statement available as of
+    MySQL 8.0.19.  MariaDB compilation retains its existing table value
+    constructor syntax.

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -1317,6 +1317,22 @@ class MySQLCompiler(
 
         return ""
 
+    def _render_values(self, element, **kw):
+        return self.dialect._dispatch_for_vendor(
+            self._mysql_render_values,
+            super()._render_values,
+            element,
+            **kw,
+        )
+
+    def _mysql_render_values(self, element, **kw):
+        kw["_mysql_values_row"] = True
+        return super()._render_values(element, **kw)
+
+    def visit_tuple(self, clauselist, **kw):
+        prefix = "ROW" if kw.pop("_mysql_values_row", False) else ""
+        return prefix + super().visit_tuple(clauselist, **kw)
+
     def visit_random_func(self, fn: random, **kw: Any) -> str:
         return "rand%s" % self.function_argspec(fn)
 

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -54,6 +54,7 @@ from sqlalchemy import TIMESTAMP
 from sqlalchemy import types as sqltypes
 from sqlalchemy import Unicode
 from sqlalchemy import UnicodeText
+from sqlalchemy import values
 from sqlalchemy import VARCHAR
 from sqlalchemy.dialects.mysql import base as mysql
 from sqlalchemy.dialects.mysql import insert
@@ -177,6 +178,61 @@ class CompileTest(ReservedWordFixture, fixtures.TestBase, AssertsCompiledSQL):
         eq_ignore_whitespace(
             str(stmt.compile(dialect=mysql.dialect())),
             "INSERT INTO t (description) VALUES (lower(%s))",
+        )
+
+    def test_values(self):
+        value_expr = values(
+            column("col1", String),
+            column("col2", Integer),
+            name="temp_1",
+        ).data([("a", 2), ("b", 3)])
+
+        self.assert_compile(
+            select(value_expr),
+            "SELECT temp_1.col1, temp_1.col2 "
+            "FROM (VALUES ROW(%s, %s), ROW(%s, %s)) "
+            "AS temp_1 (col1, col2)",
+            checkpositional=("a", 2, "b", 3),
+        )
+        self.assert_compile(
+            select(value_expr),
+            "SELECT temp_1.col1, temp_1.col2 "
+            "FROM (VALUES ROW('a', 2), ROW('b', 3)) "
+            "AS temp_1 (col1, col2)",
+            literal_binds=True,
+        )
+
+    def test_values_mariadb(self):
+        value_expr = values(
+            column("col1", String),
+            column("col2", Integer),
+            name="temp_1",
+            literal_binds=True,
+        ).data([("a", 2), ("b", 3)])
+
+        self.assert_compile(
+            select(value_expr),
+            "SELECT temp_1.col1, temp_1.col2 "
+            "FROM (VALUES ('a', 2), ('b', 3)) "
+            "AS temp_1 (col1, col2)",
+            dialect=mysql.dialect(is_mariadb=True),
+        )
+
+    @testing.combinations(
+        ("mysql", "(VALUES ROW(%s), ROW(%s))"),
+        ("mariadb", "(VALUES (%s), (%s))"),
+        argnames="dialect, expected",
+    )
+    def test_scalar_values(self, dialect, expected):
+        value_expr = (
+            values(column("col1", Integer)).data([(1,), (2,)]).scalar_values()
+        )
+
+        self.assert_compile(
+            value_expr,
+            expected,
+            dialect=dialect,
+            checkpositional=(1, 2),
         )
 
     def test_create_index_simple(self):


### PR DESCRIPTION
### Description

MySQL's table `VALUES` statement, available as of MySQL 8.0.19,
requires every row to use the `ROW(...)` constructor.  SQLAlchemy
currently compiles `Values` rows using bare parentheses, which produces
invalid MySQL SQL.

This change renders MySQL `Values` and `ScalarValues` rows with the
required `ROW(...)` constructor while delegating data iteration, tuple
construction, literal binds, and parameter handling to the generic
`_render_values()` helper.  MySQL and MariaDB behavior is selected using
the dialect's vendor dispatch; MariaDB continues to use its existing
`VALUES (...), (...)` table value constructor syntax.  No server-version
guard is needed because older MySQL versions do not support the table
`VALUES` statement itself.

Regression coverage checks MySQL bound and literal `Values` rendering,
`ScalarValues` rendering for both MySQL and MariaDB, multiple rows, and
unchanged MariaDB rendering.  Bound parameter ordering is verified with
`checkpositional`.  The existing core `Values` tests verify that generic
dialect output is unchanged.  A 2.0 changelog entry is included.

### Validation

- `python -m pytest test/dialect/mysql/test_compiler.py::CompileTest::test_values test/dialect/mysql/test_compiler.py::CompileTest::test_values_mariadb test/dialect/mysql/test_compiler.py::CompileTest::test_scalar_values` — 4 passed
- `python -m pytest test/dialect/mysql/test_compiler.py::CompileTest` — 58 passed
- `python -m pytest test/dialect/mysql/test_compiler.py` — 255 passed
- `python -m pytest test/sql/test_values.py` — 41 passed
- `python -m nox -t py311-sqlite-nocext -- test/dialect/mysql/test_compiler.py::CompileTest::test_values test/dialect/mysql/test_compiler.py::CompileTest::test_values_mariadb` — 2 passed
- `python -m black --check lib/sqlalchemy/dialects/mysql/base.py test/dialect/mysql/test_compiler.py` — passed with Black 26.3.1
- `flake8p lib/sqlalchemy/dialects/mysql/base.py test/dialect/mysql/test_compiler.py` — passed with Flake8 7.3.0
- `zimports --diff lib/sqlalchemy/dialects/mysql/base.py test/dialect/mysql/test_compiler.py` — unchanged with zimports 0.7.0
- `git diff upstream/main...HEAD --check` — passed

The full test suite and tests against a live MySQL or MariaDB server were
not run; this is a compiler-only change.  The repository-wide pre-commit
wrapper was not run because its configured Python 3.14 interpreter is not
installed.  Its relevant Black, Flake8, and zimports checks were run
directly using the same versions configured by the repository.

### Checklist

This pull request is:

- [ ] A documentation / typographical / small typing error fix
- [x] A short code fix
- [ ] A new feature implementation

Fixes: #10310
