### PR TITLE
Add per-statement timeout for asyncpg

### DIFF
--- a/doc/build/changelog/unreleased_20/7604.rst
+++ b/doc/build/changelog/unreleased_20/7604.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: feature, postgresql
+    :tickets: 7604
+
+    Added the ``asyncpg_timeout`` execution option to the asyncpg dialect,
+    allowing a timeout in seconds to be passed to asyncpg for individual
+    statement and executemany executions, including server-side cursors.

--- a/lib/sqlalchemy/dialects/postgresql/asyncpg.py
+++ b/lib/sqlalchemy/dialects/postgresql/asyncpg.py
@@ -30,6 +30,26 @@ This dialect should normally be used only with the
 
 .. versionadded:: 1.4
 
+.. _asyncpg_statement_timeout:
+
+Per-Statement Timeout
+---------------------
+
+The ``asyncpg_timeout`` execution option may be used to pass a timeout, in
+seconds, to asyncpg for an individual statement execution::
+
+    from sqlalchemy import text
+
+    async with engine.connect() as connection:
+        result = await connection.execute(
+            text("select pg_sleep(10)"),
+            execution_options={"asyncpg_timeout": 1},
+        )
+
+The option also applies to executemany operations and server-side cursors.
+
+.. versionadded:: 2.0.54
+
 .. note::
 
     By default asyncpg does not decode the ``json`` and ``jsonb`` types and
@@ -481,6 +501,10 @@ class PGExecutionContext_asyncpg(PGExecutionContext):
             self.dialect._invalidate_schema_cache()
 
     def pre_exec(self):
+        self.cursor._asyncpg_timeout = self.execution_options.get(
+            "asyncpg_timeout"
+        )
+
         if self.isddl:
             self.dialect._invalidate_schema_cache()
 
@@ -511,7 +535,11 @@ class _AsyncpgTransaction(Protocol):
 
 class _AsyncpgConnection(Protocol):
     async def executemany(
-        self, operation: Any, seq_of_parameters: Sequence[Tuple[Any, ...]]
+        self,
+        operation: Any,
+        seq_of_parameters: Sequence[Tuple[Any, ...]],
+        *,
+        timeout: Optional[float] = None,
     ) -> Any: ...
 
     async def reload_schema_state(self) -> None: ...
@@ -538,7 +566,9 @@ class _AsyncpgConnection(Protocol):
 
 
 class _AsyncpgCursor(Protocol):
-    def fetch(self, size: int) -> Any: ...
+    async def fetch(
+        self, size: int, *, timeout: Optional[float] = None
+    ) -> Any: ...
 
 
 class AsyncAdapt_asyncpg_cursor(AsyncAdapt_dbapi_cursor):
@@ -547,6 +577,7 @@ class AsyncAdapt_asyncpg_cursor(AsyncAdapt_dbapi_cursor):
         "_arraysize",
         "_rowcount",
         "_invalidate_schema_cache_asof",
+        "_asyncpg_timeout",
     )
 
     _adapt_connection: AsyncAdapt_asyncpg_connection
@@ -563,6 +594,7 @@ class AsyncAdapt_asyncpg_cursor(AsyncAdapt_dbapi_cursor):
         self._arraysize = 1
         self._rowcount = -1
         self._invalidate_schema_cache_asof = 0
+        self._asyncpg_timeout = None
 
     def _handle_exception(self, error):
         self._adapt_connection._handle_exception(error)
@@ -599,10 +631,16 @@ class AsyncAdapt_asyncpg_cursor(AsyncAdapt_dbapi_cursor):
                     self._description = None
 
                 if self.server_side:
-                    self._cursor = await prepared_stmt.cursor(*parameters)
+                    self._cursor = await prepared_stmt.cursor(
+                        *parameters, timeout=self._asyncpg_timeout
+                    )
                     self._rowcount = -1
                 else:
-                    self._rows = deque(await prepared_stmt.fetch(*parameters))
+                    self._rows = deque(
+                        await prepared_stmt.fetch(
+                            *parameters, timeout=self._asyncpg_timeout
+                        )
+                    )
                     status = prepared_stmt.get_statusmsg()
 
                     reg = re.match(
@@ -647,7 +685,9 @@ class AsyncAdapt_asyncpg_cursor(AsyncAdapt_dbapi_cursor):
 
             try:
                 return await self._connection.executemany(
-                    operation, seq_of_parameters
+                    operation,
+                    seq_of_parameters,
+                    timeout=self._asyncpg_timeout,
                 )
             except Exception as error:
                 self._handle_exception(error)
@@ -677,7 +717,9 @@ class AsyncAdapt_asyncpg_ss_cursor(
 
     def _buffer_rows(self):
         assert self._cursor is not None
-        new_rows = await_(self._cursor.fetch(50))
+        new_rows = await_(
+            self._cursor.fetch(50, timeout=self._asyncpg_timeout)
+        )
         self._rowbuffer.extend(new_rows)
 
     def __aiter__(self):
@@ -710,7 +752,13 @@ class AsyncAdapt_asyncpg_ss_cursor(
         rb = self._rowbuffer
         lb = len(rb)
         if size > lb:
-            rb.extend(await_(self._cursor.fetch(size - lb)))
+            rb.extend(
+                await_(
+                    self._cursor.fetch(
+                        size - lb, timeout=self._asyncpg_timeout
+                    )
+                )
+            )
 
         return [rb.popleft() for _ in range(min(size, len(rb)))]
 
@@ -728,7 +776,9 @@ class AsyncAdapt_asyncpg_ss_cursor(
         # TODO: looks like we have to hand-roll some kind of batching here.
         # hardcoding for the moment but this should be improved.
         while True:
-            batch = await self._cursor.fetch(1000)
+            batch = await self._cursor.fetch(
+                1000, timeout=self._asyncpg_timeout
+            )
             if batch:
                 rows.extend(batch)
                 continue

--- a/test/dialect/postgresql/test_async_pg.py
+++ b/test/dialect/postgresql/test_async_pg.py
@@ -1,3 +1,4 @@
+import asyncio
 import random
 import uuid
 
@@ -303,6 +304,20 @@ class AsyncPgTest(fixtures.TestBase):
             await conn.rollback()
 
             eq_((await conn.execute(select(1))).scalar(), 1)
+
+    @async_test
+    async def test_per_statement_timeout(self, async_testing_engine):
+        engine = async_testing_engine()
+
+        async with engine.connect() as conn:
+            with expect_raises(asyncio.TimeoutError):
+                await conn.exec_driver_sql(
+                    "select pg_sleep(2)",
+                    execution_options={"asyncpg_timeout": 0.1},
+                )
+
+            await conn.rollback()
+            eq_((await conn.exec_driver_sql("select 1")).scalar(), 1)
 
     @async_test
     async def test_rollback_twice_no_problem(

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -1577,6 +1577,84 @@ $$ LANGUAGE plpgsql;
         eq_(cursor.rowcount, 1)
 
 
+class AsyncpgTimeoutTest(fixtures.TestBase):
+    def _adapt_connection(self, prepared_statement):
+        return mock.Mock(
+            _connection=mock.Mock(
+                executemany=mock.AsyncMock(return_value=None)
+            ),
+            _execute_mutex=asyncio.Lock(),
+            _transaction=mock.sentinel.transaction,
+            _prepare=mock.AsyncMock(return_value=(prepared_statement, ())),
+            _check_type_cache_invalidation=mock.AsyncMock(return_value=None),
+        )
+
+    def test_execution_option_is_applied_to_cursor(self):
+        context = object.__new__(asyncpg_dialect.PGExecutionContext_asyncpg)
+        context.cursor = mock.Mock()
+        context.dialect = mock.Mock(_invalidate_schema_cache_asof=0)
+        context.execution_options = {"asyncpg_timeout": 2.5}
+        context.isddl = False
+        context.compiled = None
+
+        context.pre_exec()
+
+        eq_(context.cursor._asyncpg_timeout, 2.5)
+
+    def test_timeout_is_passed_to_prepared_statement_fetch(self):
+        prepared_statement = mock.Mock(
+            fetch=mock.AsyncMock(return_value=[]),
+            get_statusmsg=mock.Mock(return_value="SELECT 0"),
+        )
+        cursor = asyncpg_dialect.AsyncAdapt_asyncpg_cursor(
+            self._adapt_connection(prepared_statement)
+        )
+        cursor._asyncpg_timeout = 2.5
+
+        asyncio.run(cursor._prepare_and_execute("select $1", (1,)))
+
+        eq_(
+            prepared_statement.fetch.await_args_list,
+            [mock.call(1, timeout=2.5)],
+        )
+
+    def test_timeout_is_passed_to_server_side_cursor(self):
+        raw_cursor = mock.Mock(fetch=mock.AsyncMock(return_value=[]))
+        prepared_statement = mock.Mock(
+            cursor=mock.AsyncMock(return_value=raw_cursor)
+        )
+        cursor = asyncpg_dialect.AsyncAdapt_asyncpg_ss_cursor(
+            self._adapt_connection(prepared_statement)
+        )
+        cursor._asyncpg_timeout = 3
+
+        asyncio.run(cursor._prepare_and_execute("select $1", (1,)))
+
+        eq_(
+            prepared_statement.cursor.await_args_list,
+            [mock.call(1, timeout=3)],
+        )
+
+        asyncio.run(cursor._all())
+
+        eq_(
+            raw_cursor.fetch.await_args_list,
+            [mock.call(1000, timeout=3)],
+        )
+
+    def test_timeout_is_passed_to_executemany(self):
+        adapt_connection = self._adapt_connection(mock.Mock())
+        cursor = asyncpg_dialect.AsyncAdapt_asyncpg_cursor(adapt_connection)
+        cursor._asyncpg_timeout = 4
+
+        asyncio.run(cursor._executemany("insert into t values ($1)", [(1,)]))
+
+        eq_(
+            adapt_connection._connection.executemany.await_args_list,
+            [mock.call("insert into t values ($1)", [(1,)], timeout=4)],
+        )
+
+
 class Psycopg3Test(fixtures.TestBase):
     __only_on__ = ("postgresql+psycopg",)
 


### PR DESCRIPTION
Fixes: #7604

### Description

Adds the `asyncpg_timeout` execution option requested in #7604 and passes it through to asyncpg for regular statement execution, executemany calls, and server-side cursor creation and fetches.

The change includes unit coverage for each adapter path, a PostgreSQL/asyncpg `pg_sleep()` integration test that verifies timeout and connection recovery, dialect documentation, and a 2.0 changelog entry.

Local verification:

- `pytest -q test/dialect/postgresql/test_dialect.py` — 112 passed, 8 skipped
- targeted asyncpg timeout unit tests — 4 passed
- Black and Flake8 on the changed Python files
- `git diff --check`