### PR TITLE
Close the DBAPI connection if a connect event raises

### DIFF
--- a/doc/build/changelog/unreleased_21/13548.rst
+++ b/doc/build/changelog/unreleased_21/13548.rst
@@ -1,0 +1,8 @@
+.. change::
+    :tags: bug, pool
+    :tickets: 13548
+
+    Fixed issue where a DBAPI connection created by the pool was left open if a
+    :meth:`_events.PoolEvents.connect` or :meth:`_events.PoolEvents.first_connect`
+    listener raised. The connection is now closed before the exception
+    propagates.

--- a/lib/sqlalchemy/pool/base.py
+++ b/lib/sqlalchemy/pool/base.py
@@ -898,18 +898,27 @@ class _ConnectionRecord(ConnectionPoolEntry):
             with util.safe_reraise():
                 pool.logger.debug("Error on connect(): %s", e)
         else:
-            # in SQLAlchemy 1.4 the first_connect event is not used by
-            # the engine, so this will usually not be set
-            if pool.dispatch.first_connect:
-                pool.dispatch.first_connect.for_modify(
-                    pool.dispatch
-                ).exec_once_unless_exception(self.dbapi_connection, self)
+            try:
+                # in SQLAlchemy 1.4 the first_connect event is not used by
+                # the engine, so this will usually not be set
+                if pool.dispatch.first_connect:
+                    pool.dispatch.first_connect.for_modify(
+                        pool.dispatch
+                    ).exec_once_unless_exception(self.dbapi_connection, self)
 
-            # init of the dialect now takes place within the connect
-            # event, so ensure a mutex is used on the first run
-            pool.dispatch.connect.for_modify(
-                pool.dispatch
-            )._exec_w_sync_on_first_run(self.dbapi_connection, self)
+                # init of the dialect now takes place within the connect
+                # event, so ensure a mutex is used on the first run
+                pool.dispatch.connect.for_modify(
+                    pool.dispatch
+                )._exec_w_sync_on_first_run(self.dbapi_connection, self)
+            except BaseException:
+                # listeners ran after the DBAPI connection was created; close
+                # it so a failed connect event cannot strand the socket
+                conn = self.dbapi_connection
+                self.dbapi_connection = None
+                with util.safe_reraise():
+                    if conn is not None:
+                        pool._close_connection(conn, terminate=True)
 
 
 def _finalize_fairy(

--- a/test/engine/test_pool.py
+++ b/test/engine/test_pool.py
@@ -587,6 +587,46 @@ class PoolEventsTest(PoolTestBase):
         p.connect()
         eq_(canary, ["first_connect"])
 
+    def test_connect_event_exception_closes_dbapi_connection(self):
+        dbapi, p = self._queuepool_dbapi_fixture()
+        created = []
+        real_connect = dbapi.connect.side_effect
+
+        def wrap(*a, **k):
+            conn = real_connect(*a, **k)
+            created.append(conn)
+            return conn
+
+        dbapi.connect.side_effect = wrap
+
+        @event.listens_for(p, "connect")
+        def go_boom(dbapi_con, rec):
+            raise RuntimeError("connect listener failed")
+
+        assert_raises(RuntimeError, p.connect)
+        eq_(len(created), 1)
+        eq_(created[0].close.call_count, 1)
+
+    def test_first_connect_event_exception_closes_dbapi_connection(self):
+        dbapi, p = self._queuepool_dbapi_fixture()
+        created = []
+        real_connect = dbapi.connect.side_effect
+
+        def wrap(*a, **k):
+            conn = real_connect(*a, **k)
+            created.append(conn)
+            return conn
+
+        dbapi.connect.side_effect = wrap
+
+        @event.listens_for(p, "first_connect")
+        def go_boom(dbapi_con, rec):
+            raise RuntimeError("first_connect listener failed")
+
+        assert_raises(RuntimeError, p.connect)
+        eq_(len(created), 1)
+        eq_(created[0].close.call_count, 1)
+
     def test_first_connect_event_fires_once(self):
         p, canary = self._first_connect_event_fixture()
 


### PR DESCRIPTION
`_ConnectionRecord.__connect` assigns the DBAPI connection, then fires `first_connect` / `connect`. If a listener raises, that connection was left on a record that never made it into the pool — `_close_connection` was never called.

Close it before the exception leaves `__connect`.

Fixes: #13548
