### PR TITLE
fix: escape underscore in Postgres get_schema_names LIKE filter

### DIFF
--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -4066,7 +4066,7 @@ class PGDialect(default._BackendsMultiReflection, default.DefaultDialect):
     def get_schema_names(self, connection, **kw):
         query = (
             select(pg_catalog.pg_namespace.c.nspname)
-            .where(pg_catalog.pg_namespace.c.nspname.not_like("pg_%"))
+            .where(pg_catalog.pg_namespace.c.nspname.not_like("pg\_%"))
             .order_by(pg_catalog.pg_namespace.c.nspname)
         )
         return connection.scalars(query).all()


### PR DESCRIPTION
Fixes #13472

**Problem**: get_schema_names() on Postgres filters system schemas with NOT LIKE 'pg_%', but _ is a single-character wildcard in SQL LIKE — so any user schema starting with pg plus one more character (e.g. pgx) is silently dropped, not just the literal pg_ prefix used by real system schemas.

**Fix**: escape the underscore (NOT LIKE 'pg\_%') so the filter matches the literal pg_ prefix only.