### PR TITLE
Release disposed mappers from declared-events listeners and sync-target tracking

### DIFF
--- a/doc/build/changelog/unreleased_20/13564.rst
+++ b/doc/build/changelog/unreleased_20/13564.rst
@@ -1,0 +1,15 @@
+.. change::
+    :tags: bug, orm
+    :tickets: 13564
+
+    Fixed two process-wide references that kept the classes, mappers and
+    tables of a disposed :class:`_orm.registry` (or of classes removed via
+    :func:`_orm.clear_mappers`) in memory indefinitely.  The
+    ``after_configured`` / ``before_configured`` listeners that declarative
+    registers for ``__declare_last__`` and ``__declare_first__`` now refer to
+    the class weakly and are removed when the class is unmapped, instead of
+    accumulating one per mapped class for the lifetime of the process.  The
+    internal bookkeeping used to warn about relationships writing the same
+    column now holds its columns weakly as well, so that a column expression
+    attached to a table (such as an :class:`.Index` built from an ORM
+    attribute) no longer pins the whole mapping.

--- a/lib/sqlalchemy/orm/decl_api.py
+++ b/lib/sqlalchemy/orm/decl_api.py
@@ -53,6 +53,7 @@ from .decl_base import _DeclarativeMapperConfig
 from .decl_base import _DeferredDeclarativeConfig
 from .decl_base import _del_attribute
 from .decl_base import _ORMClassConfigurator
+from .decl_base import _remove_declared_events
 from .decl_base import MappedClassProtocol
 from .descriptor_props import Composite
 from .descriptor_props import Synonym
@@ -1549,6 +1550,7 @@ class registry(EventTarget):
 
         class_ = manager.class_
         self._dispose_cls(class_)
+        _remove_declared_events(class_)
         instrumentation._instrumentation_factory.unregister(class_)
 
     def generate_base(

--- a/lib/sqlalchemy/orm/decl_base.py
+++ b/lib/sqlalchemy/orm/decl_base.py
@@ -251,6 +251,23 @@ def _check_declared_props_nocascade(
         return False
 
 
+_declared_event_listeners: weakref.WeakKeyDictionary[
+    Type[Any], List[Tuple[str, Callable[[], None]]]
+] = weakref.WeakKeyDictionary()
+"""Mapper-level listeners created for ``__declare_last__`` /
+``__declare_first__``, keyed by the mapped class, so that they can be
+removed when the class is unmapped."""
+
+
+def _remove_declared_events(cls: Type[Any]) -> None:
+    """Remove the Mapper listeners that were registered for ``cls`` by
+    :meth:`._ClassScanMapperConfig._setup_declared_events`."""
+
+    for identifier, fn in _declared_event_listeners.pop(cls, ()):
+        if event.contains(Mapper, identifier, fn):
+            event.remove(Mapper, identifier, fn)
+
+
 class _ORMClassConfigurator:
     """Object that configures a class that's potentially going to be
     mapped, and/or turned into an ORM dataclass.
@@ -1041,21 +1058,41 @@ class _DeclarativeMapperConfig(_MapperConfig, _ClassScanAbstractConfig):
             self._early_mapping(util.EMPTY_DICT)
 
     def _setup_declared_events(self) -> None:
+        # The listeners registered here live on the Mapper class for the
+        # whole process.  They refer to the mapped class only through a
+        # weak reference and are recorded so that unmapping the class
+        # (registry.dispose(), clear_mappers()) can remove them; otherwise
+        # every class ever mapped with __declare_last__ would be kept alive
+        # and the listener list would grow without bound.
+        cls_ref = weakref.ref(self.cls)
+        listeners: List[Tuple[str, Callable[[], None]]] = []
+
         if _get_immediate_cls_attr(self.cls, "__declare_last__"):
 
-            @event.listens_for(Mapper, "after_configured")
             def after_configured() -> None:
-                cast(
-                    "_DeclMappedClassProtocol[Any]", self.cls
-                ).__declare_last__()
+                target = cls_ref()
+                if target is not None:
+                    cast(
+                        "_DeclMappedClassProtocol[Any]", target
+                    ).__declare_last__()
+
+            event.listen(Mapper, "after_configured", after_configured)
+            listeners.append(("after_configured", after_configured))
 
         if _get_immediate_cls_attr(self.cls, "__declare_first__"):
 
-            @event.listens_for(Mapper, "before_configured")
             def before_configured() -> None:
-                cast(
-                    "_DeclMappedClassProtocol[Any]", self.cls
-                ).__declare_first__()
+                target = cls_ref()
+                if target is not None:
+                    cast(
+                        "_DeclMappedClassProtocol[Any]", target
+                    ).__declare_first__()
+
+            event.listen(Mapper, "before_configured", before_configured)
+            listeners.append(("before_configured", before_configured))
+
+        if listeners:
+            _declared_event_listeners[self.cls] = listeners
 
     def _scan_attributes(self) -> None:
         cls = self.cls

--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -3208,10 +3208,15 @@ class _JoinCondition:
             secondary_sync_pairs
         )
 
+    # Both levels refer to their columns and properties weakly.  A strong
+    # reference to the "from" column would reach its Table and, through the
+    # ORM annotations of any expression attached to the table, the mapper
+    # and everything mapped alongside it; that in turn keeps the weak "to"
+    # column key alive, so entries for disposed mappers would never expire.
     _track_overlapping_sync_targets: weakref.WeakKeyDictionary[
         ColumnElement[Any],
         weakref.WeakKeyDictionary[
-            RelationshipProperty[Any], ColumnElement[Any]
+            RelationshipProperty[Any], weakref.ref[ColumnElement[Any]]
         ],
     ] = weakref.WeakKeyDictionary()
 
@@ -3238,15 +3243,17 @@ class _JoinCondition:
 
             if to_ not in self._track_overlapping_sync_targets:
                 self._track_overlapping_sync_targets[to_] = (
-                    weakref.WeakKeyDictionary({self.prop: from_})
+                    weakref.WeakKeyDictionary({self.prop: weakref.ref(from_)})
                 )
             else:
                 other_props = []
                 prop_to_from = self._track_overlapping_sync_targets[to_]
 
-                for pr, fr_ in prop_to_from.items():
+                for pr, fr_ref in prop_to_from.items():
+                    fr_ = fr_ref()
                     if (
-                        not pr.mapper._dispose_called
+                        fr_ is not None
+                        and not pr.mapper._dispose_called
                         and pr not in self.prop._reverse_property
                         and pr.key not in self.prop._overlaps
                         and self.prop.key not in pr._overlaps
@@ -3299,7 +3306,9 @@ class _JoinCondition:
                         ),
                         code="qzyx",
                     )
-                self._track_overlapping_sync_targets[to_][self.prop] = from_
+                self._track_overlapping_sync_targets[to_][self.prop] = (
+                    weakref.ref(from_)
+                )
 
     @util.memoized_property
     def remote_columns(self) -> Set[ColumnElement[Any]]:

--- a/test/orm/declarative/test_mixin.py
+++ b/test/orm/declarative/test_mixin.py
@@ -1,4 +1,5 @@
 from operator import is_not
+import weakref
 from typing import Annotated
 
 import sqlalchemy as sa
@@ -24,6 +25,7 @@ from sqlalchemy.orm import deferred
 from sqlalchemy.orm import events as orm_events
 from sqlalchemy.orm import has_inherited_table
 from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import Mapper
 from sqlalchemy.orm import registry
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm import synonym
@@ -2540,3 +2542,59 @@ class AbstractTest(DeclarativeTestBase):
         assert B1.__mapper__.inherits is A.__mapper__
 
         assert B2.__mapper__.inherits is A.__mapper__
+
+
+class DeclaredEventsGCTest(fixtures.TestBase):
+    """__declare_last__ / __declare_first__ listeners must neither keep a
+    disposed class alive nor accumulate on the Mapper class."""
+
+    __requires__ = ("predictable_gc",)
+
+    def _count_listeners(self, identifier):
+        dispatch = getattr(Mapper.dispatch, identifier)
+        return sum(len(coll) for coll in dispatch._clslevel.values())
+
+    @testing.teardown_events(orm_events.MapperEvents)
+    @testing.combinations(
+        ("__declare_last__", "after_configured"),
+        ("__declare_first__", "before_configured"),
+        argnames="hook, identifier",
+    )
+    def test_disposed_class_released(self, hook, identifier):
+        canary = mock.Mock()
+        before = self._count_listeners(identifier)
+
+        reg = registry()
+        Base = reg.generate_base()
+
+        if hook == "__declare_last__":
+
+            class A(Base):
+                __tablename__ = "a"
+                id = Column(Integer, primary_key=True)
+
+                @classmethod
+                def __declare_last__(cls):
+                    canary(cls.__name__)
+
+        else:
+
+            class A(Base):
+                __tablename__ = "a"
+                id = Column(Integer, primary_key=True)
+
+                @classmethod
+                def __declare_first__(cls):
+                    canary(cls.__name__)
+
+        configure_mappers()
+        eq_(canary.mock_calls, [mock.call("A")])
+        eq_(self._count_listeners(identifier), before + 1)
+
+        ref = weakref.ref(A)
+        reg.dispose()
+        del A, Base
+        gc_collect()
+
+        is_(ref(), None)
+        eq_(self._count_listeners(identifier), before)

--- a/test/orm/test_relationships.py
+++ b/test/orm/test_relationships.py
@@ -42,6 +42,10 @@ from sqlalchemy.testing import eq_
 from sqlalchemy.testing import expect_raises_message
 from sqlalchemy.testing import expect_warnings
 from sqlalchemy.testing import fixtures
+from sqlalchemy.testing.util import gc_collect
+from sqlalchemy.orm import registry
+from sqlalchemy import Index
+import weakref
 from sqlalchemy.testing import is_
 from sqlalchemy.testing.assertsql import assert_engine
 from sqlalchemy.testing.assertsql import CompiledSQL
@@ -7243,3 +7247,39 @@ class AnnotationsMaintainedTest(AssertsCompiledSQL, fixtures.TestBase):
             f"""{" AND employee.type IN (__[POSTCOMPILE_type_1])"
                  if use_orm else ""})""",
         )
+
+
+class SyncTargetsGCTest(fixtures.TestBase):
+    """the overlapping-sync-target tracking must not keep disposed
+    mappers alive."""
+
+    __requires__ = ("predictable_gc",)
+
+    def test_disposed_registry_released(self):
+        reg = registry()
+        Base = reg.generate_base()
+
+        class Parent(Base):
+            __tablename__ = "parent"
+            id = Column(Integer, primary_key=True)
+
+        class Child(Base):
+            __tablename__ = "child"
+            id = Column(Integer, primary_key=True)
+            parent_id = Column(ForeignKey("parent.id"))
+            parent = relationship(Parent)
+
+        # an expression built from an ORM attribute is annotated with the
+        # mapper; attached to the Table it links the Table back to the
+        # whole mapping
+        Index("ix_parent_id_desc", Parent.id.desc())
+        configure_mappers()
+
+        refs = [weakref.ref(obj) for obj in (Parent, Child, Parent.__table__)]
+        reg.dispose()
+        # the registry's MetaData still holds the tables, and the index
+        # expression links the table back to the mapper; drop it as well
+        del Parent, Child, Base, reg
+        gc_collect()
+
+        eq_([ref() for ref in refs], [None, None, None])


### PR DESCRIPTION
### Description

Fixes #13564.

Two process-wide structures kept disposed mappers (and everything reachable from them) alive:

- `_JoinCondition._track_overlapping_sync_targets` stored the `from_` column strongly. Whenever that column could reach the weak `to_` key (e.g. via an `Index` built from an ORM attribute, whose expression is annotated with the mapper), the entry never expired and pinned the whole mapping. The inner dictionary now stores `weakref.ref(from_)`; dead references are skipped when the conflict warning is evaluated.
- The `after_configured` / `before_configured` listeners created for `__declare_last__` / `__declare_first__` captured the `_ClassScanMapperConfig` (and the class) and were never removed. They now hold the class through a weak reference and are recorded per class so that `registry._dispose_manager_and_mapper()` (used by `registry.dispose()` and `clear_mappers()`) removes them.

Two tests added (`predictable_gc`): a class with either hook is collected after `registry.dispose()` and the listener count on `Mapper` returns to its previous value; a disposed registry with an ORM-attribute `Index` is collected.

### Checklist

This pull request is:

- [x] A bug fix
  - The changelog entry is in `doc/build/changelog/unreleased_20/`; ticket #13564.
- [ ] A new feature implementation
- [ ] A documentation / typographical / small typing error fix
