### PR TITLE
Reset _flushing when a bulk_* call fails before it can begin

### DIFF
--- a/doc/build/changelog/unreleased_20/13485.rst
+++ b/doc/build/changelog/unreleased_20/13485.rst
@@ -1,0 +1,14 @@
+.. change::
+    :tags: bug, orm
+    :tickets: 13485
+
+    Fixed issue where a :meth:`_orm.Session.bulk_save_objects`,
+    :meth:`_orm.Session.bulk_insert_mappings` or
+    :meth:`_orm.Session.bulk_update_mappings` call made while the
+    :class:`_orm.Session`'s transaction was not active would leave the
+    ``Session`` permanently in the "flushing" state, so that every subsequent
+    :meth:`_orm.Session.flush` raised ``Session is already flushing``.  The
+    flag was set before the transaction was begun but the ``finally:`` block
+    that resets it only covered the statements after that point, and neither
+    :meth:`_orm.Session.rollback` nor :meth:`_orm.Session.close` clears it, so
+    the ``Session`` could not be recovered.

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -4902,32 +4902,35 @@ class Session(_SessionClassMethods, EventTarget):
         render_nulls: bool,
     ) -> None:
         mapper = _class_to_mapper(mapper)
+
+        # the flag has to be set before _begin(), as SessionTransaction
+        # autoflushes when it is not set, which would recurse back into here
         self._flushing = True
-
-        transaction = self._autobegin_t()._begin()
         try:
-            if isupdate:
-                bulk_persistence._bulk_update(
-                    mapper,
-                    mappings,
-                    transaction,
-                    isstates=isstates,
-                    update_changed_only=update_changed_only,
-                )
-            else:
-                bulk_persistence._bulk_insert(
-                    mapper,
-                    mappings,
-                    transaction,
-                    isstates=isstates,
-                    return_defaults=return_defaults,
-                    render_nulls=render_nulls,
-                )
-            transaction.commit()
+            transaction = self._autobegin_t()._begin()
+            try:
+                if isupdate:
+                    bulk_persistence._bulk_update(
+                        mapper,
+                        mappings,
+                        transaction,
+                        isstates=isstates,
+                        update_changed_only=update_changed_only,
+                    )
+                else:
+                    bulk_persistence._bulk_insert(
+                        mapper,
+                        mappings,
+                        transaction,
+                        isstates=isstates,
+                        return_defaults=return_defaults,
+                        render_nulls=render_nulls,
+                    )
+                transaction.commit()
 
-        except:
-            with util.safe_reraise():
-                transaction.rollback(_capture_exception=True)
+            except:
+                with util.safe_reraise():
+                    transaction.rollback(_capture_exception=True)
         finally:
             self._flushing = False
 

--- a/test/orm/test_transaction.py
+++ b/test/orm/test_transaction.py
@@ -36,6 +36,7 @@ from sqlalchemy.testing import expect_raises_message
 from sqlalchemy.testing import expect_warnings
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
+from sqlalchemy.testing import is_false
 from sqlalchemy.testing import is_not
 from sqlalchemy.testing import mock
 from sqlalchemy.testing.config import Variation
@@ -1026,6 +1027,32 @@ class SessionTransactionTest(fixtures.RemovesEvents, FixtureTest):
                 "was:",
                 sess.commit,
             )
+        sess.rollback()
+        sess.add(User(id=5, name="some name"))
+        sess.commit()
+
+    @testing.combinations(
+        "bulk_update_mappings", "bulk_insert_mappings", argnames="meth"
+    )
+    def test_bulk_failure_resets_flushing_flag(self, meth):
+        """a bulk_* call that raises before it can begin must not leave the
+        Session stuck in the flushing state.
+
+        """
+        User = self.classes.User
+
+        sess, u1 = self._inactive_flushed_session_fixture()
+        is_false(sess._flushing)
+
+        assert_raises(
+            sa_exc.PendingRollbackError,
+            getattr(sess, meth),
+            User,
+            [{"id": 1, "name": "u2"}],
+        )
+        is_false(sess._flushing)
+
+        # the documented recovery works again
         sess.rollback()
         sess.add(User(id=5, name="some name"))
         sess.commit()


### PR DESCRIPTION
Fixes #13485

### Description

`Session._bulk_save_mappings` sets the flushing flag and begins the transaction *above* its `try:`:

```python
mapper = _class_to_mapper(mapper)
self._flushing = True

transaction = self._autobegin_t()._begin()
try:
    ...
finally:
    self._flushing = False
```

`_begin()` carries `@_StateChange.declare_states((SessionTransactionState.ACTIVE,), NO_CHANGE)`, so on a Session whose transaction is not active it raises `PendingRollbackError` — before the `try:` is entered. The `finally:` never runs and `_flushing` stays `True`.

The Session is then unrecoverable: `grep -n "_flushing"` shows the flag is only ever set back to `False` in `__init__`, in `flush()`, and in that `finally:`. Neither `rollback()` nor `close()` touches it, so the recovery the `PendingRollbackError` message advises does not work, and every subsequent `flush()` raises `InvalidRequestError: Session is already flushing`.

`flush()` itself is fine — it sets the flag *inside* its `try:` (`session.py:4504-4513`), which is why the reporter's step 1 self-heals and only the bulk path sticks.

Reproduced on current main (2.1.0b4, 5995834) with the reporter's script; output matches their 1.4.54 / 2.0.51 results exactly.

### Fix

The obvious-looking fix — move `self._flushing = True` below `_begin()` and into the `try:` — would be wrong, and I want to flag that explicitly since it is the first thing a reviewer will reach for.

`_begin()` constructs a `SessionTransaction` with origin `SUBTRANSACTION`, and `SessionTransaction.__init__` does:

```python
if not is_begin and not self.session._flushing:
    self.session.flush()
```

So the flag being set *before* `_begin()` is load-bearing — it suppresses a recursive autoflush on the bulk path. I kept the assignment where it is and wrapped `_begin()` plus the existing `try`/`except` in the `try:` instead, which is a pure indentation change to the existing body.

### Tests

Added to `SessionTransactionTest` in `test/orm/test_transaction.py` rather than `test/orm/dml/test_bulk.py`, because that class already has `_inactive_flushed_session_fixture()`, which produces exactly the deactivated-transaction state this needs, and its `FixtureTest` base handles table lifecycle for a session that is deliberately left mid-failure. (I tried it in `test_bulk.py` first; `BulkTest.run_define_tables = "each"` plus `sqlite:///:memory:` meant a deliberately un-rolled-back session took the schema with it between tests.)

The test parameterises over `bulk_update_mappings` and `bulk_insert_mappings`, asserts `_flushing` is `False` after the `PendingRollbackError`, and then asserts the documented recovery works — `rollback()`, add, `commit()` — since silently losing the Session is the actual user-visible symptom.

Verified non-vacuous: with `lib/sqlalchemy/orm/session.py` reverted both parameterisations fail; with the fix both pass.

`test/orm/` in full: 10880 passed, 142 skipped. `black --check` clean on both changed files; `flake8` reports the same 21 pre-existing `I100` import-order notes on `session.py` before and after.

### Changelog

`doc/build/changelog/unreleased_20/13485.rst`, since the issue is milestoned `2.0.x`.
