### PR TITLE
fix: implement SQLiteDialect.get_table_options to reflect STRICT and WITHOUT ROWID

### DIFF
--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -2462,6 +2462,27 @@ class SQLiteDialect(default.DefaultDialect):
             )
 
     @reflection.cache
+    def get_table_options(self, connection, table_name, schema=None, **kw):
+        opts = self._get_table_sql(connection, table_name, schema, **kw)
+        if opts is None:
+            return ReflectionDefaults.table_options()
+        # extract trailing STRICT / WITHOUT ROWID modifiers
+        opts_match = re.search(
+            r"(?:\s*,?\s*(?:WITHOUT\s+ROWID|STRICT))+$",
+            opts.strip(),
+            re.IGNORECASE,
+        )
+        if opts_match:
+            opts_str = opts_match.group(0).lower()
+            result = {}
+            if "strict" in opts_str:
+                result["sqlite_strict"] = True
+            if "without rowid" in opts_str:
+                result["sqlite_with_rowid"] = True
+            return result
+        return ReflectionDefaults.table_options()
+
+    @reflection.cache
     def get_columns(self, connection, table_name, schema=None, **kw):
         pragma = "table_info"
         # computed columns are threaded as hidden, they require table_xinfo


### PR DESCRIPTION
## Summary

SQLite reflection did not implement `get_table_options()`, causing `NotImplementedError` when calling `Inspector.get_table_options()` on any SQLite table. It also did not populate `Table.kwargs` with `sqlite_strict`/`sqlite_with_rowid`, so round-tripping `STRICT`/`WITHOUT ROWID` tables through reflection silently dropped both modifiers.

## Root Cause

`SQLiteDialect` inherits the base `NotImplementedError`-raising stub from `DefaultDialect`. The `get_columns()` implementation has a regex that strips `WITHOUT ROWID`/`STRICT` from the `CREATE TABLE` text but discards the information entirely.

## Fix

Implement `get_table_options()` that fetches the `CREATE TABLE` SQL via `_get_table_sql()` and extracts trailing `STRICT`/`WITHOUT ROWID` modifiers, returning them as `{'sqlite_strict': True}` and/or `{'sqlite_with_rowid': True}`.

```python
# Verification
>>> import sqlalchemy as sa
>>> e = sa.create_engine("sqlite://")
>>> with e.begin() as conn:
...     conn.exec_driver_sql(
...         'CREATE TABLE "t" (id INTEGER NOT NULL, PRIMARY KEY (id)) '
...         'WITHOUT ROWID, STRICT'
...     )
>>> meta = sa.MetaData()
>>> with e.begin() as conn:
...     reflected = sa.Table("t", meta, autoload_with=conn)
...     print(dict(reflected.kwargs))
{'sqlite_strict': True, 'sqlite_with_rowid': True}

>>> insp = sa.inspect(conn)
>>> insp.get_table_options("t")
{'sqlite_strict': True, 'sqlite_with_rowid': True}
```

Fixes #13543
