### PR TITLE
Improve validation and failure modes in with_parent()

### DIFF
--- a/doc/build/changelog/unreleased_21/6860.rst
+++ b/doc/build/changelog/unreleased_21/6860.rst
@@ -1,0 +1,11 @@
+.. change::
+    :tags: bug, orm
+    :tickets: 6860
+
+    Improved validation and error messages in :func:`_orm.with_parent`.
+    An :class:`~sqlalchemy.exc.ArgumentError` is now raised early when
+    the given instance is ``None``, is not a mapped instance, or does not
+    match the parent mapper of the specified relationship attribute.
+    Passing a non-attribute or unsupported object as the relationship
+    property also now raises :class:`~sqlalchemy.exc.ArgumentError` rather
+    than falling through to an unhandled ``AttributeError``.

--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -1233,7 +1233,10 @@ class RelationshipProperty(
         alias_secondary: bool = True,
         from_entity: Optional[_EntityType[Any]] = None,
     ) -> ColumnElement[bool]:
-        assert instance is not None
+        if instance is None:
+            raise sa_exc.ArgumentError(
+                f"Expected mapped instance for relationship '{self}', got None"
+            )
         adapt_source: Optional[_CoreAdapterProto] = None
         if from_entity is not None:
             insp: Optional[_InternalEntityType[Any]] = inspect(from_entity)
@@ -1290,6 +1293,14 @@ class RelationshipProperty(
             mapper = self.mapper
         else:
             mapper = self.parent
+
+        if not state.mapper.isa(mapper):
+            raise sa_exc.ArgumentError(
+                f"Instance '{state.obj()}' is not an instance of "
+                f"'{mapper.class_.__name__}', which is the "
+                f"{'target' if reverse_direction else 'parent'} class for "
+                f"relationship '{self}'"
+            )
 
         dict_ = attributes.instance_dict(state.obj())
 

--- a/lib/sqlalchemy/orm/util.py
+++ b/lib/sqlalchemy/orm/util.py
@@ -2059,6 +2059,17 @@ def with_parent(
       "zero" entity of the :class:`_query.Query` itself.
 
     """  # noqa: E501
+    if instance is None:
+        raise sa_exc.ArgumentError(
+            "Expected mapped instance for with_parent(), got None"
+        )
+
+    state = inspection.inspect(instance, raiseerr=False)
+    if state is None or not getattr(state, "is_instance", False):
+        raise sa_exc.ArgumentError(
+            f"Expected mapped instance for with_parent(), got {instance!r}"
+        )
+
     prop_t: RelationshipProperty[Any]
 
     if isinstance(prop, str):
@@ -2077,8 +2088,20 @@ def with_parent(
                 f"got {mapper_property}"
             )
         prop_t = mapper_property
+    elif hasattr(prop, "_with_parent"):
+        prop_t = prop  # type: ignore[assignment]
     else:
-        prop_t = prop
+        raise sa_exc.ArgumentError(
+            f"Expected relationship property for with_parent(), got {prop!r}"
+        )
+
+    if hasattr(prop_t, "parent") and hasattr(prop_t.parent, "isa"):
+        if not state.mapper.isa(prop_t.parent):
+            raise sa_exc.ArgumentError(
+                f"Instance '{instance}' is not an instance of "
+                f"'{prop_t.parent.class_.__name__}', which is the parent "
+                f"class for relationship '{prop}'"
+            )
 
     return prop_t._with_parent(instance, from_entity=from_entity)
 

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -6002,6 +6002,52 @@ class ParentTest(QueryTest, AssertsCompiledSQL):
         ):
             with_parent(u1, User.name)
 
+    def test_none_instance(self):
+        User = self.classes.User
+        with expect_raises_message(
+            sa_exc.ArgumentError,
+            r"Expected mapped instance for with_parent\(\), got None",
+        ):
+            with_parent(None, User.orders)
+
+    def test_non_mapped_instance(self):
+        User = self.classes.User
+        with expect_raises_message(
+            sa_exc.ArgumentError,
+            r"Expected mapped instance for with_parent\(\)",
+        ):
+            with_parent(object(), User.orders)
+
+    def test_non_attribute_prop(self):
+        User = self.classes.User
+        sess = fixture_session()
+        u1 = sess.get(User, 7)
+        with expect_raises_message(
+            sa_exc.ArgumentError,
+            r"Expected relationship property for with_parent\(\), got 123",
+        ):
+            with_parent(u1, 123)
+
+    def test_mismatched_instance(self):
+        User, Order = self.classes.User, self.classes.Order
+        sess = fixture_session()
+        u1 = sess.get(User, 7)
+        o1 = sess.get(Order, 1)
+
+        with expect_raises_message(
+            sa_exc.ArgumentError,
+            r"is not an instance of 'User', which is the parent class for "
+            r"relationship 'User.orders'",
+        ):
+            with_parent(o1, User.orders)
+
+        with expect_raises_message(
+            sa_exc.ArgumentError,
+            r"is not an instance of 'Order', which is the parent class for "
+            r"relationship 'Order.items'",
+        ):
+            with_parent(u1, Order.items)
+
     def test_select_from(self):
         User, Address = self.classes.User, self.classes.Address
 


### PR DESCRIPTION
### Fixes
Fixes: #6860

### Description
Improve error reporting and validation for `with_parent()`:
- Added early validation in `with_parent()` ensuring `instance` is not `None` and is a mapped instance, raising a descriptive `ArgumentError`.
- Added early validation in `_with_parent()` and `_optimized_compare()` ensuring `instance` matches the parent mapper of the provided relationship property (`not state.mapper.isa(mapper)`), raising an `ArgumentError` when mismatched entities are passed (e.g., `with_parent(a1, B.a)` where `B.a` belongs to `B`).
- Added validation for `property` to ensure it is a valid relationship attribute or queryable property, raising `ArgumentError` rather than falling through to an unhandled `AttributeError`.

### Checklist
- [x] Added unit tests covering all failure modes in `test/orm/test_query.py` (`ParentTest`)
- [x] All 19 `ParentTest` tests and existing `with_parent` tests pass cleanly
- [x] Added changelog fragment `doc/build/changelog/unreleased_21/6860.rst`