### PR TITLE
Fix: MySQLTypeCompiler._visit_enumerated_values() in...

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2681,6 +2681,8 @@ class MySQLTypeCompiler(
         for e in enumerated_values:
             if self.dialect.identifier_preparer._double_percents:
                 e = e.replace("%", "%%")
+            if self.dialect._backslash_escapes:
+                e = e.replace("\\", "\\\\")
             quoted_enums.append("'%s'" % e.replace("'", "''"))
         return self._extend_string(
             type_, {}, "%s(%s)" % (name, ",".join(quoted_enums))

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -993,6 +993,40 @@ class SQLTest(fixtures.TestBase, AssertsCompiledSQL, CacheKeyFixture):
             dialect=dialect,
         )
 
+    def test_enum_set_backslash_escaping(self):
+        t1 = Table(
+            "sometable",
+            MetaData(),
+            Column("e1", mysql.ENUM("a\\b", "c\\")),
+            Column("s1", mysql.SET("a\\b", "c\\")),
+        )
+        self.assert_compile(
+            schema.CreateTable(t1),
+            "CREATE TABLE sometable ("
+            "e1 ENUM('a\\\\b','c\\\\'), "
+            "s1 SET('a\\\\b','c\\\\')"
+            ")",
+        )
+
+    def test_enum_set_backslash_escaping_disabled(self):
+        dialect = mysql.dialect()
+        dialect._backslash_escapes = False
+
+        t1 = Table(
+            "sometable",
+            MetaData(),
+            Column("e1", mysql.ENUM("a\\b", "c\\")),
+            Column("s1", mysql.SET("a\\b", "c\\")),
+        )
+        self.assert_compile(
+            schema.CreateTable(t1),
+            "CREATE TABLE sometable ("
+            "e1 ENUM('a\\b','c\\'), "
+            "s1 SET('a\\b','c\\')"
+            ")",
+            dialect=dialect,
+        )
+
     def test_limit(self):
         t = sql.table("t", sql.column("col1"), sql.column("col2"))
 


### PR DESCRIPTION
## Summary
In _visit_enumerated_values, before the quote-doubling step, added: if self.dialect._backslash_escapes: e = e.replace('\\', '\\\\'). This mirrors render_literal_value's pattern, doubling backslashes only when MySQL is in a sql_mode where backslash is an escape char (i.e. NOT NO_BACKSLASH_ESCAPES), leaving NO_BACKSLASH_ESCAPES-mode output unchanged. Applied before quote-doubling so the newly-doubled backslashes are not re-escaped.

## Problem
sqlalchemy/sqlalchemy issue reference: sqlalchemy/sqlalchemy#13466

## Root Cause
MySQLTypeCompiler._visit_enumerated_values() in lib/sqlalchemy/dialects/mysql/base.py only doubled single quotes (e.replace("'", "''")) and never escaped backslashes, unlike MySQLCompiler.render_literal_value() which already doubles backslashes guarded by self.dialect._backslash_escapes.

## Testing
PASS - new tests pass (3/3 backslash-escaping tests including the new ones), and full mysql test_compiler.py + test_types.py suites pass (379 passed, 0 failed).

## Related Issue
sqlalchemy/sqlalchemy#13466
