### PR TITLE
Add with_hint() to Exists

### DIFF
--- a/doc/build/changelog/unreleased_21/8311.rst
+++ b/doc/build/changelog/unreleased_21/8311.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: feature, sql
+    :tickets: 8311
+
+    Added :meth:`_sql.Exists.with_hint`, allowing table hints to be applied to
+    the SELECT statement contained by an :class:`_sql.Exists` construct.

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -7316,6 +7316,35 @@ class Exists(UnaryExpression[bool]):
         e.element = self._regroup(lambda element: element.select_from(*froms))
         return e
 
+    def with_hint(
+        self,
+        selectable: _FromClauseArgument,
+        text: str,
+        dialect_name: str = "*",
+    ) -> Self:
+        r"""Return a new :class:`_expression.Exists` construct with a
+        table hint applied to its contained SELECT statement.
+
+        This method mirrors the :meth:`_sql.Select.with_hint` method of the
+        underlying :class:`_sql.Select`. For example::
+
+            stmt = exists(1).select_from(table).with_hint(
+                table, "WITH (NOLOCK)", "mssql"
+            )
+
+        .. versionadded:: 2.1
+
+        .. seealso::
+
+            :meth:`_sql.Select.with_hint`
+
+        """
+        e = self._clone()
+        e.element = self._regroup(
+            lambda element: element.with_hint(selectable, text, dialect_name)
+        )
+        return e
+
     def where(self, *clause: _ColumnExpressionArgument[bool]) -> Self:
         """Return a new :func:`_expression.exists` construct with the
         given expression added to

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -7329,7 +7329,13 @@ class Exists(UnaryExpression[bool]):
         underlying :class:`_sql.Select`. For example::
 
             stmt = (
-                exists(1).select_from(table).with_hint(table, "WITH (NOLOCK)", "mssql")
+                exists(1)
+                .select_from(table)
+                .with_hint(
+                    table,
+                    "WITH (NOLOCK)",
+                    "mssql",
+                )
             )
 
         .. versionadded:: 2.1

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -7328,8 +7328,8 @@ class Exists(UnaryExpression[bool]):
         This method mirrors the :meth:`_sql.Select.with_hint` method of the
         underlying :class:`_sql.Select`. For example::
 
-            stmt = exists(1).select_from(table).with_hint(
-                table, "WITH (NOLOCK)", "mssql"
+            stmt = (
+                exists(1).select_from(table).with_hint(table, "WITH (NOLOCK)", "mssql")
             )
 
         .. versionadded:: 2.1

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -1359,6 +1359,21 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
             "HAVING count(myothertable.otherid) > :count_2)",
         )
 
+    def test_exists_with_hint(self):
+        stmt = table1.select().where(
+            exists(1)
+            .select_from(table2)
+            .with_hint(table2, "WITH (NOLOCK)", "mssql")
+        )
+
+        self.assert_compile(
+            stmt,
+            "SELECT mytable.myid, mytable.name, mytable.description "
+            "FROM mytable WHERE EXISTS (SELECT 1 FROM myothertable "
+            "WITH (NOLOCK))",
+            dialect=mssql.dialect(),
+        )
+
     def test_where_subquery(self):
         s = (
             select(addresses.c.street)

--- a/test/sql/test_selectable.py
+++ b/test/sql/test_selectable.py
@@ -3990,6 +3990,7 @@ class ResultMapTest(fixtures.TestBase):
         lambda e, t: e.correlate(t),
         lambda e, t: e.correlate_except(t),
         lambda e, t: e.select_from(t),
+        lambda e, t: e.with_hint(t, "hint", "mssql"),
         lambda e, t: e.where(t.c.y == 5),
         argnames="testcase",
     )


### PR DESCRIPTION
This adds `Exists.with_hint()` by applying the hint to the SELECT contained by the EXISTS expression. It includes MSSQL compilation coverage and extends the existing regrouping tests so the method remains generative and handles compound selects consistently with the other `Exists` modifiers.

Fixes #8311