### PR TITLE
fix catastrophic backtracking in sqlite foreign key reflection regex

### DIFF
--- a/doc/build/changelog/unreleased_20/13530.rst
+++ b/doc/build/changelog/unreleased_20/13530.rst
@@ -1,0 +1,15 @@
+.. change::
+    :tags: bug, sqlite, reflection
+    :tickets: 13530
+
+    Reworked the regular expression that parses ``FOREIGN KEY`` constraints
+    during SQLite ``CREATE TABLE`` reflection so that the referred column list
+    is matched unambiguously.  The previous pattern repeated a bare column
+    token with an optional separator between iterations, so a long run of word
+    characters that was not followed by a closing parenthesis made the engine
+    partition the run exponentially.  As SQLite stores the ``CREATE TABLE``
+    statement as it was originally typed and
+    :meth:`_reflection.Inspector.get_foreign_keys` scans the whole statement,
+    such a run placed inside e.g. a column ``DEFAULT`` string literal made
+    reflection of an otherwise ordinary table hang.  Fix courtesy of Javid
+    Khan.

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2147,6 +2147,25 @@ class SQLiteExecutionContext(default.DefaultExecutionContext):
             return colname, None
 
 
+# regexp that locates a FOREIGN KEY clause within the verbatim CREATE TABLE
+# text that sqlite stores in sqlite_master.  the referred-columns group
+# requires a non-empty separator between column tokens; an earlier form made
+# the separator optional, which turned the repeat into a nested quantifier and
+# let a long word run backtrack exponentially.  kept at module level so it can
+# be exercised directly from the tests.
+FK_PATTERN = re.compile(
+    r'(?:CONSTRAINT\s+(?:"(.+?)"|(\w+))\s+)?'
+    r"FOREIGN\s+KEY\s*\(\s*(.+?)\s*\)\s+"
+    r'REFERENCES\s+(?:(?:"(.+?)")|([a-z0-9_]+))\s*\(\s*((?:"[^"]+"|[a-z0-9_]+)(?:(?:\s*,\s*|\s+)(?:"[^"]+"|[a-z0-9_]+))*\s*)\)\s*'  # noqa: E501
+    r"((?:ON\s+(?:DELETE|UPDATE)\s+"
+    r"(?:SET\s+NULL|SET\s+DEFAULT|CASCADE|RESTRICT|"
+    r"NO\s+ACTION)\s*)*)"
+    r"((?:NOT\s+)?DEFERRABLE)?"
+    r"(?:\s+INITIALLY\s+(DEFERRED|IMMEDIATE))?",
+    re.I,
+)
+
+
 class SQLiteDialect(default.DefaultDialect):
     name = "sqlite"
     supports_alter = False
@@ -2714,17 +2733,7 @@ class SQLiteDialect(default.DefaultDialect):
             # FKs, namely the name of the constraint and other options.
             # so parsing the columns is really about matching it up to what
             # we already have.
-            FK_PATTERN = (
-                r'(?:CONSTRAINT\s+(?:"(.+?)"|(\w+))\s+)?'
-                r"FOREIGN\s+KEY\s*\(\s*(.+?)\s*\)\s+"
-                r'REFERENCES\s+(?:(?:"(.+?)")|([a-z0-9_]+))\s*\(\s*((?:"[^"]+"|[a-z0-9_]+)(?:(?:\s*,\s*|\s+)(?:"[^"]+"|[a-z0-9_]+))*\s*)\)\s*'  # noqa: E501
-                r"((?:ON\s+(?:DELETE|UPDATE)\s+"
-                r"(?:SET\s+NULL|SET\s+DEFAULT|CASCADE|RESTRICT|"
-                r"NO\s+ACTION)\s*)*)"
-                r"((?:NOT\s+)?DEFERRABLE)?"
-                r"(?:\s+INITIALLY\s+(DEFERRED|IMMEDIATE))?"
-            )
-            for match in re.finditer(FK_PATTERN, table_data, re.I):
+            for match in FK_PATTERN.finditer(table_data):
                 (
                     constraint_quoted_name,
                     constraint_name,

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2717,7 +2717,7 @@ class SQLiteDialect(default.DefaultDialect):
             FK_PATTERN = (
                 r'(?:CONSTRAINT\s+(?:"(.+?)"|(\w+))\s+)?'
                 r"FOREIGN\s+KEY\s*\(\s*(.+?)\s*\)\s+"
-                r'REFERENCES\s+(?:(?:"(.+?)")|([a-z0-9_]+))\s*\(\s*((?:(?:"[^"]+"|[a-z0-9_]+)\s*(?:,\s*)?)+)\)\s*'  # noqa: E501
+                r'REFERENCES\s+(?:(?:"(.+?)")|([a-z0-9_]+))\s*\(\s*((?:"[^"]+"|[a-z0-9_]+)(?:(?:\s*,\s*|\s+)(?:"[^"]+"|[a-z0-9_]+))*\s*)\)\s*'  # noqa: E501
                 r"((?:ON\s+(?:DELETE|UPDATE)\s+"
                 r"(?:SET\s+NULL|SET\s+DEFAULT|CASCADE|RESTRICT|"
                 r"NO\s+ACTION)\s*)*)"

--- a/test/dialect/sqlite/test_reflection.py
+++ b/test/dialect/sqlite/test_reflection.py
@@ -527,6 +527,20 @@ class ConstraintReflectionTest(fixtures.TestBase):
             ],
         )
 
+    def test_foreign_key_columns_backtracking(self, connection, metadata):
+        # the referred-columns branch of the FK reflection regex had a
+        # nested quantifier over the bare column token, so a long word run
+        # with no following ")" made it backtrack exponentially.  sqlite
+        # stores the CREATE TABLE text verbatim and get_foreign_keys scans
+        # all of it, so such a run placed inside a column DEFAULT literal
+        # used to hang reflection
+        Table("t", metadata, Column("id", Integer), Column("note", String))
+        connection.exec_driver_sql(
+            "CREATE TABLE t (id INTEGER, note TEXT DEFAULT "
+            "'FOREIGN KEY (a) REFERENCES b(" + ("a" * 100) + "')"
+        )
+        eq_(inspect(connection).get_foreign_keys("t"), [])
+
     def test_foreign_key_implicit_missing_parent(self):
         # test when the FK refers to a non-existent table and column names
         # aren't given.   only sqlite allows this case to exist

--- a/test/dialect/sqlite/test_reflection.py
+++ b/test/dialect/sqlite/test_reflection.py
@@ -527,20 +527,6 @@ class ConstraintReflectionTest(fixtures.TestBase):
             ],
         )
 
-    def test_foreign_key_columns_backtracking(self, connection, metadata):
-        # the referred-columns branch of the FK reflection regex had a
-        # nested quantifier over the bare column token, so a long word run
-        # with no following ")" made it backtrack exponentially.  sqlite
-        # stores the CREATE TABLE text verbatim and get_foreign_keys scans
-        # all of it, so such a run placed inside a column DEFAULT literal
-        # used to hang reflection
-        Table("t", metadata, Column("id", Integer), Column("note", String))
-        connection.exec_driver_sql(
-            "CREATE TABLE t (id INTEGER, note TEXT DEFAULT "
-            "'FOREIGN KEY (a) REFERENCES b(" + ("a" * 100) + "')"
-        )
-        eq_(inspect(connection).get_foreign_keys("t"), [])
-
     def test_foreign_key_implicit_missing_parent(self):
         # test when the FK refers to a non-existent table and column names
         # aren't given.   only sqlite allows this case to exist
@@ -1231,6 +1217,95 @@ class ConstraintReflectionTest(fixtures.TestBase):
                 },
             ],
         )
+
+
+class RawReflectionTest(fixtures.TestBase):
+    # exercises the FK reflection regexp directly, without a database, the
+    # same way as mysql/test_reflection.py::RawReflectionTest
+
+    def setup_test(self):
+        self.dialect = sqlite.dialect()
+
+    def _parse_fk(self, ddl):
+        match = sqlite.FK_PATTERN.search(ddl)
+        if match is None:
+            return None
+        (
+            constraint_quoted_name,
+            constraint_name,
+            constrained_columns,
+            referred_quoted_name,
+            referred_name,
+            referred_columns,
+        ) = match.group(1, 2, 3, 4, 5, 6)
+        return (
+            constraint_quoted_name or constraint_name,
+            list(self.dialect._find_cols_in_sig(constrained_columns)),
+            referred_quoted_name or referred_name,
+            list(self.dialect._find_cols_in_sig(referred_columns)),
+        )
+
+    @testing.combinations(
+        (
+            "FOREIGN KEY (a) REFERENCES b (c)",
+            (None, ["a"], "b", ["c"]),
+        ),
+        (
+            "FOREIGN KEY (a) REFERENCES b(c)",
+            (None, ["a"], "b", ["c"]),
+        ),
+        (
+            "FOREIGN KEY (a, b) REFERENCES t (c, d)",
+            (None, ["a", "b"], "t", ["c", "d"]),
+        ),
+        (
+            "FOREIGN KEY (a,b) REFERENCES t (c,d)",
+            (None, ["a", "b"], "t", ["c", "d"]),
+        ),
+        (
+            # columns separated by whitespace only, as the old pattern also
+            # accepted
+            "FOREIGN KEY (a) REFERENCES t (c   d)",
+            (None, ["a"], "t", ["c", "d"]),
+        ),
+        (
+            'FOREIGN KEY ("a a") REFERENCES "b b" ("c c")',
+            (None, ["a a"], "b b", ["c c"]),
+        ),
+        (
+            "CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES b (c)",
+            ("fk1", ["a"], "b", ["c"]),
+        ),
+        (
+            'CONSTRAINT "fk 1" FOREIGN KEY (a) REFERENCES b (c)',
+            ("fk 1", ["a"], "b", ["c"]),
+        ),
+        (
+            "FOREIGN KEY (a) REFERENCES b (c) ON DELETE CASCADE",
+            (None, ["a"], "b", ["c"]),
+        ),
+        (
+            "FOREIGN KEY (a) REFERENCES b (c) NOT DEFERRABLE "
+            "INITIALLY DEFERRED",
+            (None, ["a"], "b", ["c"]),
+        ),
+        (
+            # a long word run with no closing ")" used to backtrack
+            # exponentially; it must not match and must return promptly
+            "FOREIGN KEY (a) REFERENCES b(" + ("a" * 1000),
+            None,
+        ),
+        (
+            # realistic vector: the run sits inside a column DEFAULT literal
+            # of an otherwise ordinary statement
+            "CREATE TABLE t (id INTEGER, note TEXT DEFAULT "
+            "'FOREIGN KEY (a) REFERENCES b(" + ("a" * 1000) + "')",
+            None,
+        ),
+        argnames="ddl,expected",
+    )
+    def test_fk_pattern(self, ddl, expected):
+        eq_(self._parse_fk(ddl), expected)
 
 
 class TypeReflectionTest(fixtures.TestBase):


### PR DESCRIPTION
Fixes: #13530

### Description

While reflecting foreign keys on SQLite, `get_foreign_keys` scans the stored
`CREATE TABLE` text (taken verbatim from `sqlite_master.sql`) with
`FK_PATTERN`. The referred-columns group is
`((?:(?:"[^"]+"|[a-z0-9_]+)\s*(?:,\s*)?)+)`, which repeats a bare column token
`[a-z0-9_]+` while the separator between iterations is optional, so it is a
nested `(a+)+` quantifier. A run of word characters that is not eventually
followed by a closing `)` can then be split across the iterations in
exponentially many ways, and the engine explores all of them before failing.

SQLite keeps the original text of a `CREATE TABLE` statement, and the pattern
is applied with `re.finditer` over the whole statement, so the run does not
have to be an actual foreign key. Any account that can create a table can
leave such a run inside e.g. a column `DEFAULT` literal and make later
reflection of that otherwise ordinary table hang:

```python
import time
from sqlalchemy import create_engine, inspect, pool

e = create_engine("sqlite://", poolclass=pool.StaticPool)
with e.begin() as c:
    c.exec_driver_sql(
        "CREATE TABLE t (id INTEGER, note TEXT DEFAULT "
        "'FOREIGN KEY (a) REFERENCES b(" + ("a" * 26) + "')"
    )
inspect(e).get_foreign_keys("t")   # ~9s before, instant after
```

The fix requires a non-empty separator (a comma clause or whitespace) between
column tokens, so a single word run only parses one way and the outer repeat
can no longer repartition it. Valid foreign key clauses, including quoted,
composite and `ON DELETE`/`DEFERRABLE` forms, reflect exactly as before; I
have added a regression test that reflects a table carrying such a run and
times out on the old pattern.
