### PR TITLE
Add named SQL window definitions

### DIFF
--- a/doc/build/changelog/unreleased_21/8352.rst
+++ b/doc/build/changelog/unreleased_21/8352.rst
@@ -1,0 +1,11 @@
+.. change::
+    :tags: usecase, sql
+    :tickets: 8352
+
+    Added support for named SQL window definitions with the new
+    :func:`_sql.window` constructor and :class:`_sql.Window` object.  Window
+    objects may be passed directly to :meth:`_functions.FunctionElement.over`
+    and are added to the enclosing SELECT automatically, or may be referenced
+    by string name and registered with :meth:`_sql.Select.add_window`.  Named
+    windows can derive from earlier definitions while preserving dependency
+    order, and participate fully in SQL traversal and statement cache keys.

--- a/doc/build/core/sqlelement.rst
+++ b/doc/build/core/sqlelement.rst
@@ -126,6 +126,8 @@ Functions listed here are more commonly available as methods from any
 
 .. autofunction:: over
 
+.. autofunction:: window
+
 .. autofunction:: within_group
 
 Column Element Class Documentation
@@ -211,6 +213,9 @@ The classes here are generated using the constructors listed at
    :members:
 
 .. autoclass:: Over
+   :members:
+
+.. autoclass:: Window
    :members:
 
 .. autoclass:: FrameClause

--- a/doc/build/tutorial/data_select.rst
+++ b/doc/build/tutorial/data_select.rst
@@ -1639,6 +1639,46 @@ We also may make use of the ``ORDER BY`` clause using :paramref:`_functions.Func
     {stop}[(2, 'sandy', 'sandy@sqlalchemy.org'), (2, 'sandy', 'sandy@squirrelpower.org'), (3, 'spongebob', 'spongebob@sqlalchemy.org')]
     {printsql}ROLLBACK{stop}
 
+Named windows allow the same partitioning, ordering, and frame definition to
+be reused by multiple ``OVER`` expressions.  A :func:`_expression.window`
+object passed to :meth:`_functions.FunctionElement.over` is associated with
+the enclosing :class:`_sql.Select` automatically::
+
+    >>> from sqlalchemy import window
+    >>> by_user = window(
+    ...     name="by_user",
+    ...     partition_by=user_table.c.name,
+    ...     order_by=address_table.c.email_address,
+    ... )
+    >>> stmt = (
+    ...     select(
+    ...         func.row_number().over(by_user),
+    ...         user_table.c.name,
+    ...         address_table.c.email_address,
+    ...     )
+    ...     .select_from(user_table)
+    ...     .join(address_table)
+    ... )
+    >>> print(stmt)
+    {printsql}SELECT row_number() OVER by_user AS anon_1, user_account.name,
+    address.email_address
+    FROM user_account JOIN address ON user_account.id = address.user_id
+    WINDOW by_user AS (PARTITION BY user_account.name
+    ORDER BY address.email_address)
+
+A window may instead be referenced by string name and registered explicitly
+using :meth:`_sql.Select.add_window`.  A second window can build on an earlier
+one using :meth:`_sql.Window.window`; SQLAlchemy renders object dependencies in
+the required definition order.
+
+.. seealso::
+
+    :func:`_expression.window`
+
+    :class:`_sql.Window`
+
+    :meth:`_sql.Select.add_window`
+
 Further options for window functions include usage of ranges; see
 :func:`_expression.over` for more examples.
 

--- a/lib/sqlalchemy/__init__.py
+++ b/lib/sqlalchemy/__init__.py
@@ -232,6 +232,8 @@ from .sql.expression import Values as Values
 from .sql.expression import values as values
 from .sql.expression import ValuesBase as ValuesBase
 from .sql.expression import Visitable as Visitable
+from .sql.expression import Window as Window
+from .sql.expression import window as window
 from .sql.expression import within_group as within_group
 from .sql.expression import WithinGroup as WithinGroup
 from .types import ARRAY as ARRAY

--- a/lib/sqlalchemy/sql/__init__.py
+++ b/lib/sqlalchemy/sql/__init__.py
@@ -114,6 +114,7 @@ from .expression import Update as Update
 from .expression import update as update
 from .expression import Values as Values
 from .expression import values as values
+from .expression import window as window
 from .expression import within_group as within_group
 from .expression import WriteableColumnCollection as WriteableColumnCollection
 from .visitors import ClauseVisitor as ClauseVisitor

--- a/lib/sqlalchemy/sql/_elements_constructors.py
+++ b/lib/sqlalchemy/sql/_elements_constructors.py
@@ -49,6 +49,7 @@ from .elements import TString
 from .elements import Tuple
 from .elements import TypeCoerce
 from .elements import UnaryExpression
+from .elements import Window
 from .elements import WithinGroup
 from .functions import FunctionElement
 
@@ -1639,6 +1640,33 @@ if not TYPE_CHECKING:
         return BooleanClauseList.or_(*clauses)
 
 
+def window(
+    name: str,
+    *,
+    existing_window: Window | str | None = None,
+    partition_by: _ByArgument | None = None,
+    order_by: _ByArgument | None = None,
+    range_: _FrameIntTuple | FrameClause | None = None,
+    rows: _FrameIntTuple | FrameClause | None = None,
+    groups: _FrameIntTuple | FrameClause | None = None,
+    exclude: str | None = None,
+) -> Window:
+    """Produce a named SQL :class:`_expression.Window` definition.
+
+    .. versionadded:: 2.1
+    """
+    return Window(
+        name,
+        existing_window=existing_window,
+        partition_by=partition_by,
+        order_by=order_by,
+        range_=range_,
+        rows=rows,
+        groups=groups,
+        exclude=exclude,
+    )
+
+
 def over(
     element: FunctionElement[_T],
     partition_by: _ByArgument | None = None,
@@ -1647,6 +1675,7 @@ def over(
     rows: _FrameIntTuple | FrameClause | None = None,
     groups: _FrameIntTuple | FrameClause | None = None,
     exclude: str | None = None,
+    window: Window | str | None = None,
 ) -> Over[_T]:
     r"""Produce an :class:`.Over` object against a function.
 
@@ -1780,6 +1809,7 @@ def over(
         rows,
         groups,
         exclude,
+        window=window,
     )
 
 

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -435,6 +435,8 @@ class _CompilerStackEntry(_BaseCompilerStackEntry, total=False):
     need_result_map_for_compound: bool
     select_0: ReturnsRows
     insert_from_select: Select[Unpack[TupleAny]]
+    window_clause_prefix: str
+    window_definitions: List[elements.Window]
 
 
 class ExpandedState(NamedTuple):
@@ -3048,6 +3050,8 @@ class SQLCompiler(Compiled):
         text = over.element._compiler_dispatch(self, **kwargs)
         if over.window is not None:
             window_name = over.window.name
+            if self.stack:
+                self.stack[-1]["window_definitions"].append(over.window)
         else:
             window_name = over.window_name
 
@@ -5277,6 +5281,15 @@ class SQLCompiler(Compiled):
             if per_dialect:
                 text += " " + self.get_statement_hint_text(per_dialect)
 
+        referenced_windows = self.stack[-1]["window_definitions"]
+        if select_stmt._window_definitions or referenced_windows:
+            position = len(self.stack[-1]["window_clause_prefix"])
+            text = (
+                text[:position]
+                + self.window_clause(select_stmt, referenced_windows, **kwargs)
+                + text[position:]
+            )
+
         # In compound query, CTEs are shared at the compound level
         if self.ctes and (not is_embedded_select or toplevel):
             nesting_level = len(self.stack) if not toplevel else None
@@ -5350,12 +5363,13 @@ class SQLCompiler(Compiled):
             "correlate_froms": all_correlate_froms,
             "selectable": select,
             "compile_state": compile_state,
+            "window_definitions": [],
         }
         self.stack.append(new_entry)
 
         return froms
 
-    def _collect_select_windows(self, select):
+    def _collect_select_windows(self, select, referenced_windows):
         definitions: Dict[str, elements.Window] = {}
         visiting = set()
 
@@ -5378,44 +5392,15 @@ class SQLCompiler(Compiled):
                 definitions[window.name] = window
             visiting.remove(identity)
 
-        for window in select._window_definitions:
-            add_window(window)
-
-        seen = set()
-
-        def visit(element):
-            if isinstance(element, (list, tuple)):
-                for child in element:
-                    visit(child)
-                return
-            elif not isinstance(element, elements.ClauseElement):
-                return
-
-            identity = id(element)
-            if identity in seen:
-                return
-            seen.add(identity)
-            if isinstance(element, elements.Window):
-                add_window(element)
-                return
-            if isinstance(element, selectable.SelectBase):
-                return
-            for child in element.get_children():
-                visit(child)
-
-        for clause in itertools.chain(
-            select._raw_columns,
-            select._where_criteria,
-            select._having_criteria,
-            select._group_by_clauses,
-            select._order_by_clauses,
+        for window in itertools.chain(
+            select._window_definitions, referenced_windows
         ):
-            visit(clause)
+            add_window(window)
 
         return list(definitions.values())
 
-    def window_clause(self, select, **kwargs):
-        windows = self._collect_select_windows(select)
+    def window_clause(self, select, referenced_windows, **kwargs):
+        windows = self._collect_select_windows(select, referenced_windows)
         if not windows:
             return ""
         return " WINDOW " + ", ".join(
@@ -5506,7 +5491,7 @@ class SQLCompiler(Compiled):
             if t:
                 text += " \nHAVING " + t
 
-        text += self.window_clause(select, **kwargs)
+        self.stack[-1]["window_clause_prefix"] = text
 
         if select._post_criteria_clause is not None:
             pcc = self.process(select._post_criteria_clause, **kwargs)

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -3008,37 +3008,77 @@ class SQLCompiler(Compiled):
 
         return f"{left} AND {right}"
 
-    def visit_over(self, over, **kwargs):
-        text = over.element._compiler_dispatch(self, **kwargs)
-        if over.range_ is not None:
-            range_ = f"RANGE BETWEEN {self.process(over.range_, **kwargs)}"
-        elif over.rows is not None:
-            range_ = f"ROWS BETWEEN {self.process(over.rows, **kwargs)}"
-        elif over.groups is not None:
-            range_ = f"GROUPS BETWEEN {self.process(over.groups, **kwargs)}"
+    def _window_specification(
+        self,
+        element,
+        *,
+        existing_window_name=None,
+        **kwargs,
+    ):
+        if element.range_ is not None:
+            frame = f"RANGE BETWEEN {self.process(element.range_, **kwargs)}"
+        elif element.rows is not None:
+            frame = f"ROWS BETWEEN {self.process(element.rows, **kwargs)}"
+        elif element.groups is not None:
+            frame = f"GROUPS BETWEEN {self.process(element.groups, **kwargs)}"
         else:
-            range_ = None
+            frame = None
 
-        if range_ is not None and over.exclude is not None:
-            range_ += " EXCLUDE " + self.preparer.validate_sql_phrase(
-                over.exclude, _WINDOW_EXCLUDE_RE
+        if frame is not None and element.exclude is not None:
+            frame += " EXCLUDE " + self.preparer.validate_sql_phrase(
+                element.exclude, _WINDOW_EXCLUDE_RE
             )
 
-        return "%s OVER (%s)" % (
-            text,
-            " ".join(
-                [
-                    "%s BY %s"
-                    % (word, clause._compiler_dispatch(self, **kwargs))
-                    for word, clause in (
-                        ("PARTITION", over.partition_by),
-                        ("ORDER", over.order_by),
-                    )
-                    if clause is not None and len(clause)
-                ]
-                + ([range_] if range_ else [])
-            ),
+        clauses = []
+        if existing_window_name is not None:
+            clauses.append(self.preparer.quote(existing_window_name))
+        clauses.extend(
+            "%s BY %s" % (word, clause._compiler_dispatch(self, **kwargs))
+            for word, clause in (
+                ("PARTITION", element.partition_by),
+                ("ORDER", element.order_by),
+            )
+            if clause is not None and len(clause)
         )
+        if frame:
+            clauses.append(frame)
+        return " ".join(clauses)
+
+    def visit_over(self, over, **kwargs):
+        text = over.element._compiler_dispatch(self, **kwargs)
+        if over.window is not None:
+            window_name = over.window.name
+        else:
+            window_name = over.window_name
+
+        specification = self._window_specification(
+            over, existing_window_name=window_name, **kwargs
+        )
+        has_local_specification = any(
+            item is not None
+            for item in (
+                over.partition_by,
+                over.order_by,
+                over.range_,
+                over.rows,
+                over.groups,
+            )
+        )
+
+        if window_name is not None and not has_local_specification:
+            return f"{text} OVER {self.preparer.quote(window_name)}"
+        else:
+            return f"{text} OVER ({specification})"
+
+    def visit_window(self, window, **kwargs):
+        if window.existing_window is not None:
+            existing_window_name = window.existing_window.name
+        else:
+            existing_window_name = window.existing_window_name
+        specification = self._window_specification(
+            window, existing_window_name=existing_window_name, **kwargs
+        )
+        return f"{self.preparer.quote(window.name)} AS ({specification})"
 
     def visit_withingroup(self, withingroup, **kwargs):
         return "%s WITHIN GROUP (ORDER BY %s)" % (
@@ -5315,6 +5355,73 @@ class SQLCompiler(Compiled):
 
         return froms
 
+    def _collect_select_windows(self, select):
+        definitions: Dict[str, elements.Window] = {}
+        visiting = set()
+
+        def add_window(window):
+            identity = id(window)
+            if identity in visiting:
+                raise exc.CompileError("named window definitions are cyclic")
+            visiting.add(identity)
+            if window.existing_window is not None:
+                add_window(window.existing_window)
+
+            existing = definitions.get(window.name)
+            if existing is not None and existing is not window:
+                if not existing.compare(window):
+                    raise exc.CompileError(
+                        f"named window {window.name!r} is defined more "
+                        "than once"
+                    )
+            else:
+                definitions[window.name] = window
+            visiting.remove(identity)
+
+        for window in select._window_definitions:
+            add_window(window)
+
+        seen = set()
+
+        def visit(element):
+            if isinstance(element, (list, tuple)):
+                for child in element:
+                    visit(child)
+                return
+            elif not isinstance(element, elements.ClauseElement):
+                return
+
+            identity = id(element)
+            if identity in seen:
+                return
+            seen.add(identity)
+            if isinstance(element, elements.Window):
+                add_window(element)
+                return
+            if isinstance(element, selectable.SelectBase):
+                return
+            for child in element.get_children():
+                visit(child)
+
+        for clause in itertools.chain(
+            select._raw_columns,
+            select._where_criteria,
+            select._having_criteria,
+            select._group_by_clauses,
+            select._order_by_clauses,
+        ):
+            visit(clause)
+
+        return list(definitions.values())
+
+    def window_clause(self, select, **kwargs):
+        windows = self._collect_select_windows(select)
+        if not windows:
+            return ""
+        return " WINDOW " + ", ".join(
+            window._compiler_dispatch(self, **kwargs) for window in windows
+        )
+
     def _compose_select_body(
         self,
         text,
@@ -5398,6 +5505,8 @@ class SQLCompiler(Compiled):
             )
             if t:
                 text += " \nHAVING " + t
+
+        text += self.window_clause(select, **kwargs)
 
         if select._post_criteria_clause is not None:
             pcc = self.process(select._post_criteria_clause, **kwargs)

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -4512,6 +4512,137 @@ class _OverrideBinds(Grouping[_T]):
 _FrameIntTuple = tuple[int | None, int | None]
 
 
+class Window(ClauseElement):
+    """Represent a named SQL window definition.
+
+    Named windows are associated with a :class:`_sql.Select` automatically
+    when referenced by an :class:`.Over` construct, or explicitly with
+    :meth:`_sql.Select.add_window`.
+
+    .. versionadded:: 2.1
+    """
+
+    __visit_name__ = "window"
+
+    inherit_cache = True
+
+    _traverse_internals: _TraverseInternalsType = [
+        ("name", InternalTraversal.dp_string),
+        ("existing_window", InternalTraversal.dp_clauseelement),
+        ("existing_window_name", InternalTraversal.dp_string),
+        ("order_by", InternalTraversal.dp_clauseelement),
+        ("partition_by", InternalTraversal.dp_clauseelement),
+        ("range_", InternalTraversal.dp_clauseelement),
+        ("rows", InternalTraversal.dp_clauseelement),
+        ("groups", InternalTraversal.dp_clauseelement),
+        ("exclude", InternalTraversal.dp_string),
+    ]
+
+    name: str
+    existing_window: Window | None
+    existing_window_name: str | None
+    order_by: ClauseList | None = None
+    partition_by: ClauseList | None = None
+    range_: FrameClause | None
+    rows: FrameClause | None
+    groups: FrameClause | None
+    exclude: str | None
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        existing_window: Window | str | None = None,
+        partition_by: _ByArgument | None = None,
+        order_by: _ByArgument | None = None,
+        range_: _FrameIntTuple | FrameClause | None = None,
+        rows: _FrameIntTuple | FrameClause | None = None,
+        groups: _FrameIntTuple | FrameClause | None = None,
+        exclude: str | None = None,
+    ):
+        if not isinstance(name, str) or not name:
+            raise exc.ArgumentError("a named window requires a name")
+        self.name = name
+
+        if isinstance(existing_window, Window):
+            self.existing_window = existing_window
+            self.existing_window_name = None
+        elif existing_window is None or (
+            isinstance(existing_window, str) and existing_window
+        ):
+            self.existing_window = None
+            self.existing_window_name = existing_window
+        else:
+            raise exc.ArgumentError(
+                "existing_window must be a Window object or a non-empty name"
+            )
+
+        if order_by is not None:
+            self.order_by = ClauseList(
+                *util.to_list(order_by), _literal_as_text_role=roles.ByOfRole
+            )
+        if partition_by is not None:
+            self.partition_by = ClauseList(
+                *util.to_list(partition_by),
+                _literal_as_text_role=roles.ByOfRole,
+            )
+
+        if sum(item is not None for item in (range_, rows, groups)) > 1:
+            raise exc.ArgumentError(
+                "only one of 'rows', 'range_', or 'groups' may be provided"
+            )
+        self.range_ = FrameClause._parse(range_, coerce_int=False)
+        self.rows = FrameClause._parse(rows, coerce_int=True)
+        self.groups = FrameClause._parse(groups, coerce_int=True)
+        self.exclude = exclude
+
+        if exclude is not None and not any(
+            item is not None for item in (range_, rows, groups)
+        ):
+            raise exc.ArgumentError(
+                "'exclude' requires that one of 'rows', "
+                "'range_', or 'groups' is also specified"
+            )
+
+    def window(
+        self,
+        name: str,
+        *,
+        partition_by: _ByArgument | None = None,
+        order_by: _ByArgument | None = None,
+        range_: _FrameIntTuple | FrameClause | None = None,
+        rows: _FrameIntTuple | FrameClause | None = None,
+        groups: _FrameIntTuple | FrameClause | None = None,
+        exclude: str | None = None,
+    ) -> Window:
+        """Return a named window derived from this window."""
+        return Window(
+            name,
+            existing_window=self,
+            partition_by=partition_by,
+            order_by=order_by,
+            range_=range_,
+            rows=rows,
+            groups=groups,
+            exclude=exclude,
+        )
+
+    @util.ro_non_memoized_property
+    def _from_objects(self) -> List[FromClause]:
+        from_objects: List[FromClause] = []
+        window: Window | None = self
+        seen: Set[int] = set()
+
+        while window is not None and id(window) not in seen:
+            seen.add(id(window))
+            for clause in (window.partition_by, window.order_by):
+                if clause is not None:
+                    from_objects.extend(clause._from_objects)
+            window = window.existing_window
+
+        return from_objects
+
+
 class Over(ColumnElement[_T]):
     """Represent an OVER clause.
 
@@ -4526,6 +4657,8 @@ class Over(ColumnElement[_T]):
 
     _traverse_internals: _TraverseInternalsType = [
         ("element", InternalTraversal.dp_clauseelement),
+        ("window", InternalTraversal.dp_clauseelement),
+        ("window_name", InternalTraversal.dp_string),
         ("order_by", InternalTraversal.dp_clauseelement),
         ("partition_by", InternalTraversal.dp_clauseelement),
         ("range_", InternalTraversal.dp_clauseelement),
@@ -4545,6 +4678,8 @@ class Over(ColumnElement[_T]):
     rows: FrameClause | None
     groups: FrameClause | None
     exclude: str | None
+    window: Window | None
+    window_name: str | None
 
     def __init__(
         self,
@@ -4555,8 +4690,19 @@ class Over(ColumnElement[_T]):
         rows: _FrameIntTuple | FrameClause | None = None,
         groups: _FrameIntTuple | FrameClause | None = None,
         exclude: str | None = None,
+        window: Window | str | None = None,
     ):
         self.element = element
+        if isinstance(window, Window):
+            self.window = window
+            self.window_name = None
+        elif window is None or (isinstance(window, str) and window):
+            self.window = None
+            self.window_name = window
+        else:
+            raise exc.ArgumentError(
+                "window must be a Window object or a non-empty name"
+            )
         if order_by is not None:
             self.order_by = ClauseList(
                 *util.to_list(order_by), _literal_as_text_role=roles.ByOfRole
@@ -4598,7 +4744,12 @@ class Over(ColumnElement[_T]):
             itertools.chain(
                 *[
                     c._from_objects
-                    for c in (self.element, self.partition_by, self.order_by)
+                    for c in (
+                        self.element,
+                        self.window,
+                        self.partition_by,
+                        self.order_by,
+                    )
                     if c is not None
                 ]
             )
@@ -4814,6 +4965,7 @@ class AggregateOrderBy(WrapsColumnExpression[_T]):
 
     def over(
         self,
+        window: Window | str | None = None,
         *,
         partition_by: _ByArgument | None = None,
         order_by: _ByArgument | None = None,
@@ -4837,6 +4989,7 @@ class AggregateOrderBy(WrapsColumnExpression[_T]):
             rows=rows,
             groups=groups,
             exclude=exclude,
+            window=window,
         )
 
     @overload
@@ -4967,6 +5120,7 @@ class FunctionFilter(Generative, ColumnElement[_T]):
         rows: _FrameIntTuple | FrameClause | None = None,
         groups: _FrameIntTuple | FrameClause | None = None,
         exclude: str | None = None,
+        window: Window | str | None = None,
     ) -> Over[_T]:
         """Produce an OVER clause against this filtered function.
 
@@ -4994,6 +5148,7 @@ class FunctionFilter(Generative, ColumnElement[_T]):
             rows=rows,
             groups=groups,
             exclude=exclude,
+            window=window,
         )
 
     def within_group(

--- a/lib/sqlalchemy/sql/expression.py
+++ b/lib/sqlalchemy/sql/expression.py
@@ -44,6 +44,7 @@ from ._elements_constructors import try_cast as try_cast
 from ._elements_constructors import tstring as tstring
 from ._elements_constructors import tuple_ as tuple_
 from ._elements_constructors import type_coerce as type_coerce
+from ._elements_constructors import window as window
 from ._elements_constructors import within_group as within_group
 from ._selectable_constructors import alias as alias
 from ._selectable_constructors import cte as cte
@@ -114,6 +115,7 @@ from .elements import Tuple as Tuple
 from .elements import TypeClause as TypeClause
 from .elements import TypeCoerce as TypeCoerce
 from .elements import UnaryExpression as UnaryExpression
+from .elements import Window as Window
 from .elements import WithinGroup as WithinGroup
 from .functions import func as func
 from .functions import Function as Function

--- a/lib/sqlalchemy/sql/functions.py
+++ b/lib/sqlalchemy/sql/functions.py
@@ -55,6 +55,7 @@ from .elements import Grouping
 from .elements import literal_column
 from .elements import NamedColumn
 from .elements import Over
+from .elements import Window
 from .elements import WithinGroup
 from .selectable import FromClause
 from .selectable import Select
@@ -457,6 +458,7 @@ class FunctionElement(
 
     def over(
         self,
+        window: Window | str | None = None,
         *,
         partition_by: _ByArgument | None = None,
         order_by: _ByArgument | None = None,
@@ -497,6 +499,7 @@ class FunctionElement(
             range_=range_,
             groups=groups,
             exclude=exclude,
+            window=window,
         )
 
     def aggregate_order_by(

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -104,6 +104,7 @@ from .elements import literal_column
 from .elements import TableValuedColumn
 from .elements import TextClause
 from .elements import UnaryExpression
+from .elements import Window
 from .operators import OperatorType
 from .sqltypes import NULLTYPE
 from .visitors import _TraverseInternalsType
@@ -5002,6 +5003,12 @@ class SelectState(util.MemoizedSlots, CompileState):
                         for element in statement._where_criteria
                     ]
                 ),
+                itertools.chain.from_iterable(
+                    [
+                        element._from_objects
+                        for element in statement._window_definitions
+                    ]
+                ),
             ),
             check_statement=statement,
             ambiguous_table_name_map=ambiguous_table_name_map,
@@ -5493,6 +5500,7 @@ class Select(
     _where_criteria: Tuple[ColumnElement[Any], ...] = ()
     _having_criteria: Tuple[ColumnElement[Any], ...] = ()
     _from_obj: Tuple[FromClause, ...] = ()
+    _window_definitions: Tuple[Window, ...] = ()
 
     _position_map = util.immutabledict(
         {
@@ -5552,6 +5560,10 @@ class Select(
             ("_from_obj", InternalTraversal.dp_clauseelement_list),
             ("_where_criteria", InternalTraversal.dp_clauseelement_tuple),
             ("_having_criteria", InternalTraversal.dp_clauseelement_tuple),
+            (
+                "_window_definitions",
+                InternalTraversal.dp_clauseelement_tuple,
+            ),
             ("_order_by_clauses", InternalTraversal.dp_clauseelement_tuple),
             ("_group_by_clauses", InternalTraversal.dp_clauseelement_tuple),
             ("_setup_joins", InternalTraversal.dp_setup_join_tuple),
@@ -6519,6 +6531,25 @@ class Select(
                 roles.WhereHavingRole, criterion, apply_propagate_attrs=self
             )
             self._having_criteria += (having_criteria,)
+        return self
+
+    @_generative
+    def add_window(self, *windows: Window) -> Self:
+        """Add one or more named window definitions to this SELECT.
+
+        Window objects referenced directly by :meth:`.FunctionElement.over`
+        are added automatically.  This method is useful when an OVER clause
+        refers to a window by string name, or when a window should be rendered
+        independently of an expression reference.
+
+        .. versionadded:: 2.1
+        """
+        for window in windows:
+            if not isinstance(window, Window):
+                raise exc.ArgumentError(
+                    "Select.add_window() arguments must be Window objects"
+                )
+            self._window_definitions += (window,)
         return self
 
     @_generative

--- a/test/sql/test_window.py
+++ b/test/sql/test_window.py
@@ -1,0 +1,155 @@
+from sqlalchemy import column
+from sqlalchemy import exc
+from sqlalchemy import func
+from sqlalchemy import select
+from sqlalchemy import table
+from sqlalchemy import window
+from sqlalchemy.testing import assert_raises_message
+from sqlalchemy.testing import AssertsCompiledSQL
+from sqlalchemy.testing import fixtures
+
+
+class NamedWindowTest(fixtures.TestBase, AssertsCompiledSQL):
+    __dialect__ = "default"
+
+    def test_object_reference_adds_definition(self):
+        w = window("w", partition_by=column("x"), order_by=column("y"))
+
+        stmt = select(func.sum(column("z")).over(w))
+
+        self.assert_compile(
+            stmt,
+            "SELECT sum(z) OVER w AS anon_1 "
+            "WINDOW w AS (PARTITION BY x ORDER BY y)",
+        )
+
+    def test_string_reference_with_explicit_definition(self):
+        w = window("w", partition_by=column("x"))
+
+        stmt = select(func.sum(column("z")).over("w")).add_window(w)
+
+        self.assert_compile(
+            stmt,
+            "SELECT sum(z) OVER w AS anon_1 " "WINDOW w AS (PARTITION BY x)",
+        )
+
+    def test_derived_window_dependency_order(self):
+        w1 = window("w1", partition_by=column("x"))
+        w2 = w1.window("w2", order_by=column("y"))
+
+        stmt = select(func.sum(column("z")).over(w2))
+
+        self.assert_compile(
+            stmt,
+            "SELECT sum(z) OVER w2 AS anon_1 "
+            "WINDOW w1 AS (PARTITION BY x), w2 AS (w1 ORDER BY y)",
+        )
+
+    def test_named_window_with_local_frame(self):
+        w = window("w", order_by=column("x"))
+
+        stmt = select(func.sum(column("z")).over(w, rows=(None, 0)))
+
+        self.assert_compile(
+            stmt,
+            "SELECT sum(z) OVER (w ROWS BETWEEN UNBOUNDED PRECEDING "
+            "AND CURRENT ROW) AS anon_1 WINDOW w AS (ORDER BY x)",
+        )
+
+    def test_window_name_quoted(self):
+        w = window("select", partition_by=column("x"))
+
+        stmt = select(func.sum(column("z")).over(w))
+
+        self.assert_compile(
+            stmt,
+            'SELECT sum(z) OVER "select" AS anon_1 '
+            'WINDOW "select" AS (PARTITION BY x)',
+        )
+
+    def test_conflicting_window_names(self):
+        w1 = window("w", partition_by=column("x"))
+        w2 = window("w", partition_by=column("y"))
+        stmt = select(column("z")).add_window(w1, w2)
+
+        assert_raises_message(
+            exc.CompileError,
+            "named window 'w' is defined more than once",
+            stmt.compile,
+        )
+
+    def test_window_definition_contributes_from_clause(self):
+        t = table("t", column("x"))
+        w = window("w", partition_by=t.c.x)
+
+        stmt = select(func.count().over("w")).add_window(w)
+
+        self.assert_compile(
+            stmt,
+            "SELECT count(*) OVER w AS anon_1 FROM t "
+            "WINDOW w AS (PARTITION BY t.x)",
+        )
+
+    def test_window_cache_key_tracks_definition(self):
+        w1 = window("w", partition_by=column("x"))
+        w2 = window("w", partition_by=column("x"))
+        w3 = window("w", partition_by=column("y"))
+
+        stmt1 = select(func.sum(column("z")).over(w1))
+        stmt2 = select(func.sum(column("z")).over(w2))
+        stmt3 = select(func.sum(column("z")).over(w3))
+
+        assert stmt1._generate_cache_key() == stmt2._generate_cache_key()
+        assert stmt1._generate_cache_key() != stmt3._generate_cache_key()
+
+    def test_nested_select_keeps_window_scope_local(self):
+        w = window("inner_w", partition_by=column("x"))
+        inner = select(func.sum(column("z")).over(w).label("total")).subquery()
+
+        self.assert_compile(
+            select(inner.c.total),
+            "SELECT anon_1.total FROM "
+            "(SELECT sum(z) OVER inner_w AS total "
+            "WINDOW inner_w AS (PARTITION BY x)) AS anon_1",
+        )
+
+    def test_string_derived_window(self):
+        w1 = window("w1", partition_by=column("x"))
+        w2 = window("w2", existing_window="w1", order_by=column("y"))
+
+        stmt = select(func.sum(column("z")).over("w2")).add_window(w1, w2)
+
+        self.assert_compile(
+            stmt,
+            "SELECT sum(z) OVER w2 AS anon_1 "
+            "WINDOW w1 AS (PARTITION BY x), w2 AS (w1 ORDER BY y)",
+        )
+
+    def test_invalid_window_reference(self):
+        assert_raises_message(
+            exc.ArgumentError,
+            "window must be a Window object or a non-empty name",
+            func.sum(column("z")).over,
+            "",
+        )
+
+        assert_raises_message(
+            exc.ArgumentError,
+            "existing_window must be a Window object or a non-empty name",
+            window,
+            "w",
+            existing_window="",
+        )
+
+    def test_cyclic_window_definitions(self):
+        w1 = window("w1")
+        w2 = window("w2", existing_window=w1)
+        w1.existing_window = w2
+
+        stmt = select(column("z")).add_window(w1)
+
+        assert_raises_message(
+            exc.CompileError,
+            "named window definitions are cyclic",
+            stmt.compile,
+        )

--- a/test/sql/test_window.py
+++ b/test/sql/test_window.py
@@ -23,6 +23,16 @@ class NamedWindowTest(fixtures.TestBase, AssertsCompiledSQL):
             "WINDOW w AS (PARTITION BY x ORDER BY y)",
         )
 
+    def test_order_by_reference_adds_definition(self):
+        w = window("w", partition_by=column("x"))
+
+        stmt = select(column("z")).order_by(func.sum(column("z")).over(w))
+
+        self.assert_compile(
+            stmt,
+            "SELECT z WINDOW w AS (PARTITION BY x) ORDER BY sum(z) OVER w",
+        )
+
     def test_string_reference_with_explicit_definition(self):
         w = window("w", partition_by=column("x"))
 


### PR DESCRIPTION
Fixes #8352.

This adds first-class named SQL window definitions using a reusable `Window`
object and `window()` constructor.

Window objects can be passed directly to `FunctionElement.over()` and are
collected into the enclosing `SELECT` automatically. String references remain
available with explicit `Select.add_window()` registration. Derived windows
preserve dependency order, duplicate names and cycles are diagnosed, nested
select scopes remain isolated, and window definitions participate in FROM
discovery, cloning traversal, and statement cache keys.

The compiler renders `WINDOW` in standard SELECT-clause order and supports
named-window references with local frame specifications. The change includes
public exports, API and tutorial documentation, an unreleased changelog entry,
and tests for object and string references, derivation, quoting, frames,
conflicts, cycles, nested scoping, FROM discovery, cache keys, and ORDER BY-only
references.

Validation:

- Added 13 focused named-window test cases; all 13 pass in
  `pytest -q test/sql/test_window.py`
- full SQLAlchemy SQL regression suite (`pytest -q test/sql`): 8,334 passed,
  359 skipped; this project-suite total includes the 13 new tests
- focused window/compiler/function/selectable project regression suites: 880
  passed, 5 skipped; this total also includes the new test module
- Black passes for all changed Python files
AI tools were used in preparing this change.