### PR TITLE
fix: surface STRICT and WITHOUT ROWID in SQLite reflection

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2443,6 +2443,19 @@ class SQLiteDialect(default.DefaultDialect):
             )
 
     @reflection.cache
+    def get_table_options(
+        self, connection, table_name, schema=None, **kw
+    ) -> dict[str, Any]:
+        """Return the table options for the given table."""
+        options: dict[str, Any] = {}
+        tablesql = self._get_table_sql(connection, table_name, schema, **kw)
+        if re.search(r"WITHOUT\s+ROWID", tablesql, re.IGNORECASE):
+            options["sqlite_with_rowid"] = False
+        if re.search(r"STRICT", tablesql, re.IGNORECASE):
+            options["sqlite_strict"] = True
+        return options
+
+    @reflection.cache
     def get_columns(self, connection, table_name, schema=None, **kw):
         pragma = "table_info"
         # computed columns are threaded as hidden, they require table_xinfo


### PR DESCRIPTION
Fixes #13543

**Problem**: reflecting a SQLite table created with `STRICT` and/or `WITHOUT ROWID` produces a `Table` whose `.kwargs` does not carry `sqlite_strict`/`sqlite_with_rowid` — the dialect renders both when compiling CREATE TABLE but reflection never surfaces them.

**Fix**: implement `get_table_options` on the SQLite dialect, parsing the CREATE TABLE text for `STRICT` and `WITHOUT ROWID` and returning them as `sqlite_strict` / `sqlite_with_rowid`, mirroring the MySQL/MSSQL dialect pattern.