### PR TITLE
sqlite: preserve table options during reflection

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2507,6 +2507,30 @@ class SQLiteDialect(default.DefaultDialect):
         else:
             return ReflectionDefaults.columns()
 
+    @reflection.cache
+    def get_table_options(self, connection, table_name, schema=None, **kw):
+        table_sql = self._get_table_sql(connection, table_name, schema=schema)
+        if table_sql is None:
+            raise exc.NoSuchTableError(
+                f"{schema}.{table_name}" if schema else table_name
+            )
+
+        match = re.match(
+            r"create table .*?\(.*\)(?P<options>.*?);?$",
+            table_sql.strip(),
+            re.DOTALL | re.IGNORECASE,
+        )
+        if not match:
+            return ReflectionDefaults.table_options()
+
+        options = {}
+        suffix = match.group("options")
+        if re.search(r"\bWITHOUT\s+ROWID\b", suffix, re.IGNORECASE):
+            options["sqlite_with_rowid"] = False
+        if re.search(r"\bSTRICT\b", suffix, re.IGNORECASE):
+            options["sqlite_strict"] = True
+        return options
+
     def _get_column_info(
         self,
         name,

--- a/test/dialect/sqlite/test_reflection.py
+++ b/test/dialect/sqlite/test_reflection.py
@@ -1476,6 +1476,37 @@ class ReflectInternalSchemaTables(fixtures.TablesTest):
             connection.exec_driver_sql("DROP VIEW sqlitetempview")
 
 
+class TableOptionsReflectionTest(fixtures.TestBase):
+    __only_on__ = "sqlite"
+    __backend__ = True
+
+    @testing.only_on("sqlite>=3.37.0")
+    def test_reflect_table_options(self, connection):
+        connection.exec_driver_sql(
+            "CREATE TABLE without_rowid (id INTEGER PRIMARY KEY) "
+            "WITHOUT ROWID"
+        )
+        connection.exec_driver_sql(
+            "CREATE TABLE strict (id INTEGER PRIMARY KEY) STRICT"
+        )
+        connection.exec_driver_sql(
+            "CREATE TABLE both (id INTEGER PRIMARY KEY) STRICT, WITHOUT ROWID"
+        )
+
+        inspector = inspect(connection)
+        eq_(inspector.get_table_options("without_rowid"),
+            {"sqlite_with_rowid": False})
+        eq_(inspector.get_table_options("strict"),
+            {"sqlite_strict": True})
+        eq_(inspector.get_table_options("both"),
+            {"sqlite_strict": True, "sqlite_with_rowid": False})
+
+        metadata = MetaData()
+        table = Table("both", metadata, autoload_with=connection)
+        eq_(dict(table.dialect_kwargs),
+            {"sqlite_strict": True, "sqlite_with_rowid": False})
+
+
 class ComputedReflectionTest(fixtures.TestBase):
     __only_on__ = "sqlite"
     __backend__ = True


### PR DESCRIPTION
## Summary

SQLite reflection currently drops STRICT and WITHOUT ROWID table options. This loses schema information from reflected Table objects and causes round trips such as Alembic batch recreates to omit the options.

Implement SQLite table option reflection and apply the reflected dialect kwargs to Table objects.

## Tests

- `/tmp/sqlalchemy-venv/bin/python -m pytest -q test/dialect/sqlite/test_reflection.py -k TableOptionsReflectionTest`
- `/tmp/sqlalchemy-venv/bin/python -m pytest -q test/dialect/sqlite/test_reflection.py`
- `git diff --check`

Fixes #13543.