### PR TITLE
Say what required the foreign key to resolve in naming conventions

### DIFF
--- a/doc/build/changelog/unreleased_20/5350.rst
+++ b/doc/build/changelog/unreleased_20/5350.rst
@@ -1,0 +1,16 @@
+.. change::
+    :tags: bug, schema
+    :tickets: 5350
+
+    Improved the error raised when a naming convention using a
+    ``%(referred_column_0_name)s`` token cannot resolve the target of a
+    string-based :class:`_schema.ForeignKey`, which happens when the
+    referenced :class:`_schema.Table` has not been defined yet.  Reading that
+    token resolves the foreign key while the constraint name is being built,
+    whereas the target is otherwise resolved lazily; the resulting
+    :class:`_exc.NoReferencedTableError` named only the missing table and gave
+    no indication that the naming convention was what required it.  The error
+    now names the token, and points at defining the referenced table first,
+    passing the :class:`_schema.Column` object rather than a string, or using
+    ``%(referred_table_name)s``, which is read from the string and needs no
+    resolution.  The exception type is unchanged.

--- a/lib/sqlalchemy/sql/naming.py
+++ b/lib/sqlalchemy/sql/naming.py
@@ -92,7 +92,43 @@ class ConventionDict:
         # note that before [ticket:3989], this method was returning
         # the specification for the :class:`.ForeignKey` itself, which normally
         # would be using the ``.key`` of the column, not the name.
-        return fk.column.name
+        try:
+            return fk.column.name
+        except exc.NoReferenceError as err:
+            # ``fk.column`` resolves the target on access. The name is built
+            # when the constraint is attached to its table, which for a
+            # string-based ForeignKey can be before the referenced Table is
+            # in the MetaData -- every other path resolves lazily, so the
+            # plain "could not find table" message gives no hint that the
+            # naming convention is what forced the resolution.
+            raise self._referred_resolution_error(err) from err
+
+    def _referred_resolution_error(self, err):
+        """Re-raise a failed target resolution as the same error type, saying
+        what actually required the foreign key to be resolvable.
+
+        The type is preserved so that existing
+        ``except NoReferencedTableError`` handling keeps working.
+
+        """
+        message = (
+            "Naming convention including the "
+            "%%(referred_column_0_name)s token requires the foreign key "
+            "target to be resolvable when the constraint is attached to "
+            "table '%s'; %s. Either define the referenced table before this "
+            "one, pass the target Column object to ForeignKey() rather than "
+            "a string, or use the %%(referred_table_name)s token, which is "
+            "read from the string and does not require resolution."
+            % (self.table.name, err.args[0])
+        )
+        if isinstance(err, exc.NoReferencedColumnError):
+            return exc.NoReferencedColumnError(
+                message, err.table_name, err.column_name
+            )
+        elif isinstance(err, exc.NoReferencedTableError):
+            return exc.NoReferencedTableError(message, err.table_name)
+        else:
+            return type(err)(message)
 
     def __getitem__(self, key):
         if key in self.convention:

--- a/test/sql/test_metadata.py
+++ b/test/sql/test_metadata.py
@@ -6280,6 +6280,63 @@ class NamingConventionTest(fixtures.TestBase, AssertsCompiledSQL):
         )
         eq_(fks[0].name, "fk_id")
 
+    def test_fk_ref_unresolvable_target_reports_the_convention(self):
+        """test #5350
+
+        A ``referred_column_*`` token resolves the ForeignKey while the name
+        is being built, which happens when the constraint is attached. For a
+        string target that can be before the referenced Table exists, and the
+        plain resolution error says nothing about the convention that
+        required it.
+
+        """
+
+        metadata = MetaData(
+            naming_convention={"fk": "fk_%(referred_column_0_name)s"}
+        )
+
+        with expect_raises_message(
+            exc.NoReferencedTableError,
+            r"Naming convention including the "
+            r"%\(referred_column_0_name\)s token requires the foreign key "
+            r"target to be resolvable when the constraint is attached to "
+            r"table 'b'; Foreign key associated with column 'b.aid' "
+            r"could not find table 'a'.*"
+            r"use the %\(referred_table_name\)s token",
+        ):
+            Table(
+                "b",
+                metadata,
+                Column("id", Integer, primary_key=True),
+                Column("aid", ForeignKey("a.id")),
+            )
+
+    def test_fk_ref_referred_table_name_needs_no_resolution(self):
+        """test #5350
+
+        ``%(referred_table_name)s`` is read out of the string target, so it
+        does not force resolution and keeps working when the referenced
+        table is defined later.
+
+        """
+
+        metadata = MetaData(
+            naming_convention={"fk": "fk_%(referred_table_name)s"}
+        )
+
+        b = Table(
+            "b",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("aid", ForeignKey("a.id")),
+        )
+        Table("a", metadata, Column("id", Integer, primary_key=True))
+
+        fks = list(
+            c for c in b.constraints if isinstance(c, ForeignKeyConstraint)
+        )
+        eq_(fks[0].name, "fk_a")
+
     def test_custom(self):
         def key_hash(const, table):
             return "HASH_%s" % table.name


### PR DESCRIPTION
Fixes: #5350

### Description

A naming convention using `%(referred_column_0_name)s` reads `fk.column` while the constraint name is being built, which happens when the constraint is attached to its table. For a string-based `ForeignKey` that can be before the referenced `Table` exists in the `MetaData` — every other path resolves the target lazily, which is why the same models work when the referenced table is declared first, or when the convention uses no `referred_` token.

Isolated on 2.1.0b4, with the child table declared first:

| case | result |
|---|---|
| no naming convention | works |
| convention without `referred_*` | works |
| convention with `referred_column_0_name` | `NoReferencedTableError` |

The error named the column and the missing table and said nothing about the naming convention, so there was nothing in the message to lead anyone to the cause.

This re-raises it naming the token and the three ways out: declare the referenced table first, pass the `Column` object rather than a string, or use `%(referred_table_name)s`, which is read from the string and needs no resolution. The exception type and its `table_name` / `column_name` attributes are unchanged, so existing `except NoReferencedTableError` handling keeps working.

Scoped to the error message per the note on the issue that the naming mechanics are not expected to be easy to change here.

### Verification

- new tests pass; revert-checked — stashing only `naming.py` fails `test_fk_ref_unresolvable_target_reports_the_convention` with the old bare message
- `test/sql/` + `test/base/`: 9037 passed
- `test/orm/declarative/`: 2850 passed
- `black --check` and `flake8` (project config) clean

Supersedes #13498, which was auto-closed because its description was left as the template with an empty `Fixes:` line.
