### PR TITLE
Skip reflection of foreign keys that reference a source column more than once

### DIFF
--- a/doc/build/changelog/unreleased_21/13509.rst
+++ b/doc/build/changelog/unreleased_21/13509.rst
@@ -1,0 +1,12 @@
+.. change::
+    :tags: bug, schema, reflection
+    :tickets: 13509
+
+    Fixed reflection so that a foreign key constraint which references the
+    same source column more than once is skipped with a warning rather than
+    raising :class:`.ArgumentError`, which previously prevented the rest of
+    the table from being reflected. Such constraints are legal in some
+    backends (e.g. PostgreSQL) but are not supported by
+    :class:`.ForeignKeyConstraint`; per the documented limitations of
+    reflection, unsupported structures should be skipped or partially
+    reflected rather than being fatal.

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -1790,6 +1790,16 @@ class Inspector(inspection.Inspectable["Inspector"]):
             ):
                 continue
 
+            if len(set(constrained_columns)) != len(constrained_columns):
+                util.warn(
+                    f"On reflected table {table.name}, skipping reflection of "
+                    "foreign key constraint "
+                    f"{conname}; one or more subject columns within "
+                    f"name(s) {', '.join(constrained_columns)} are reflected "
+                    "more than once, which is not supported"
+                )
+                continue
+
             referred_schema = fkey_d["referred_schema"]
             referred_table = fkey_d["referred_table"]
             referred_columns = fkey_d["referred_columns"]

--- a/test/engine/test_reflection.py
+++ b/test/engine/test_reflection.py
@@ -146,6 +146,56 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
         assert t1r.c.t2id.references(t2r.c.id)
         assert t1r.c.t3id.references(t3r.c.id)
 
+    def test_reflect_fk_duplicate_source_columns_skipped(
+        self, connection, metadata
+    ):
+        """reflection should skip an FK that names the same source column
+        twice, rather than failing the whole table (issue #13509)"""
+
+        meta = metadata
+        Table(
+            "profile_merges",
+            meta,
+            Column("profile_id", sa.String, primary_key=True),
+            Column("canonical_profile_id", sa.String, nullable=False),
+        )
+        Table(
+            "other",
+            meta,
+            Column("id", sa.Integer, primary_key=True),
+        )
+        meta.create_all(connection)
+
+        schema_name = None
+        fake_fks = {
+            (schema_name, "other"): [
+                {
+                    "name": "dup_fk",
+                    "constrained_columns": ["id", "id"],
+                    "referred_schema": None,
+                    "referred_table": "profile_merges",
+                    "referred_columns": [
+                        "profile_id",
+                        "canonical_profile_id",
+                    ],
+                    "options": {},
+                }
+            ]
+        }
+
+        with mock.patch.object(
+            Inspector, "get_multi_foreign_keys", return_value=fake_fks
+        ):
+            m2 = MetaData()
+            with expect_warnings(
+                r"On reflected table other, skipping reflection of foreign "
+                r"key constraint dup_fk; one or more subject columns within "
+                r"name\(s\) id, id are reflected more than once, which is "
+                r"not supported"
+            ):
+                t2 = Table("other", m2, autoload_with=connection)
+        eq_(t2.foreign_keys, set())
+
     def test_resolve_fks_false_table(self, connection, metadata):
         meta = metadata
         Table(


### PR DESCRIPTION
Fixes: #13509

### Description

PostgreSQL accepts a foreign key that names the same source column twice (e.g. `FOREIGN KEY (a, a) REFERENCES r (b, c)`). `ForeignKeyConstraint` does not support this form and raises `ArgumentError` in its constructor. Because reflection constructs the constraint while reflecting the table, one such constraint made the entire table unreflectable (`MetaData.reflect()`, `autoload_with`, and Alembic autogenerate all fail).

Per the documented "Limitations of Reflection", unsupported structures should be skipped or partially reflected rather than fatal. This change detects duplicate constrained columns in `Inspector._reflect_fk` and skips that constraint with a `SAWarning`, mirroring the existing skip path for `ConstraintColumnNotFoundError`, so the rest of the table still reflects.

### Change

`lib/sqlalchemy/engine/reflection.py` — in `_reflect_fk`, if the same source column appears more than once among the FK's constrained columns, warn and skip the constraint instead of raising.

### Tests

Added `test_reflect_fk_duplicate_source_columns_skipped` in `test/engine/test_reflection.py`, which reflects a table through a mocked `Inspector.get_multi_foreign_keys` returning a constraint with duplicate source columns, asserts the `SAWarning` is emitted, and that the reflected table ends up with no foreign keys (reflection completes).

Ran on SQLite backend: `test/engine/test_reflection.py` 109 passed; `test/sql/test_constraints.py` + `test/sql/test_metadata.py` 659 passed.