### PR TITLE
Fix GenericRepr dropping args of a secondary inspected class with no defaults

### DIFF
--- a/lib/sqlalchemy/util/langhelpers.py
+++ b/lib/sqlalchemy/util/langhelpers.py
@@ -856,7 +856,14 @@ class GenericRepr:
                         pos_args.extend(spec.args[1:])
                 else:
                     kw_args.update(
-                        [(arg, missing) for arg in spec.args[1:-default_len]]
+                        [
+                            (arg, missing)
+                            for arg in (
+                                spec.args[1:-default_len]
+                                if default_len
+                                else spec.args[1:]
+                            )
+                        ]
                     )
 
                 if default_len:

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -3248,6 +3248,24 @@ class GenericReprTest(fixtures.TestBase):
             "Bar(b='b', c='c', a='a')",
         )
 
+    def test_multi_kw_secondary_no_defaults(self):
+        # a secondary inspected class with no default arguments must still
+        # have its arguments included in the repr; previously they were
+        # dropped because spec.args[1:-0] evaluates to []
+        class Foo:
+            def __init__(self, a):
+                self.a = a
+
+        class Bar(Foo):
+            def __init__(self, b=2, **kw):
+                self.b = b
+                super().__init__(**kw)
+
+        eq_(
+            util.generic_repr(Bar(a="a", b="b"), to_inspect=[Bar, Foo]),
+            "Bar(b='b', a='a')",
+        )
+
     def test_discard_vargs(self):
         class Foo:
             def __init__(self, a, b, *args):


### PR DESCRIPTION
## Summary

In `GenericRepr` (`util/langhelpers.py`), the loop over `to_inspect` guards the argument slice with `if default_len` for the **first** inspected class (`i == 0`), falling back to `spec.args[1:]` when a class has no default arguments. The branch for **subsequent** inspected classes does not:

```python
if i == 0:
    ...
    if default_len:
        pos_args.extend(spec.args[1:-default_len])
    else:
        pos_args.extend(spec.args[1:])
else:
    kw_args.update(
        [(arg, missing) for arg in spec.args[1:-default_len]]   # no guard
    )
```

When a secondary inspected class has no default arguments, `default_len == 0`, so `spec.args[1:-default_len]` becomes `spec.args[1:-0]` == `spec.args[1:0]` == `[]`, and **all** of that class's arguments are silently dropped from the repr.

## Reproduction

```python
class Foo:            # secondary, no defaults
    def __init__(self, a): ...

class Bar(Foo):
    def __init__(self, b=2, **kw): ...

generic_repr(Bar(a="a", b="b"), to_inspect=[Bar, Foo])
# before: "Bar(b='b')"          <- 'a' dropped
# after:  "Bar(b='b', a='a')"
```

## Fix

Mirror the `i == 0` guard:

```diff
-                    [(arg, missing) for arg in spec.args[1:-default_len]]
+                    [
+                        (arg, missing)
+                        for arg in (
+                            spec.args[1:-default_len]
+                            if default_len
+                            else spec.args[1:]
+                        )
+                    ]
```

## Tests

Added `GenericReprTest.test_multi_kw_secondary_no_defaults`, which fails on the previous behavior (drops the secondary class's arg) and passes with the fix.
