### PR TITLE
Support UPDATE..RETURNING on MariaDB 13.0.1+

### DIFF
--- a/doc/build/changelog/unreleased_21/13575.rst
+++ b/doc/build/changelog/unreleased_21/13575.rst
@@ -1,0 +1,12 @@
+.. change::
+    :tags: usecase, mariadb
+    :tickets: 13575
+
+    Added support for ``UPDATE..RETURNING`` on MariaDB, which is available as
+    of MariaDB 13.0.1.  The MariaDB dialect's ``update_returning`` flag is now
+    enabled when connected to MariaDB 13.0 or greater, so that
+    :meth:`_dml.Update.returning` may be used with :class:`_dml.Update`
+    constructs, in the same way as the existing ``INSERT..RETURNING`` and
+    ``DELETE..RETURNING`` support.  Multiple-table UPDATE statements do not
+    support ``RETURNING`` on MariaDB, so ``update_returning_multifrom``
+    remains disabled.

--- a/lib/sqlalchemy/dialects/mysql/_mariadb_shim.py
+++ b/lib/sqlalchemy/dialects/mysql/_mariadb_shim.py
@@ -244,6 +244,7 @@ class MariaDBShim(DefaultDialect):
             # if using older mariadb version
             self.delete_returning = True
             self.insert_returning = True
+            self.update_returning = True
 
         self.is_mariadb = is_mariadb
 
@@ -281,6 +282,9 @@ class MariaDBShim(DefaultDialect):
         self.delete_returning = self.server_version_info >= (10, 0, 5)
 
         self.insert_returning = self.server_version_info >= (10, 5)
+
+        # ref https://jira.mariadb.org/browse/MDEV-5092
+        self.update_returning = self.server_version_info >= (13, 0, 1)
 
         self._warn_for_known_db_issues()
 

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -556,15 +556,15 @@ available.
 
     :class:`_mysql.match`
 
-INSERT/DELETE...RETURNING
--------------------------
+INSERT/UPDATE/DELETE...RETURNING
+--------------------------------
 
-The MariaDB dialect supports 10.5+'s ``INSERT..RETURNING`` and
-``DELETE..RETURNING`` (10.0+) syntaxes.   ``INSERT..RETURNING`` may be used
-automatically in some cases in order to fetch newly generated identifiers in
-place of the traditional approach of using ``cursor.lastrowid``, however
-``cursor.lastrowid`` is currently still preferred for simple single-statement
-cases for its better performance.
+The MariaDB dialect supports 10.5+'s ``INSERT..RETURNING``,
+``DELETE..RETURNING`` (10.0+) and ``UPDATE..RETURNING`` (13.0.1+) syntaxes.
+``INSERT..RETURNING`` may be used automatically in some cases in order to fetch
+newly generated identifiers in place of the traditional approach of using
+``cursor.lastrowid``, however ``cursor.lastrowid`` is currently still preferred
+for simple single-statement cases for its better performance.
 
 To specify an explicit ``RETURNING`` clause, use the
 :meth:`._UpdateBase.returning` method on a per-statement basis::
@@ -572,6 +572,15 @@ To specify an explicit ``RETURNING`` clause, use the
     # INSERT..RETURNING
     result = connection.execute(
         table.insert().values(name="foo").returning(table.c.col1, table.c.col2)
+    )
+    print(result.all())
+
+    # UPDATE..RETURNING
+    result = connection.execute(
+        table.update()
+        .where(table.c.name == "foo")
+        .values(name="bar")
+        .returning(table.c.col1, table.c.col2)
     )
     print(result.all())
 
@@ -583,7 +592,13 @@ To specify an explicit ``RETURNING`` clause, use the
     )
     print(result.all())
 
+``UPDATE..RETURNING`` is supported for single-table UPDATE statements only;
+MariaDB does not support ``RETURNING`` with the multiple-table
+``UPDATE t1, t2 SET ...`` form.
+
 .. versionadded:: 2.0  Added support for MariaDB RETURNING
+
+.. versionadded:: 2.1  Added support for MariaDB 13.0's ``UPDATE..RETURNING``
 
 .. _mysql_insert_on_duplicate_key_update:
 

--- a/test/dialect/mysql/test_dialect.py
+++ b/test/dialect/mysql/test_dialect.py
@@ -625,6 +625,39 @@ class ParseVersionTest(fixtures.TestBase):
         assert dialect._is_mariadb is is_mariadb
 
     @testing.combinations(
+        ("10.4.0-MariaDB", False, True, False),
+        ("10.6.12-MariaDB", True, True, False),
+        ("11.4.2-MariaDB", True, True, False),
+        ("12.1.0-MariaDB", True, True, False),
+        ("13.0.0-MariaDB", True, True, False),
+        ("13.0.1-MariaDB", True, True, True),
+        ("13.1.0-MariaDB", True, True, True),
+        ("14.0.0-MariaDB", True, True, True),
+        argnames="version, insert_returning, delete_returning, "
+        "update_returning",
+    )
+    def test_mariadb_returning_flags(
+        self, version, insert_returning, delete_returning, update_returning
+    ):
+        dialect = mysql.dialect(is_mariadb=True)
+        dialect._parse_server_version(version)
+        dialect._initialize_mariadb(None)
+        eq_(dialect.insert_returning, insert_returning)
+        eq_(dialect.delete_returning, delete_returning)
+        eq_(dialect.update_returning, update_returning)
+        # MariaDB has no RETURNING for multiple-table UPDATE / DELETE
+        is_(dialect.update_returning_multifrom, False)
+        is_(dialect.delete_returning_multifrom, False)
+
+    def test_mysql_no_update_returning(self):
+        dialect = mysql.dialect()
+        dialect._parse_server_version("8.4.0")
+        dialect._initialize_mysql(None)
+        is_(dialect.insert_returning, False)
+        is_(dialect.update_returning, False)
+        is_(dialect.delete_returning, False)
+
+    @testing.combinations(
         (True, "10.2.7-MariaDB"),
         (True, "5.6.15-10.2.7-MariaDB"),
         (False, "10.2.10-MariaDB"),


### PR DESCRIPTION
Added support for ``UPDATE..RETURNING`` on MariaDB, which is available as of MariaDB 13.0.1. 

### Fixes

Fixes: #13575

### Description

 The MariaDB dialect's ``update_returning`` flag is now enabled when connected to MariaDB 13.0.1 or greater, in the same way as the existing ``INSERT..RETURNING`` and ``DELETE..RETURNING`` support.

``update_returning_multifrom`` remains disabled, as MariaDB only supports RETURNING for single-table UPDATE statements (multi-table support is tracked in MDEV-38704).
