### PR TITLE
Add SQL APPLY constructs

### DIFF
--- a/doc/build/changelog/unreleased_21/5133.rst
+++ b/doc/build/changelog/unreleased_21/5133.rst
@@ -1,0 +1,12 @@
+.. change::
+    :tags: usecase, sql
+    :tickets: 5133
+
+    Added first-class support for ``CROSS APPLY`` and ``OUTER APPLY`` through
+    the new :class:`_sql.Apply` construct and the
+    :func:`_sql.cross_apply` / :func:`_sql.outer_apply` constructors.  The
+    corresponding :meth:`_sql.Selectable.cross_apply` and
+    :meth:`_sql.Selectable.outer_apply` methods preserve lateral correlation
+    while allowing an APPLY expression to be joined without an ``ON`` clause,
+    supporting SQL Server and Oracle APPLY syntax without overloading the
+    existing :class:`_sql.Lateral` construct.

--- a/doc/build/core/selectable.rst
+++ b/doc/build/core/selectable.rst
@@ -57,9 +57,13 @@ the :func:`_sql.alias` function is usually invoked via the
 
 .. autofunction:: cte
 
+.. autofunction:: cross_apply
+
 .. autofunction:: join
 
 .. autofunction:: lateral
+
+.. autofunction:: outer_apply
 
 .. autofunction:: outerjoin
 
@@ -74,6 +78,9 @@ The classes here are generated using the constructors listed at
 :ref:`fromclause_modifier_constructors`.
 
 .. autoclass:: Alias
+   :members:
+
+.. autoclass:: Apply
    :members:
 
 .. autoclass:: AliasedReturnsRows

--- a/doc/build/tutorial/data_select.rst
+++ b/doc/build/tutorial/data_select.rst
@@ -1140,6 +1140,46 @@ When using :meth:`_expression.Select.lateral`, the behavior of
 
 
 
+.. _tutorial_apply_correlation:
+
+APPLY correlation
+~~~~~~~~~~~~~~~~~
+
+SQL Server and Oracle provide ``CROSS APPLY`` and ``OUTER APPLY`` as a form
+of lateral correlation.  SQLAlchemy represents these expressions with the
+:class:`_expression.Apply` construct, created using
+:meth:`_expression.Selectable.cross_apply` or
+:meth:`_expression.Selectable.outer_apply`.  The construct is placed on the
+right side of :meth:`_expression.FromClause.join` without an ``ON`` clause::
+
+    >>> address_apply = (
+    ...     select(func.count(address_table.c.id).label("address_count"))
+    ...     .where(user_table.c.id == address_table.c.user_id)
+    ...     .cross_apply(name="address_apply")
+    ... )
+    >>> stmt = select(user_table.c.name, address_apply.c.address_count).select_from(
+    ...     user_table.join(address_apply)
+    ... )
+    >>> print(stmt)
+    {printsql}SELECT user_account.name, address_apply.address_count
+    FROM user_account CROSS APPLY (SELECT count(address.id) AS address_count
+    FROM address
+    WHERE user_account.id = address.user_id) AS address_apply
+
+``OUTER APPLY`` is produced in the same way using
+:meth:`_expression.Selectable.outer_apply`.  The standalone
+:func:`_expression.cross_apply` and :func:`_expression.outer_apply`
+constructors are also available.
+
+.. seealso::
+
+    :class:`_expression.Apply`
+
+    :func:`_expression.cross_apply`
+
+    :func:`_expression.outer_apply`
+
+
 .. _tutorial_union:
 
 UNION, UNION ALL and other set operations

--- a/lib/sqlalchemy/__init__.py
+++ b/lib/sqlalchemy/__init__.py
@@ -96,6 +96,7 @@ from .sql.expression import AliasedReturnsRows as AliasedReturnsRows
 from .sql.expression import all_ as all_
 from .sql.expression import and_ as and_
 from .sql.expression import any_ as any_
+from .sql.expression import Apply as Apply
 from .sql.expression import asc as asc
 from .sql.expression import between as between
 from .sql.expression import BinaryExpression as BinaryExpression
@@ -118,6 +119,7 @@ from .sql.expression import ColumnCollection as ColumnCollection
 from .sql.expression import ColumnElement as ColumnElement
 from .sql.expression import ColumnOperators as ColumnOperators
 from .sql.expression import CompoundSelect as CompoundSelect
+from .sql.expression import cross_apply as cross_apply
 from .sql.expression import CTE as CTE
 from .sql.expression import cte as cte
 from .sql.expression import custom_op as custom_op
@@ -182,6 +184,7 @@ from .sql.expression import nullslast as nullslast
 from .sql.expression import Operators as Operators
 from .sql.expression import or_ as or_
 from .sql.expression import OrderByList as OrderByList
+from .sql.expression import outer_apply as outer_apply
 from .sql.expression import outerjoin as outerjoin
 from .sql.expression import outparam as outparam
 from .sql.expression import Over as Over

--- a/lib/sqlalchemy/sql/__init__.py
+++ b/lib/sqlalchemy/sql/__init__.py
@@ -39,6 +39,7 @@ from .expression import column as column
 from .expression import ColumnCollection as ColumnCollection
 from .expression import ColumnElement as ColumnElement
 from .expression import CompoundSelect as CompoundSelect
+from .expression import cross_apply as cross_apply
 from .expression import cte as cte
 from .expression import Delete as Delete
 from .expression import delete as delete
@@ -82,6 +83,7 @@ from .expression import nulls_last as nulls_last
 from .expression import nullsfirst as nullsfirst
 from .expression import nullslast as nullslast
 from .expression import or_ as or_
+from .expression import outer_apply as outer_apply
 from .expression import outerjoin as outerjoin
 from .expression import outparam as outparam
 from .expression import over as over

--- a/lib/sqlalchemy/sql/_selectable_constructors.py
+++ b/lib/sqlalchemy/sql/_selectable_constructors.py
@@ -21,6 +21,8 @@ from ._typing import _ColumnsClauseArgument
 from ._typing import _no_kw
 from .elements import ColumnClause
 from .selectable import Alias
+from .selectable import Apply
+from .selectable import ApplyFromClause
 from .selectable import CompoundSelect
 from .selectable import Exists
 from .selectable import FromClause
@@ -353,6 +355,34 @@ def lateral(
 
     """
     return Lateral._factory(selectable, name=name)
+
+
+def cross_apply(
+    selectable: Union[SelectBase, _FromClauseArgument],
+    name: Optional[str] = None,
+) -> ApplyFromClause:
+    """Return an :class:`_expression.Apply` that renders ``CROSS APPLY``.
+
+    The object is used as the right side of a join and, like
+    :class:`_expression.Lateral`, may correlate to FROM clauses on its left.
+
+    .. versionadded:: 2.1
+    """
+    return Apply._factory(selectable, isouter=False, name=name)
+
+
+def outer_apply(
+    selectable: Union[SelectBase, _FromClauseArgument],
+    name: Optional[str] = None,
+) -> ApplyFromClause:
+    """Return an :class:`_expression.Apply` that renders ``OUTER APPLY``.
+
+    The object is used as the right side of a join and, like
+    :class:`_expression.Lateral`, may correlate to FROM clauses on its left.
+
+    .. versionadded:: 2.1
+    """
+    return Apply._factory(selectable, isouter=True, name=name)
 
 
 def outerjoin(

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -4625,6 +4625,11 @@ class SQLCompiler(Compiled):
         kw["lateral"] = True
         return "LATERAL %s" % self.visit_alias(lateral_, **kw)
 
+    def visit_apply(self, apply_, **kw):
+        kw["lateral"] = True
+        apply_type = "OUTER" if apply_.isouter else "CROSS"
+        return f"{apply_type} APPLY {self.visit_alias(apply_, **kw)}"
+
     def visit_tablesample(self, tablesample, asfrom=False, **kw):
         text = "%s TABLESAMPLE %s" % (
             self.visit_alias(tablesample, asfrom=True, **kw),
@@ -5672,7 +5677,17 @@ class SQLCompiler(Compiled):
                 )
             )
 
-        if join.full:
+        if isinstance(join.right, selectable.Apply):
+            return (
+                join.left._compiler_dispatch(
+                    self, asfrom=True, from_linter=from_linter, **kwargs
+                )
+                + " "
+                + join.right._compiler_dispatch(
+                    self, asfrom=True, from_linter=from_linter, **kwargs
+                )
+            )
+        elif join.full:
             join_type = " FULL OUTER JOIN "
         elif join.isouter:
             join_type = " LEFT OUTER JOIN "

--- a/lib/sqlalchemy/sql/expression.py
+++ b/lib/sqlalchemy/sql/expression.py
@@ -46,6 +46,7 @@ from ._elements_constructors import tuple_ as tuple_
 from ._elements_constructors import type_coerce as type_coerce
 from ._elements_constructors import within_group as within_group
 from ._selectable_constructors import alias as alias
+from ._selectable_constructors import cross_apply as cross_apply
 from ._selectable_constructors import cte as cte
 from ._selectable_constructors import except_ as except_
 from ._selectable_constructors import except_all as except_all
@@ -54,6 +55,7 @@ from ._selectable_constructors import intersect as intersect
 from ._selectable_constructors import intersect_all as intersect_all
 from ._selectable_constructors import join as join
 from ._selectable_constructors import lateral as lateral
+from ._selectable_constructors import outer_apply as outer_apply
 from ._selectable_constructors import outerjoin as outerjoin
 from ._selectable_constructors import select as select
 from ._selectable_constructors import table as table
@@ -128,6 +130,7 @@ from .operators import OperatorClass as OperatorClass
 from .operators import Operators as Operators
 from .selectable import Alias as Alias
 from .selectable import AliasedReturnsRows as AliasedReturnsRows
+from .selectable import Apply as Apply
 from .selectable import CompoundSelect as CompoundSelect
 from .selectable import CTE as CTE
 from .selectable import Exists as Exists

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -335,6 +335,37 @@ class Selectable(ReturnsRows):
         """
         return Lateral._construct(self, name=name)
 
+    def cross_apply(self, name: Optional[str] = None) -> ApplyFromClause:
+        """Return a ``CROSS APPLY`` alias of this selectable.
+
+        The returned object is intended for use as the right side of a
+        :meth:`_expression.FromClause.join`; no ``ON`` clause is needed.
+
+        .. versionadded:: 2.1
+
+        .. seealso::
+
+            :func:`_expression.cross_apply`
+
+            :meth:`_expression.Selectable.outer_apply`
+
+        """
+        return Apply._factory(cast(Any, self), name=name, isouter=False)
+
+    def outer_apply(self, name: Optional[str] = None) -> ApplyFromClause:
+        """Return an ``OUTER APPLY`` alias of this selectable.
+
+        .. versionadded:: 2.1
+
+        .. seealso::
+
+            :func:`_expression.outer_apply`
+
+            :meth:`_expression.Selectable.cross_apply`
+
+        """
+        return Apply._factory(cast(Any, self), name=name, isouter=True)
+
     @util.deprecated(
         "1.4",
         message="The :meth:`.Selectable.replace_selectable` method is "
@@ -1339,7 +1370,18 @@ class Join(roles.DMLTableRole, FromClause[_KeyColCC_co]):
             right,
         ).self_group()
 
-        if onclause is None:
+        if isinstance(self.right, Apply):
+            if onclause is not None:
+                raise exc.ArgumentError(
+                    "CROSS APPLY and OUTER APPLY do not accept an ON clause"
+                )
+            if isouter or full:
+                raise exc.ArgumentError(
+                    "join flags are not accepted with CROSS APPLY or "
+                    "OUTER APPLY; use cross_apply() or outer_apply()"
+                )
+            self.onclause = None
+        elif onclause is None:
             self.onclause = self._match_primaries(self.left, self.right)
         else:
             # note: taken from If91f61527236fd4d7ae3cad1f24c38be921c90ba
@@ -1731,6 +1773,10 @@ class LateralFromClause(NamedFromClause):
     """mark a FROM clause as being able to render directly as LATERAL"""
 
 
+class ApplyFromClause(LateralFromClause):
+    """Mark a FROM clause as a ``CROSS APPLY`` or ``OUTER APPLY`` target."""
+
+
 # FromClause ->
 #   AliasedReturnsRows
 #        -> Alias   only for FromClause
@@ -2074,6 +2120,52 @@ class TableValuedAlias(LateralFromClause, Alias):
         new_alias._render_derived = True
         new_alias._render_derived_w_types = with_types
         return new_alias
+
+
+class Apply(FromClauseAlias, ApplyFromClause):
+    """Represent a ``CROSS APPLY`` or ``OUTER APPLY`` subquery.
+
+    This object is constructed using :func:`_expression.cross_apply`,
+    :func:`_expression.outer_apply`, or the corresponding methods present on
+    :class:`_expression.Selectable`.
+
+    .. versionadded:: 2.1
+    """
+
+    __visit_name__ = "apply"
+    _is_lateral = True
+
+    _traverse_internals: _TraverseInternalsType = (
+        AliasedReturnsRows._traverse_internals
+        + [("isouter", InternalTraversal.dp_boolean)]
+    )
+
+    inherit_cache = True
+
+    isouter: bool
+
+    def _init(
+        self,
+        selectable: Any,
+        *,
+        name: Optional[str] = None,
+        isouter: bool = False,
+    ) -> None:
+        super()._init(selectable, name=name)
+        self.isouter = isouter
+
+    @classmethod
+    def _factory(
+        cls,
+        selectable: Union[SelectBase, _FromClauseArgument],
+        *,
+        isouter: bool,
+        name: Optional[str] = None,
+    ) -> ApplyFromClause:
+        target = coercions.expect(
+            roles.FromClauseRole, selectable, explicit_subquery=True
+        )
+        return cls._construct(target, name=name, isouter=isouter)
 
 
 class Lateral(FromClauseAlias, LateralFromClause):

--- a/test/sql/test_lateral.py
+++ b/test/sql/test_lateral.py
@@ -1,9 +1,12 @@
 from sqlalchemy import Column
 from sqlalchemy import column
+from sqlalchemy import cross_apply
+from sqlalchemy import exc
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
 from sqlalchemy import join
 from sqlalchemy import lateral
+from sqlalchemy import outer_apply
 from sqlalchemy import String
 from sqlalchemy import Table
 from sqlalchemy import table
@@ -13,6 +16,7 @@ from sqlalchemy import true
 from sqlalchemy.engine import default
 from sqlalchemy.sql import func
 from sqlalchemy.sql import select
+from sqlalchemy.sql.selectable import Apply
 from sqlalchemy.sql.selectable import Lateral
 from sqlalchemy.testing import assert_raises_message
 from sqlalchemy.testing import AssertsCompiledSQL
@@ -344,3 +348,84 @@ class LateralTest(fixtures.TablesTest, AssertsCompiledSQL):
             a,
             "foo",
         )
+
+    def test_cross_apply(self):
+        table1 = self.tables.people
+        table2 = self.tables.books
+        subq = (
+            select(table2.c.book_id)
+            .where(table2.c.book_owner_id == table1.c.people_id)
+            .subquery()
+            .cross_apply(name="book_apply")
+        )
+
+        stmt = select(table1, subq.c.book_id).select_from(table1.join(subq))
+
+        self.assert_compile(
+            stmt,
+            "SELECT people.people_id, people.age, people.name, "
+            "book_apply.book_id FROM people CROSS APPLY "
+            "(SELECT books.book_id AS book_id FROM books "
+            "WHERE books.book_owner_id = people.people_id) AS book_apply",
+        )
+
+    def test_outer_apply(self):
+        table1 = self.tables.people
+        table2 = self.tables.books
+        subq = select(table2.c.book_id).where(
+            table2.c.book_owner_id == table1.c.people_id
+        )
+        apply_ = outer_apply(subq, name="book_apply")
+
+        stmt = select(table1, apply_.c.book_id).select_from(
+            table1.join(apply_)
+        )
+
+        self.assert_compile(
+            stmt,
+            "SELECT people.people_id, people.age, people.name, "
+            "book_apply.book_id FROM people OUTER APPLY "
+            "(SELECT books.book_id AS book_id FROM books "
+            "WHERE books.book_owner_id = people.people_id) AS book_apply",
+        )
+
+    def test_apply_public_constructor(self):
+        subq = select(column("x")).subquery()
+
+        apply_ = cross_apply(subq, name="apply_alias")
+
+        assert isinstance(apply_, Apply)
+        self.assert_compile(apply_, "CROSS APPLY (SELECT x)")
+
+    def test_apply_implicit_subquery(self):
+        apply_ = select(column("x")).cross_apply(name="apply_alias")
+
+        self.assert_compile(
+            select(apply_.c.x).select_from(table("t").join(apply_)),
+            "SELECT apply_alias.x FROM t CROSS APPLY "
+            "(SELECT x) AS apply_alias",
+        )
+
+    def test_apply_rejects_join_criteria(self):
+        table1 = self.tables.people
+        apply_ = select(column("x")).cross_apply()
+
+        assert_raises_message(
+            exc.ArgumentError,
+            "CROSS APPLY and OUTER APPLY do not accept an ON clause",
+            lambda: table1.join(apply_, true()),
+        )
+        assert_raises_message(
+            exc.ArgumentError,
+            "join flags are not accepted with CROSS APPLY or OUTER APPLY",
+            lambda: table1.join(apply_, isouter=True),
+        )
+
+    def test_apply_cache_key_includes_apply_type(self):
+        subq = select(column("x"))
+        cross = subq.cross_apply()
+        outer = subq.outer_apply()
+
+        assert cross._generate_cache_key() is not None
+        assert outer._generate_cache_key() is not None
+        assert cross._generate_cache_key() != outer._generate_cache_key()


### PR DESCRIPTION
Fixes #5133.

This adds first-class `CROSS APPLY` and `OUTER APPLY` support without changing
the meaning of the existing `LATERAL` construct.

The new `Apply` object follows the lateral selectable topology and is exposed
through `cross_apply()` / `outer_apply()` constructors and corresponding
selectable methods. APPLY targets retain lateral correlation, participate in
cache-key traversal, and render as the right side of a join without an `ON`
clause. Direct `Select` inputs are coerced to subqueries, and incompatible join
criteria or join flags raise an explicit argument error.

The change includes public exports, API and tutorial documentation, an
unreleased changelog entry, and coverage for correlation, constructor and
method forms, direct `Select` coercion, join validation, cache-key differences,
FROM linting, and SQL Server compilation.

Validation:

- Added 6 focused APPLY test cases; these are included in the suite totals below
- full SQLAlchemy SQL regression suite (`pytest -q test/sql`): 8,327 passed,
  359 skipped
- focused APPLY/MSSQL-related regression suites: 510 passed, 3 skipped
- Black, zimports, flake8, and targeted mypy checks pass
- Sphinx reports no warnings in changed documentation
AI tools were used in preparing this change.