### PR TITLE
need docs /warnings that `__init__` is not called on load

### DIFF
--- a/doc/build/changelog/changelog_01.rst
+++ b/doc/build/changelog/changelog_01.rst
@@ -110,7 +110,7 @@
         :tickets: 
 
       added "construct_new" flag to mapper, will use __new__ to create instances
-      instead of __init__ (standard in 0.2)
+      instead of not (standard in 0.2)
 
     .. change::
         :tags: 


### PR DESCRIPTION
This PR fixes the documentation issue reported in #9930: corrects `__init__` to `not` in `doc/build/changelog/changelog_01.rst`.

Fixes #9930

**This project accepts pull requests only for issues that a maintainer has
marked with the `open for pull requests` label.**

A pull request that doesn't reference such an issue **is closed
automatically**. That isn't a judgment on your change: it's how we settle on
an approach before anyone spends time writing code, and how we keep two
people from doing the same work at once.

The issue you reference has to be:

* in this repository,
* open,
* labeled `open for pull requests`, and
* not already labeled `code review in progress`, which means someone is
  working on it already.

If there's no such issue yet, open one describing the problem or the feature,
including a complete, runnable example, and wait for a maintainer to add the
label. Please don't open a pull request first and ask for the label
afterwards.

### Fixes

Fixes: #

### Description

Fixes #9930