### PR TITLE
fix: avoid catastrophic backtracking in SQLite FK reflection regex

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2717,7 +2717,7 @@ class SQLiteDialect(default.DefaultDialect):
             FK_PATTERN = (
                 r'(?:CONSTRAINT\s+(?:"(.+?)"|(\w+))\s+)?'
                 r"FOREIGN\s+KEY\s*\(\s*(.+?)\s*\)\s+"
-                r'REFERENCES\s+(?:(?:"(.+?)")|([a-z0-9_]+))\s*\(\s*((?:(?:"[^"]+"|[a-z0-9_]+)\s*(?:,\s*)?)+)\)\s*'  # noqa: E501
+                r'REFERENCES\s+(?:(?:"(.+?)")|([a-z0-9_]+))\s*\(\s*((?:"[^"]+"|[a-z0-9_]+)(?:\s*,\s*(?:"[^"]+"|[a-z0-9_]+))*)\)\s*'  # noqa: E501
                 r"((?:ON\s+(?:DELETE|UPDATE)\s+"
                 r"(?:SET\s+NULL|SET\s+DEFAULT|CASCADE|RESTRICT|"
                 r"NO\s+ACTION)\s*)*)"


### PR DESCRIPTION
Fixes #13530

**Problem**: the referred-columns part of FK_PATTERN is a nested quantifier of the (a+)+ shape, because the separator between iterations is optional. A run of word characters that is not eventually matched causes catastrophic backtracking (ReDoS) when reflecting SQLite foreign keys.

**Fix**: make the comma separator mandatory between referred columns, so matching is linear — each subsequent column must be preceded by a comma, and there is no nested quantifier to backtrack into.