### PR TITLE
fix: reflect fractional-seconds precision for MSSQL datetime/time columns

### DIFF
--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -3621,6 +3621,8 @@ class MSDialect(default._BackendsMultiReflection, default.DefaultDialect):
                 kwargs["precision"] = numericprec
                 if not issubclass(coltype, sqltypes.Float):
                     kwargs["scale"] = numericscale
+            elif issubclass(coltype, (sqltypes.DateTime, sqltypes.Time)):
+                kwargs["precision"] = numericprec
             coltype = coltype(**kwargs)
 
         cdict = {


### PR DESCRIPTION
Fixes #13497

**Problem**: reflecting MSSQL DATETIME2(p) / DATETIMEOFFSET(p) / TIME(p) columns drops the fractional-seconds precision p: MSDialect._parse_column_info only maps precision/scale onto subclasses of NumericCommon, so datetime/time types come back without precision and re-emitted DDL loses it.

**Fix**: also map numericprec to precision when coltype is a DateTime or Time subclass (DATETIME2/DATETIMEOFFSET/TIME), mirroring the NumericCommon branch.