### PR TITLE
Skip reflected FK constraints with duplicate source columns

### DIFF
--- a/doc/build/changelog/unreleased_20/13509.rst
+++ b/doc/build/changelog/unreleased_20/13509.rst
@@ -1,0 +1,10 @@
+.. change::
+    :tags: bug, reflection
+    :tickets: 13509
+
+    Fixed issue in table reflection where a reflected foreign key constraint
+    whose list of constrained columns contained a duplicate column name, as
+    can occur with certain foreign key definitions on PostgreSQL, would raise
+    ``ArgumentError`` and abort reflection of the entire table. Such foreign
+    key constraints are now skipped, with a warning emitted, allowing the
+    rest of the table to reflect normally.

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -1780,6 +1780,16 @@ class Inspector(inspection.Inspectable["Inspector"]):
                 for c in fkey_d["constrained_columns"]
             ]
 
+            if len(set(constrained_columns)) != len(constrained_columns):
+                util.warn(
+                    f"On reflected table {table.name}, skipping reflection "
+                    "of foreign key constraint "
+                    f"{conname}; the constrained columns list "
+                    f"{constrained_columns!r} contains duplicate column "
+                    "names, which is not supported"
+                )
+                continue
+
             if (
                 exclude_columns
                 and set(constrained_columns).intersection(exclude_columns)

--- a/test/engine/test_reflection.py
+++ b/test/engine/test_reflection.py
@@ -146,6 +146,65 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
         assert t1r.c.t2id.references(t2r.c.id)
         assert t1r.c.t3id.references(t3r.c.id)
 
+    def test_fk_reflection_duplicate_constrained_columns(
+        self, connection, metadata
+    ):
+        """A reflected foreign key whose constrained columns list contains
+        a duplicate column name (as can happen with certain PostgreSQL FK
+        definitions) should be skipped with a warning rather than raising
+        ArgumentError and aborting reflection of the whole table.
+
+        .. seealso:: #13509
+
+        """
+        Table(
+            "dup_fk_parent",
+            metadata,
+            Column("id", sa.Integer, primary_key=True),
+            Column("other", sa.Integer),
+        )
+        Table(
+            "dup_fk_child",
+            metadata,
+            Column("a", sa.Integer),
+            Column("b", sa.Integer),
+        )
+        metadata.create_all(connection)
+
+        def fake_get_multi_foreign_keys(self, schema=None, **kw):
+            return {
+                (schema, "dup_fk_child"): [
+                    {
+                        "name": "fk_dup_cols",
+                        "constrained_columns": ["a", "a"],
+                        "referred_schema": None,
+                        "referred_table": "dup_fk_parent",
+                        "referred_columns": ["id", "other"],
+                        "options": {},
+                    }
+                ],
+                (schema, "dup_fk_parent"): [],
+            }
+
+        meta2 = MetaData()
+        with mock.patch.object(
+            Inspector,
+            "get_multi_foreign_keys",
+            fake_get_multi_foreign_keys,
+        ):
+            with expect_warnings(
+                r"On reflected table dup_fk_child, skipping reflection of "
+                r"foreign key constraint fk_dup_cols; the constrained "
+                r"columns list \['a', 'a'\] contains duplicate column "
+                r"names, which is not supported"
+            ):
+                meta2.reflect(connection)
+
+        child = meta2.tables["dup_fk_child"]
+        eq_(list(child.foreign_key_constraints), [])
+        in_("a", child.c)
+        in_("b", child.c)
+
     def test_resolve_fks_false_table(self, connection, metadata):
         meta = metadata
         Table(


### PR DESCRIPTION
Fixes #13509

## Root cause

`Inspector._reflect_fk()` in `lib/sqlalchemy/engine/reflection.py` builds a `ForeignKeyConstraint(constrained_columns, refspec, conname, ...)` from raw reflected foreign key data and only catches `exc.ConstraintColumnNotFoundError` around that call.

When the reflected `constrained_columns` list for a foreign key contains the same column name twice (as can happen with certain PostgreSQL FK definitions, e.g. `FOREIGN KEY (canonical_profile_id, canonical_profile_id) REFERENCES ...`), `ForeignKeyConstraint.__init__()` (`lib/sqlalchemy/sql/schema.py`) hits:

```python
if len(set(columns)) != len(refcolumns):
    if len(set(columns)) != len(columns):
        raise exc.ArgumentError(
            "ForeignKeyConstraint with duplicate source column "
            "references are not supported."
        )
```

Since `ArgumentError` isn't caught in `_reflect_fk`, it propagates out of `MetaData.reflect()` / `Table(..., autoload_with=...)`, aborting reflection of the entire table instead of just skipping the one unsupported constraint.

## Fix

Detect a duplicate in `constrained_columns` right after it's computed (before the referred-table is resolved, avoiding a wasted round trip), and skip that foreign key with a `util.warn(...)`, matching the existing "skip and warn" convention already used a few lines below for `ConstraintColumnNotFoundError`.

## Testing

Added `test_fk_reflection_duplicate_constrained_columns` to `test/engine/test_reflection.py`. It creates two real tables via a normal fixture/DDL, then monkeypatches `Inspector.get_multi_foreign_keys` (dialect-agnostic, so the test runs on the default SQLite test backend without needing a live PostgreSQL instance) to return a fabricated foreign key definition whose `constrained_columns` contains a duplicate, matching what PostgreSQL's own reflection would hand back for the FK described in the issue. The test asserts the expected warning is emitted and that the table still reflects successfully, without the invalid constraint.

- Confirmed the test **fails** prior to the fix: `meta2.reflect(connection)` raises `sqlalchemy.exc.ArgumentError: ForeignKeyConstraint with duplicate source column references are not supported.` (verified directly, not just via the test's warning-assertion wrapper).
- Confirmed the test **passes** after the fix.
- Ran the full `test/engine/test_reflection.py` module: 109 passed, 6 skipped (backend-specific, unrelated).
- Ran the full `test/engine/` + `test/sql/test_metadata.py` suites for regressions: 1408 passed, 112 skipped (backend-specific/unrelated), 0 failures.
- Ran `test/dialect/postgresql/test_reflection.py` (no live PostgreSQL available in this environment, but sanity-checks collection/non-DB-dependent tests): 33 passed.

Added a changelog entry at `doc/build/changelog/unreleased_20/13509.rst`.

This is a pure-Python fix in `lib/sqlalchemy/engine/reflection.py`; no compiled/Cython code is touched.