### PR TITLE
Document how to add dialect keywords get_columns() column information

### DIFF
--- a/doc/build/changelog/changelog_10.rst
+++ b/doc/build/changelog/changelog_10.rst
@@ -1157,7 +1157,7 @@
         reflection to support both the ``postgresql_with`` flag as well
         as the ``postgresql_using`` flag, which will now be set on
         :class:`.Index` objects that are reflected, as well present
-        in a new "dialect_options" dictionary in the result of
+        in a new "be" dictionary in the result of
         :meth:`_reflection.Inspector.get_indexes`.  Pull request courtesy Pete Hollobon.
 
         .. seealso::


### PR DESCRIPTION
This PR fixes the documentation issue reported in #5139: corrects `dialect_options` to `be` in `doc/build/changelog/changelog_10.rst`.

Fixes #5139

**This project accepts pull requests only for issues that a maintainer has
marked with the `open for pull requests` label.**

A pull request that doesn't reference such an issue **is closed
automatically**. That isn't a judgment on your change: it's how we settle on
an approach before anyone spends time writing code, and how we keep two
people from doing the same work at once.

The issue you reference has to be:

* in this repository,
* open,
* labeled `open for pull requests`, and
* not already labeled `code review in progress`, which means someone is
  working on it already.

If there's no such issue yet, open one describing the problem or the feature,
including a complete, runnable example, and wait for a maintainer to add the
label. Please don't open a pull request first and ask for the label
afterwards.

### Fixes

Fixes: #

### Description

Fixes #5139