### PR TITLE
Fix __allow_unmapped__ not honored for Column/MappedColumn on mixins

### DIFF
--- a/doc/build/changelog/unreleased_21/9369.rst
+++ b/doc/build/changelog/unreleased_21/9369.rst
@@ -1,0 +1,11 @@
+.. change::
+    :tags: bug, orm
+    :tickets: 9369
+
+    Fixed bug in Declarative where ``__allow_unmapped__`` was not honored for
+    a :class:`_schema.Column` or :class:`_orm.MappedColumn` object inherited
+    from a mixin class and paired with a non-``Mapped[]`` (bare) type
+    annotation. Such an annotation would unconditionally raise
+    ``MappedAnnotationError`` even when ``__allow_unmapped__ = True`` was set
+    on the mapped class or a superclass, since the annotation-collection path
+    used for mixin attributes did not consult the flag.

--- a/lib/sqlalchemy/orm/decl_base.py
+++ b/lib/sqlalchemy/orm/decl_base.py
@@ -1430,7 +1430,11 @@ class _DeclarativeMapperConfig(_MapperConfig, _ClassScanAbstractConfig):
                     continue
 
                 collected_annotation = self._collect_annotation(
-                    name, annotation, originating_class, True, obj
+                    name,
+                    annotation,
+                    originating_class,
+                    not self.allow_unmapped_annotations,
+                    obj,
                 )
                 obj = (
                     collected_annotation.attr_value
@@ -1452,7 +1456,11 @@ class _DeclarativeMapperConfig(_MapperConfig, _ClassScanAbstractConfig):
                     continue
 
                 collected_annotation = self._collect_annotation(
-                    name, annotation, originating_class, True, obj
+                    name,
+                    annotation,
+                    originating_class,
+                    not self.allow_unmapped_annotations,
+                    obj,
                 )
                 obj = (
                     collected_annotation.attr_value

--- a/test/orm/declarative/test_typed_mapping.py
+++ b/test/orm/declarative/test_typed_mapping.py
@@ -490,6 +490,23 @@ class MappedColumnTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
             status: int
 
+    def test_allow_unmapped_column_on_mixin(self, decl_base):
+        """test #9369"""
+
+        class Mixin:
+            # a bare (non-``Mapped[]``) annotation paired with a plain
+            # ``Column``, inherited from a mixin.  this goes through
+            # _produce_column_copies(), which previously hardcoded
+            # ``expect_mapped=True`` and ignored __allow_unmapped__.
+            id: int = Column(Integer, primary_key=True)
+            status: int = Column(Integer)
+
+        class MyClass(Mixin, decl_base):
+            __tablename__ = "mytable"
+            __allow_unmapped__ = True
+
+        eq_(MyClass.__table__.c.keys(), ["id", "status"])
+
     def test_allow_unmapped_on_base(self):
         class Base(DeclarativeBase):
             __allow_unmapped__ = True


### PR DESCRIPTION
Fixes #9369

`_produce_column_copies()`, used when a `Column` or `MappedColumn` is inherited from a mixin/non-declarative base and copied onto the class being mapped, calls `_collect_annotation()` with `expect_mapped` hardcoded to `True` at both of its call sites. This bypasses `self.allow_unmapped_annotations` entirely, so a bare (non-`Mapped[]`) type-annotated attribute paired with such a column — inherited from a mixin — raises `MappedAnnotationError` even when `__allow_unmapped__ = True` is set on the mapped class or a superclass, despite the error's own text claiming that flag should suppress it:

```python
class Base(DeclarativeBase):
    __allow_unmapped__ = True

class Mixin:
    id: int = Column(Integer, primary_key=True)

class MyModel(Mixin, Base):
    __tablename__ = "my_model"
    # currently raises MappedAnnotationError despite __allow_unmapped__
```

By contrast, the equivalent path for attributes declared directly on the mapped class passes `expect_mapped=None`, which correctly defers to the flag via the dynamic computation already present in `_collect_annotation`.

## Changes
- Pass `not self.allow_unmapped_annotations` instead of a hardcoded `True` at both `_produce_column_copies()` call sites, preserving the strict default while honoring the flag, matching the direct-attribute path's behavior.
- Added a regression test (`test_allow_unmapped_column_on_mixin`) alongside the existing `test_allow_unmapped_on_mixin`/`test_allow_unmapped_cols` tests.
- Added a changelog entry.

## Test plan
- [x] Reproduced the exact repro from the issue against current `main`, confirmed fixed
- [x] Confirmed the strict default (no `__allow_unmapped__`) still correctly raises `MappedAnnotationError` for the same mixin shape — no over-broadening
- [x] New test fails on unmodified `main` and passes with the fix
- [x] `pytest test/orm/declarative/` — 2852 passed
- [x] `pytest test/orm/` (full ORM suite) — 10937 passed
- [x] `flake8` / `black --check` clean on both changed files