### PR TITLE
Handle an empty identifier in IdentifierPreparer.quote()

### DIFF
--- a/doc/build/changelog/unreleased_21/13535.rst
+++ b/doc/build/changelog/unreleased_21/13535.rst
@@ -1,0 +1,10 @@
+.. change::
+    :tags: bug, sql
+    :tickets: 13535
+
+    Fixed issue where :meth:`.IdentifierPreparer.quote` would raise
+    ``IndexError`` when given an empty string, as the check for an illegal
+    initial character indexed the value without testing its length.  An empty
+    identifier is now treated as requiring quotes, which is the form the
+    database itself holds; this is reachable through reflection, as SQLite
+    accepts a table created with an empty name.

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -8090,6 +8090,10 @@ class IdentifierPreparer:
 
     def _requires_quotes(self, value: str) -> bool:
         """Return True if the given identifier requires quoting."""
+        if not value:
+            # an empty identifier has no unquoted form; it also has no first
+            # character, which the illegal-initial test below would index
+            return True
         lc_value = value.lower()
         return (
             lc_value in self.reserved_words

--- a/test/sql/test_quote.py
+++ b/test/sql/test_quote.py
@@ -20,6 +20,7 @@ from sqlalchemy.testing import AssertsCompiledSQL
 from sqlalchemy.testing import eq_
 from sqlalchemy.testing import fixtures
 from sqlalchemy.testing import is_
+from sqlalchemy.testing import is_true
 from sqlalchemy.testing.util import picklers
 
 
@@ -874,6 +875,18 @@ class QuoteTest(fixtures.TestBase, AssertsCompiledSQL):
 
 class PreparerTest(fixtures.TestBase):
     """Test the db-agnostic quoting services of IdentifierPreparer."""
+
+    def test_quote_empty_identifier(self):
+        """an empty identifier has no unquoted form, and no first character
+        for the illegal-initial-character test to look at.
+
+        reflection can produce one: SQLite accepts CREATE TABLE "" (...).
+
+        """
+        prep = compiler.IdentifierPreparer(default.DefaultDialect())
+
+        eq_(prep.quote(""), '""')
+        is_true(prep._requires_quotes(""))
 
     def test_unformat(self):
         prep = compiler.IdentifierPreparer(default.DefaultDialect())


### PR DESCRIPTION
Fixes #13535.

### The bug

`_requires_quotes` tests the initial character of an identifier without first checking that there is one:

```python
or value[0] in self.illegal_initial_characters
```

so `IdentifierPreparer.quote("")` raised `IndexError: string index out of range` from inside the compiler — not a result, and not an error anyone could act on.

The reason this is worth more than "don't use a blank name" is that **reflection can hand you one**. SQLite accepts `CREATE TABLE "" (...)`, `MetaData.reflect()` reflects it under the name `""`, and only when the reflected table is used does the `IndexError` appear:

```python
with e.begin() as c:
    c.exec_driver_sql('CREATE TABLE "" (c INTEGER)')

md = MetaData()
md.reflect(bind=e)        # fine — md.tables has ''
select(md.tables[""]).compile(e)   # IndexError
```

This is the same failure reported in #5919, where a naming convention produced a blank constraint name. That was fixed on the producing side; the preparer itself still indexed past the end of the string, so any other route to a blank identifier reached it again.

### The change

An empty identifier has no unquoted form, so it is treated as requiring quotes and renders as `""` — the form the database itself holds. The reflect-then-query round trip then works: `SELECT "".c FROM ""`.

Four lines, and no behaviour changes for a non-empty identifier: the early return only fires on `""`, which previously could not reach the end of the function at all.

### Why quoting rather than refusing

`Column("")` already refuses a blank name — *"Column must be constructed with a non-blank name or assign a non-blank .name"* — so there is a stated policy in one place, and refusing at `Table` construction would match it. I did not do that here, because it would leave a reflected table permanently unusable and would need reflection to skip or rename it, which is a design decision rather than a bug fix. This PR only stops the preparer from reading past the end of the string; if you would rather blank names were rejected up front instead, say so on #13535 and I will redo it that way.

### Tests

`PreparerTest.test_quote_empty_identifier` in `test/sql/test_quote.py`.

- **Revert-checked**: with `compiler.py` restored to `main` and the test kept, exactly that one test fails, with the `IndexError` above; the other 65 pass.
- `pytest test/sql` — **8307 passed, 354 skipped**, against 8306 passed on an unmodified tree (the one added test).
- Verified end to end on the reproduction from the issue: reflection, compile, execute and `CreateTable` all succeed.

Tested on SQLite / pysqlite 3.50.4, Python 3.14.6, Windows.

---

*Written with assistance from Claude (Opus 5); the diagnosis, the fix and the results above were run and checked by me.*
