### PR TITLE
fix: infer expanding bind parameter type past None

### DIFF
--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -2133,7 +2133,10 @@ class BindParameter(roles.InElementRole, KeyedColumnElement[_T]):
         if type_ is None:
             if expanding:
                 if value:
-                    check_value = value[0]
+                    check_value = next(
+                        (item for item in value if item is not None),
+                        None,
+                    )
                 else:
                     check_value = type_api._NO_VALUE_IN_LIST
             else:

--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -4858,6 +4858,13 @@ class TupleTypingTest(fixtures.TestBase):
 
         self._assert_types(expr.right.type.types)
 
+    def test_expanding_type_inference_skips_none(self):
+        bind = bindparam("value", [None, 1], expanding=True)
+        is_(bind.type._type_affinity, Integer)
+
+        all_none = bindparam("all_none", [None, None], expanding=True)
+        is_(all_none.type, sqltypes.NULLTYPE)
+
     def test_tuple_type_plain_inference(self):
         a, b, c = column("a"), column("b"), column("c")
 


### PR DESCRIPTION
Skips leading None values when inferring expanding bind parameter types while preserving NULLTYPE for all-None values. Adds regression coverage.\n\nValidation: focused test/sql/test_operators.py -k test_expanding_type_inference_skips_none passed (1 passed), plus diff and compile checks.