### PR TITLE
Add column_template kwarg to composite() for dataclass composite classes

### DIFF
--- a/doc/build/changelog/unreleased_21/composite_column_template.rst
+++ b/doc/build/changelog/unreleased_21/composite_column_template.rst
@@ -1,0 +1,12 @@
+.. change::
+    :tags: feature, orm
+
+    Added :paramref:`_orm.composite.column_template` parameter to
+    :func:`_orm.composite`.  When the composite class is a dataclass, this
+    parameter accepts a string template such as ``"person_%s"``, containing
+    exactly one ``%s`` placeholder, that's used to generate column names for
+    dataclass fields that don't otherwise have an explicit name, rather than
+    using the bare field name.  This removes the need to hand-write a
+    :func:`_orm.mapped_column` for each field when the same composite
+    dataclass is mapped multiple times on the same class with different
+    column-name prefixes.

--- a/doc/build/orm/composites.rst
+++ b/doc/build/orm/composites.rst
@@ -85,6 +85,71 @@ The above mapping would correspond to a CREATE TABLE statement as:
     )
 
 
+.. _composite_column_template:
+
+Naming Composite Columns with a Template
+-----------------------------------------
+
+When the composite class is a dataclass, :func:`_orm.composite` will
+automatically generate a :func:`_orm.mapped_column` for any dataclass field
+that isn't otherwise given an explicit name, using the bare field name as
+the column name, as illustrated in the ``Vertex`` example above.  To apply a
+naming convention to these automatically generated columns instead, such as
+prefixing them, the :paramref:`_orm.composite.column_template` parameter may
+be passed a string containing exactly one ``%s`` placeholder, which is
+applied against each field name to generate the corresponding column name::
+
+    @dataclasses.dataclass
+    class Address:
+        street: str
+        city: str
+        zip: str
+
+
+    class Person(Base):
+        __tablename__ = "person"
+
+        id: Mapped[int] = mapped_column(primary_key=True)
+
+        home_address: Mapped[Address] = composite(
+            Address, column_template="home_%s"
+        )
+        work_address: Mapped[Address] = composite(
+            Address, column_template="work_%s"
+        )
+
+The above mapping is equivalent to spelling out each column explicitly::
+
+    home_address: Mapped[Address] = composite(
+        Address,
+        mapped_column("home_street"),
+        mapped_column("home_city"),
+        mapped_column("home_zip"),
+    )
+    work_address: Mapped[Address] = composite(
+        Address,
+        mapped_column("work_street"),
+        mapped_column("work_city"),
+        mapped_column("work_zip"),
+    )
+
+An explicitly passed :func:`_orm.mapped_column` or :class:`_schema.Column`
+still takes precedence over the template for the field position it
+occupies, allowing the template to be combined with one-off overrides::
+
+    shipping_address: Mapped[Address] = composite(
+        Address,
+        mapped_column("shipping_country"),  # explicit override
+        column_template="shipping_%s",  # applies to the rest
+    )
+
+:paramref:`_orm.composite.column_template` is only valid when the composite
+class is a dataclass; :class:`.ArgumentError` is raised otherwise, as well
+as for a malformed template or for a generated column name that collides
+with that of an attribute declared earlier in the same class body.
+
+.. versionadded:: 2.1
+
 Working with Mapped Composite Column Types
 -------------------------------------------
 

--- a/lib/sqlalchemy/orm/_orm_constructors.py
+++ b/lib/sqlalchemy/orm/_orm_constructors.py
@@ -642,6 +642,7 @@ def composite(
     return_none_on: Union[_NoArg, None, Callable[..., bool]] = _NoArg.NO_ARG,
     comparator_factory: Optional[Type[Composite.Comparator[_T]]] = None,
     active_history: bool = False,
+    column_template: Optional[str] = None,
     init: Union[_NoArg, bool] = _NoArg.NO_ARG,
     repr: Union[_NoArg, bool] = _NoArg.NO_ARG,  # noqa: A002
     default: Optional[Any] = _NoArg.NO_ARG,
@@ -667,6 +668,7 @@ def composite(
     return_none_on: Union[_NoArg, None, Callable[..., bool]] = _NoArg.NO_ARG,
     comparator_factory: Optional[Type[Composite.Comparator[_T]]] = None,
     active_history: bool = False,
+    column_template: Optional[str] = None,
     init: Union[_NoArg, bool] = _NoArg.NO_ARG,
     repr: Union[_NoArg, bool] = _NoArg.NO_ARG,  # noqa: A002
     default: Optional[Any] = _NoArg.NO_ARG,
@@ -691,6 +693,7 @@ def composite(
     return_none_on: Union[_NoArg, None, Callable[..., bool]] = _NoArg.NO_ARG,
     comparator_factory: Optional[Type[Composite.Comparator[_T]]] = None,
     active_history: bool = False,
+    column_template: Optional[str] = None,
     init: Union[_NoArg, bool] = _NoArg.NO_ARG,
     repr: Union[_NoArg, bool] = _NoArg.NO_ARG,  # noqa: A002
     default: Optional[Any] = _NoArg.NO_ARG,
@@ -716,6 +719,7 @@ def composite(
     return_none_on: Union[_NoArg, None, Callable[..., bool]] = _NoArg.NO_ARG,
     comparator_factory: Optional[Type[Composite.Comparator[_T]]] = None,
     active_history: bool = False,
+    column_template: Optional[str] = None,
     init: Union[_NoArg, bool] = _NoArg.NO_ARG,
     repr: Union[_NoArg, bool] = _NoArg.NO_ARG,  # noqa: A002
     default: Optional[Any] = _NoArg.NO_ARG,
@@ -785,6 +789,23 @@ def composite(
       :class:`.Composite.Comparator` which provides custom SQL
       clause generation for comparison operations.
 
+    :param column_template: A string template such as ``"person_%s"``,
+     containing exactly one ``%s`` placeholder, that's used to generate
+     column names for fields of a dataclass :paramref:`.composite.class_`
+     that don't otherwise have an explicit name.  Only supported when
+     :paramref:`.composite.class_` is a dataclass; for each dataclass
+     field that doesn't correspond to an explicitly named
+     :func:`_orm.mapped_column` or :class:`_schema.Column` argument passed
+     positionally to :func:`_orm.composite`, the generated column is named
+     using ``column_template % field_name`` rather than the bare field
+     name.  Raises :class:`.ArgumentError` if
+     :paramref:`.composite.class_` is not a dataclass, if the template
+     does not contain exactly one ``%s`` placeholder, or if a generated
+     name collides with the name of a column from an attribute already
+     declared earlier in the same class body.
+
+     .. versionadded:: 2.1
+
     :param doc:
       optional string that will be applied as the doc on the
       class-bound descriptor.
@@ -852,6 +873,7 @@ def composite(
         raiseload=raiseload,
         comparator_factory=comparator_factory,
         active_history=active_history,
+        column_template=column_template,
         info=info,
         doc=doc,
     )

--- a/lib/sqlalchemy/orm/descriptor_props.py
+++ b/lib/sqlalchemy/orm/descriptor_props.py
@@ -26,6 +26,7 @@ from typing import List
 from typing import NoReturn
 from typing import Optional
 from typing import Sequence
+from typing import Set
 from typing import Tuple
 from typing import Type
 from typing import TYPE_CHECKING
@@ -208,6 +209,7 @@ class CompositeProperty(
 
     composite_class: Union[Type[_CC], Callable[..., _CC]]
     attrs: Tuple[_CompositeAttrType[Any], ...]
+    column_template: Optional[str]
 
     _generated_composite_accessor: CallableReference[
         Optional[Callable[[_CC], Tuple[Any, ...]]]
@@ -229,6 +231,7 @@ class CompositeProperty(
         deferred: bool = False,
         group: Optional[str] = None,
         comparator_factory: Optional[Type[Comparator[_CC]]] = None,
+        column_template: Optional[str] = None,
         info: Optional[_InfoType] = None,
         **kwargs: Any,
     ):
@@ -241,6 +244,17 @@ class CompositeProperty(
         else:
             self.composite_class = _class_or_attr  # type: ignore[assignment]
             self.attrs = attrs
+
+        if column_template is not None:
+            try:
+                column_template % "x"
+            except (TypeError, ValueError) as te:
+                raise sa_exc.ArgumentError(
+                    f"column_template {column_template!r} is not a valid "
+                    "template; expected a string containing exactly one "
+                    "'%s' placeholder"
+                ) from te
+        self.column_template = column_template
 
         self.return_none_on = return_none_on
         self.active_history = active_history
@@ -428,6 +442,11 @@ class CompositeProperty(
                 decl_scan, registry, cls, originating_module, key
             )
         else:
+            if self.column_template is not None:
+                raise sa_exc.ArgumentError(
+                    "column_template is only supported when composite_class "
+                    "is a dataclass"
+                )
             for attr in self.attrs:
                 if (
                     isinstance(attr, (MappedColumn, schema.Column))
@@ -467,6 +486,35 @@ class CompositeProperty(
                 )
 
     @util.preload_module("sqlalchemy.orm.properties")
+    def _existing_declared_column_names(
+        self, decl_scan: _DeclarativeMapperConfig
+    ) -> Set[str]:
+        """Return the column names of attributes already scanned on the
+        class being mapped, at the point this composite is being scanned.
+
+        Used for a best-effort collision check when generating column
+        names from :paramref:`.composite.column_template`; attributes
+        that appear later in the class body are not visible here and are
+        not covered by this check.
+
+        """
+        MappedColumn = util.preloaded.orm_properties.MappedColumn
+
+        names: Set[str] = set()
+        for value in decl_scan.properties.values():
+            if isinstance(value, MappedColumn):
+                if value.column.name is not None:
+                    names.add(value.column.name)
+            elif isinstance(value, schema.Column):
+                if value.name is not None:
+                    names.add(value.name)
+            elif isinstance(value, CompositeProperty):
+                for col in value.columns:
+                    if col.name is not None:
+                        names.add(col.name)
+        return names
+
+    @util.preload_module("sqlalchemy.orm.properties")
     @util.preload_module("sqlalchemy.orm.decl_base")
     def _setup_for_dataclass(
         self,
@@ -481,6 +529,11 @@ class CompositeProperty(
         decl_base = util.preloaded.orm_decl_base
 
         insp = inspect.signature(self.composite_class)
+        existing_names = (
+            self._existing_declared_column_names(decl_scan)
+            if self.column_template is not None
+            else None
+        )
         for param, attr in itertools.zip_longest(
             insp.parameters.values(), self.attrs
         ):
@@ -492,8 +545,21 @@ class CompositeProperty(
                     f"{self.composite_class.__name__} {len(insp.parameters)}"
                 )
             if attr is None:
-                # fill in missing attr spots with empty MappedColumn
-                attr = MappedColumn()
+                # fill in missing attr spots with empty MappedColumn,
+                # or one named from column_template if present
+                if self.column_template is not None:
+                    generated_name = self.column_template % param.name
+                    assert existing_names is not None
+                    if generated_name in existing_names:
+                        raise sa_exc.ArgumentError(
+                            f"column_template generated column name "
+                            f"'{generated_name}' for composite '{key}' "
+                            f"conflicts with an existing column on class "
+                            f"{cls.__name__}"
+                        )
+                    attr = MappedColumn(generated_name)
+                else:
+                    attr = MappedColumn()
                 self.attrs += (attr,)
 
             if isinstance(attr, MappedColumn):

--- a/test/orm/declarative/test_dc_transforms.py
+++ b/test/orm/declarative/test_dc_transforms.py
@@ -2847,6 +2847,149 @@ class CompositeTest(fixtures.TestBase, testing.AssertsCompiledSQL):
         )
         eq_(repr(u2), "mymodule.User(name='u2', address=None)")
 
+    def test_column_template(self, dc_decl_base: Type[MappedAsDataclass]):
+        @dataclasses.dataclass
+        class Address:
+            street: str
+            city: str
+            zip_: str
+
+        class Person(dc_decl_base):
+            __tablename__ = "person"
+
+            id: Mapped[int] = mapped_column(
+                primary_key=True, init=False, repr=False
+            )
+
+            home_address: Mapped[Address] = composite(
+                Address, column_template="home_%s", default=None
+            )
+            work_address: Mapped[Address] = composite(
+                Address, column_template="work_%s", default=None
+            )
+
+        eq_(
+            {c.name for c in Person.__table__.c},
+            {
+                "id",
+                "home_street",
+                "home_city",
+                "home_zip_",
+                "work_street",
+                "work_city",
+                "work_zip_",
+            },
+        )
+
+        p = Person(
+            home_address=Address("123 anywhere", "Springfield", "00000"),
+            work_address=Address("1 Main St", "Metropolis", "11111"),
+        )
+        eq_(p.home_address, Address("123 anywhere", "Springfield", "00000"))
+        eq_(p.work_address, Address("1 Main St", "Metropolis", "11111"))
+
+    def test_column_template_explicit_override(
+        self, dc_decl_base: Type[MappedAsDataclass]
+    ):
+        @dataclasses.dataclass
+        class Address:
+            country: str
+            city: str
+            zip_: str
+
+        class Person(dc_decl_base):
+            __tablename__ = "person"
+
+            id: Mapped[int] = mapped_column(
+                primary_key=True, init=False, repr=False
+            )
+
+            shipping_address: Mapped[Address] = composite(
+                Address,
+                mapped_column("shipping_country_code"),
+                column_template="shipping_%s",
+                default=None,
+            )
+
+        eq_(
+            {c.name for c in Person.__table__.c},
+            {"id", "shipping_country_code", "shipping_city", "shipping_zip_"},
+        )
+
+    def test_column_template_requires_dataclass(
+        self, dc_decl_base: Type[MappedAsDataclass]
+    ):
+        class Address:
+            def __init__(self, street, city):
+                self.street = street
+                self.city = city
+
+            def __composite_values__(self):
+                return (self.street, self.city)
+
+        with expect_raises_message(
+            exc.ArgumentError,
+            "column_template is only supported when composite_class "
+            "is a dataclass",
+        ):
+
+            class Person(dc_decl_base):
+                __tablename__ = "person"
+
+                id: Mapped[int] = mapped_column(
+                    primary_key=True, init=False, repr=False
+                )
+
+                address: Mapped[Address] = composite(
+                    Address,
+                    mapped_column("street"),
+                    mapped_column("city"),
+                    column_template="home_%s",
+                    default=None,
+                )
+
+    @testing.combinations(
+        "person",
+        "person_%s_%s",
+        "%(name)s",
+        argnames="bad_template",
+    )
+    def test_column_template_bad_format(self, bad_template):
+        with expect_raises_message(
+            exc.ArgumentError,
+            "is not a valid template",
+        ):
+            composite(column_template=bad_template)
+
+    def test_column_template_collision(
+        self, dc_decl_base: Type[MappedAsDataclass]
+    ):
+        @dataclasses.dataclass
+        class Address:
+            street: str
+            city: str
+
+        with expect_raises_message(
+            exc.ArgumentError,
+            "column_template generated column name 'home_street' for "
+            "composite 'home_address' conflicts with an existing column "
+            "on class Person",
+        ):
+
+            class Person(dc_decl_base):
+                __tablename__ = "person"
+
+                id: Mapped[int] = mapped_column(
+                    primary_key=True, init=False, repr=False
+                )
+                home_street: Mapped[str] = mapped_column(
+                    init=False, default=None
+                )
+
+                home_address: Mapped[Address] = composite(
+                    Address, column_template="home_%s", default=None
+                )
+
 
 class ReadOnlyAttrTest(fixtures.TestBase, testing.AssertsCompiledSQL):
     """tests related to #9628"""


### PR DESCRIPTION
### Fixes

Fixes: #12575

### Description

Adds a column_template parameter to `_orm.composite()`. When the composite class is a dataclass, this parameter accepts a string template (e.g. "person_%s") with exactly one `%s` placeholder, used to generate column names for dataclass fields that don't otherwise have an explicit name.