### PR TITLE
Reflect PostgreSQL index validity separately from DDL options

### DIFF
--- a/doc/build/changelog/unreleased_21/13577.rst
+++ b/doc/build/changelog/unreleased_21/13577.rst
@@ -1,0 +1,16 @@
+.. change::
+    :tags: usecase, postgresql, reflection
+    :tickets: 13577
+
+    PostgreSQL index reflection now reports invalid indexes with
+    ``postgresql_not_valid=True`` in the Inspector's ``dialect_options``.
+    Reflected :class:`.Index` objects expose this state in a separate,
+    read-only ``index.dialect_options["postgresql"].reflected`` mapping.
+    The new :attr:`.SchemaConst.IGNORE_OPTION` marker distinguishes these
+    values from DDL options and lets constructors accept and discard them
+    for compatibility with consumers of Inspector results. The state does
+    not affect DDL or :attr:`.Index.dialect_kwargs`.
+
+    .. seealso::
+
+        :ref:`postgresql_invalid_index_reflection`

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1215,10 +1215,7 @@ DDL options on each reflected :class:`.Index`::
 
 The ``reflected`` mapping is read-only. These values are not included in
 :attr:`.Index.dialect_kwargs`, do not affect DDL, and are not copied by
-:meth:`.Table.to_metadata`. The :class:`.Index` constructor accepts and ignores
-``postgresql_not_valid`` so that consumers which construct indexes directly
-from Inspector results continue to work. Passing the keyword does not set
-the reflected state.
+:meth:`.Table.to_metadata`.
 
 An invalid index may be left by a failed ``CREATE INDEX CONCURRENTLY``, may
 still be building, or may be a partitioned index awaiting attachment of its

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1192,6 +1192,43 @@ in :attr:`_schema.Table.indexes` when it is detected as mirroring a
 :class:`.UniqueConstraint` in the :attr:`_schema.Table.constraints` collection
 .
 
+.. _postgresql_invalid_index_reflection:
+
+Invalid indexes
+^^^^^^^^^^^^^^^
+
+Indexes marked invalid by PostgreSQL remain present in reflection. The
+:meth:`_reflection.Inspector.get_indexes` and
+:meth:`_reflection.Inspector.get_multi_indexes` methods include
+``postgresql_not_valid=True`` in the index's ``dialect_options`` dictionary
+when ``pg_index.indisvalid`` is false. Valid indexes omit this flag.
+
+When reflecting a :class:`_schema.Table`, the flag is stored separately from
+DDL options on each reflected :class:`.Index`::
+
+    table = Table("my_table", MetaData(), autoload_with=engine)
+    for index in table.indexes:
+        if index.dialect_options["postgresql"].reflected.get(
+            "not_valid", False
+        ):
+            print(index.name)
+
+The ``reflected`` mapping is read-only. These values are not included in
+:attr:`.Index.dialect_kwargs`, do not affect DDL, and are not copied by
+:meth:`.Table.to_metadata`. The :class:`.Index` constructor accepts and ignores
+``postgresql_not_valid`` so that consumers which construct indexes directly
+from Inspector results continue to work. Passing the keyword does not set
+the reflected state.
+
+An invalid index may be left by a failed ``CREATE INDEX CONCURRENTLY``, may
+still be building, or may be a partitioned index awaiting attachment of its
+partition indexes. This flag reports the state at reflection time; it does
+not request an index rebuild. Unlike the ``postgresql_not_valid`` option for
+CHECK and FOREIGN KEY constraints, it does not correspond to ``NOT VALID``
+DDL syntax for indexes.
+
+.. versionadded:: 2.1
+
 Special Reflection Options
 --------------------------
 
@@ -3666,6 +3703,7 @@ class PGDialect(default._BackendsMultiReflection, default.DefaultDialect):
                 "with": {},
                 "tablespace": None,
                 "nulls_not_distinct": None,
+                "not_valid": schema.SchemaConst.IGNORE_OPTION,
             },
         ),
         (
@@ -5269,6 +5307,7 @@ class PGDialect(default._BackendsMultiReflection, default.DefaultDialect):
                 pg_catalog.pg_index.c.indrelid,
                 pg_catalog.pg_class.c.relname,
                 pg_catalog.pg_index.c.indisunique,
+                pg_catalog.pg_index.c.indisvalid,
                 pg_catalog.pg_constraint.c.conrelid.is_not(None).label(
                     "has_constraint"
                 ),
@@ -5474,6 +5513,9 @@ class PGDialect(default._BackendsMultiReflection, default.DefaultDialect):
                         dialect_options["postgresql_nulls_not_distinct"] = row[
                             "indnullsnotdistinct"
                         ]
+
+                    if not row["indisvalid"]:
+                        dialect_options["postgresql_not_valid"] = True
 
                     if dialect_options:
                         index["dialect_options"] = dialect_options

--- a/lib/sqlalchemy/engine/interfaces.py
+++ b/lib/sqlalchemy/engine/interfaces.py
@@ -560,7 +560,13 @@ class ReflectedIndex(TypedDict):
     """
 
     dialect_options: NotRequired[Dict[str, Any]]
-    """Additional dialect-specific options detected for this index"""
+    """Additional dialect-specific options detected for this index.
+
+    This may include database state that is not a DDL option. Table reflection
+    places such values in the dialect's separate ``reflected`` mapping; see
+    :attr:`.DialectKWArgs.dialect_options`.
+
+    """
 
 
 class ReflectedTableComment(TypedDict):
@@ -1258,6 +1264,15 @@ class Dialect(EventTarget):
     the namespace of arguments prefixed with that dialect name.  The rationale
     here is so that third-party dialects that haven't yet implemented this
     feature continue to function in the old way.
+
+    For index options which describe database state rather than DDL, the
+    default may be :attr:`.SchemaConst.IGNORE_OPTION`. Such keywords are
+    accepted and discarded by the constructor, while index reflection
+    stores their values in the dialect's separate ``reflected`` mapping.
+    They are excluded from ordinary option defaults and
+    :attr:`.DialectKWArgs.dialect_kwargs`.
+
+    .. versionadded:: 2.1 Added :attr:`.SchemaConst.IGNORE_OPTION`.
 
     .. seealso::
 

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -1918,12 +1918,12 @@ class Inspector(inspection.Inspectable["Inspector"]):
                             idx_element = op(idx_element)
                 idx_elements.append(idx_element)
             else:
-                sa_schema.Index(
+                sa_schema.Index._from_reflection(
                     name,
                     *idx_elements,
                     _table=table,
                     unique=unique,
-                    **dialect_options,
+                    dialect_options=dialect_options,
                 )
 
     def _reflect_unique_constraints(

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -1918,12 +1918,13 @@ class Inspector(inspection.Inspectable["Inspector"]):
                             idx_element = op(idx_element)
                 idx_elements.append(idx_element)
             else:
-                sa_schema.Index._from_reflection(
+                sa_schema.Index(
                     name,
                     *idx_elements,
                     _table=table,
                     unique=unique,
-                    dialect_options=dialect_options,
+                    _dialect_kwargs_from_reflection=True,
+                    **dialect_options,
                 )
 
     def _reflect_unique_constraints(

--- a/lib/sqlalchemy/sql/base.py
+++ b/lib/sqlalchemy/sql/base.py
@@ -448,6 +448,17 @@ class _DialectArgDict(MutableMapping[str, Any]):
     def __init__(self) -> None:
         self._non_defaults: Dict[str, Any] = {}
         self._defaults: Dict[str, Any] = {}
+        self._ignored: FrozenSet[str] = util.EMPTY_SET
+        self._reflected: util.immutabledict[str, Any] = util.EMPTY_DICT
+
+    @property
+    def reflected(self) -> Mapping[str, Any]:
+        """Database state populated by reflection, separate from DDL options.
+
+        .. versionadded:: 2.1
+
+        """
+        return self._reflected
 
     def __len__(self) -> int:
         return len(set(self._non_defaults).union(self._defaults))
@@ -462,6 +473,8 @@ class _DialectArgDict(MutableMapping[str, Any]):
             return self._defaults[key]
 
     def __setitem__(self, key: str, value: Any) -> None:
+        if key in self._ignored:
+            return
         self._non_defaults[key] = value
 
     def __delitem__(self, key: str) -> None:
@@ -525,6 +538,8 @@ class DialectKWArgs:
             return else_
 
         if argument_name in registry.get(self.__class__, {}):
+            if argument_name in self.dialect_options[dialect.name]._ignored:
+                return else_
             if (
                 deprecated_fallback is None
                 or dialect.name == deprecated_fallback
@@ -651,6 +666,7 @@ class DialectKWArgs:
     )
 
     @classmethod
+    @util.preload_module("sqlalchemy.sql.schema")
     def _kw_reg_for_dialect_cls(cls, dialect_name: str) -> _DialectArgDict:
         construct_arg_dictionary = DialectKWArgs._kw_registry[dialect_name]
         d = _DialectArgDict()
@@ -661,6 +677,13 @@ class DialectKWArgs:
             for cls in reversed(cls.__mro__):
                 if cls in construct_arg_dictionary:
                     d._defaults.update(construct_arg_dictionary[cls])
+        d._ignored = frozenset(
+            key
+            for key, value in d._defaults.items()
+            if value is util.preloaded.sql_schema.SchemaConst.IGNORE_OPTION
+        )
+        for key in d._ignored:
+            del d._defaults[key]
         return d
 
     @util.memoized_property
@@ -676,6 +699,19 @@ class DialectKWArgs:
 
         .. versionadded:: 0.9.2
 
+        For reflected indexes, database state that is not a DDL option is
+        available in a separate, read-only ``reflected`` mapping, for example::
+
+            invalid = my_index.dialect_options["postgresql"].reflected.get(
+                "not_valid", False
+            )
+
+        These values are not included in this dictionary or in
+        :attr:`.DialectKWArgs.dialect_kwargs`. They cannot be set through
+        constructor arguments and are not copied by :meth:`.Table.to_metadata`.
+
+        .. versionadded:: 2.1 Added the ``reflected`` mapping.
+
         .. seealso::
 
             :attr:`.DialectKWArgs.dialect_kwargs` - flat dictionary form
@@ -683,6 +719,42 @@ class DialectKWArgs:
         """
 
         return util.PopulateDict(self._kw_reg_for_dialect_cls)
+
+    @classmethod
+    def _from_reflection(
+        cls,
+        *args: Any,
+        dialect_options: Mapping[str, Any],
+        **kwargs: Any,
+    ) -> Self:
+        """Construct an object with separate reflected state."""
+        options = dict(dialect_options)
+        dialects: Dict[str, _DialectArgDict] = {}
+        reflected: Dict[str, Dict[str, Any]] = {}
+        for key in dialect_options:
+            dialect_name, separator, arg_name = key.partition("_")
+            if not separator:
+                # Leave malformed options to the constructor's validation.
+                continue
+            if dialect_name not in dialects:
+                try:
+                    dialects[dialect_name] = cls._kw_reg_for_dialect_cls(
+                        dialect_name
+                    )
+                except exc.NoSuchModuleError:
+                    # Preserve the constructor's warning for unknown dialects.
+                    continue
+            if arg_name in dialects[dialect_name]._ignored:
+                reflected.setdefault(dialect_name, {})[arg_name] = options.pop(
+                    key
+                )
+
+        obj = cls(*args, **kwargs, **options)
+        for dialect_name, values in reflected.items():
+            obj.dialect_options[dialect_name]._reflected = util.immutabledict(
+                values
+            )
+        return obj
 
     def _validate_dialect_kwargs(self, kwargs: Dict[str, Any]) -> None:
         # validate remaining kwargs that they all specify DB prefixes
@@ -711,6 +783,11 @@ class DialectKWArgs:
                 d._defaults.update({"*": None})
                 d._non_defaults[arg_name] = kwargs[k]
             else:
+                if arg_name in construct_arg_dictionary._ignored:
+                    # Consumers such as Alembic construct Index directly from
+                    # Inspector options. Accept reflected state without making
+                    # it part of dialect_kwargs or the generated DDL.
+                    continue
                 if (
                     "*" not in construct_arg_dictionary
                     and arg_name not in construct_arg_dictionary

--- a/lib/sqlalchemy/sql/base.py
+++ b/lib/sqlalchemy/sql/base.py
@@ -720,43 +720,9 @@ class DialectKWArgs:
 
         return util.PopulateDict(self._kw_reg_for_dialect_cls)
 
-    @classmethod
-    def _from_reflection(
-        cls,
-        *args: Any,
-        dialect_options: Mapping[str, Any],
-        **kwargs: Any,
-    ) -> Self:
-        """Construct an object with separate reflected state."""
-        options = dict(dialect_options)
-        dialects: Dict[str, _DialectArgDict] = {}
-        reflected: Dict[str, Dict[str, Any]] = {}
-        for key in dialect_options:
-            dialect_name, separator, arg_name = key.partition("_")
-            if not separator:
-                # Leave malformed options to the constructor's validation.
-                continue
-            if dialect_name not in dialects:
-                try:
-                    dialects[dialect_name] = cls._kw_reg_for_dialect_cls(
-                        dialect_name
-                    )
-                except exc.NoSuchModuleError:
-                    # Preserve the constructor's warning for unknown dialects.
-                    continue
-            if arg_name in dialects[dialect_name]._ignored:
-                reflected.setdefault(dialect_name, {})[arg_name] = options.pop(
-                    key
-                )
-
-        obj = cls(*args, **kwargs, **options)
-        for dialect_name, values in reflected.items():
-            obj.dialect_options[dialect_name]._reflected = util.immutabledict(
-                values
-            )
-        return obj
-
-    def _validate_dialect_kwargs(self, kwargs: Dict[str, Any]) -> None:
+    def _validate_dialect_kwargs(
+        self, kwargs: Dict[str, Any], *, _from_reflection: bool = False
+    ) -> None:
         # validate remaining kwargs that they all specify DB prefixes
 
         if not kwargs:
@@ -784,6 +750,12 @@ class DialectKWArgs:
                 d._non_defaults[arg_name] = kwargs[k]
             else:
                 if arg_name in construct_arg_dictionary._ignored:
+                    if _from_reflection:
+                        construct_arg_dictionary._reflected = (
+                            construct_arg_dictionary._reflected.union(
+                                {arg_name: kwargs[k]}
+                            )
+                        )
                     # Consumers such as Alembic construct Index directly from
                     # Inspector options. Accept reflected state without making
                     # it part of dialect_kwargs or the generated DDL.

--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -6012,6 +6012,7 @@ class Index(
         info: Optional[_InfoType] = None,
         _table: Optional[Table] = None,
         _column_flag: bool = False,
+        _dialect_kwargs_from_reflection: bool = False,
         **dialect_kw: Any,
     ) -> None:
         r"""Construct an index object.
@@ -6055,7 +6056,9 @@ class Index(
         if _table is not None:
             table = _table
 
-        self._validate_dialect_kwargs(dialect_kw)
+        self._validate_dialect_kwargs(
+            dialect_kw, _from_reflection=_dialect_kwargs_from_reflection
+        )
 
         self.expressions = []
         # will call _set_parent() if table-bound column

--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -175,6 +175,19 @@ class SchemaConst(Enum):
 
     """
 
+    IGNORE_OPTION = 4
+    """Mark a dialect argument as database state used only by reflection.
+
+    When used as an argument default in
+    :attr:`.DefaultDialect.construct_arguments`, the option is accepted and
+    discarded by the constructor.  Index reflection instead places its value
+    in the dialect's read-only ``reflected`` mapping, separate from the
+    options used to generate DDL.
+
+    .. versionadded:: 2.1
+
+    """
+
 
 RETAIN_SCHEMA: Final[Literal[SchemaConst.RETAIN_SCHEMA]] = (
     SchemaConst.RETAIN_SCHEMA

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -216,6 +216,165 @@ class PartitionedReflectionTest(fixtures.TablesTest, AssertsExecutionResults):
         )
 
 
+class InvalidIndexReflectionTest(fixtures.TestBase, AssertsCompiledSQL):
+    __only_on__ = "postgresql"
+
+    @testing.fixture
+    def invalid_index(self, metadata):
+        table = Table(
+            "invalid_index_table",
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("x", Integer),
+        )
+        with testing.db.begin() as connection:
+            metadata.create_all(connection)
+            connection.execute(
+                table.insert(), [{"id": 1, "x": 1}, {"id": 2, "x": 1}]
+            )
+            connection.exec_driver_sql(
+                "CREATE INDEX ix_valid ON invalid_index_table (x)"
+            )
+        with testing.db.connect().execution_options(
+            isolation_level="AUTOCOMMIT"
+        ) as connection:
+            with expect_raises(exc.IntegrityError):
+                connection.exec_driver_sql(
+                    "CREATE UNIQUE INDEX CONCURRENTLY ix_invalid "
+                    "ON invalid_index_table (x)"
+                )
+            yield connection, table
+
+    def test_inspector(self, invalid_index):
+        connection, table = invalid_index
+        is_false(
+            connection.scalar(
+                sa.select(pg_catalog.pg_index.c.indisvalid).where(
+                    pg_catalog.pg_index.c.indexrelid
+                    == sa.cast("ix_invalid", pg_catalog.REGCLASS)
+                )
+            )
+        )
+        options = (
+            {"postgresql_include": []}
+            if testing.against("postgresql >= 11")
+            else {}
+        )
+        expected = [
+            {
+                "name": "ix_invalid",
+                "unique": True,
+                "column_names": ["x"],
+                "dialect_options": dict(options, postgresql_not_valid=True),
+            },
+            {"name": "ix_valid", "unique": False, "column_names": ["x"]},
+        ]
+        if options:
+            expected[1]["dialect_options"] = options
+        inspector = inspect(connection)
+        eq_(inspector.get_indexes(table.name), expected)
+        eq_(
+            inspector.get_multi_indexes(filter_names=[table.name]),
+            {(None, table.name): expected},
+        )
+
+        # This is how consumers such as Alembic reconstruct Index from the
+        # Inspector result, without going through Table reflection.
+        index_info = inspector.get_indexes(table.name)[0]
+        metadata_table = Table(table.name, MetaData(), Column("x", Integer))
+        index = Index(
+            index_info["name"],
+            metadata_table.c.x,
+            unique=True,
+            **index_info["dialect_options"],
+        )
+        assert "postgresql_not_valid" not in index.dialect_kwargs
+        eq_(index.dialect_options["postgresql"].reflected, {})
+
+    def test_table_reflection(self, invalid_index):
+        connection, table = invalid_index
+        inspector = inspect(connection)
+        before = inspector.get_indexes(table.name)
+        reflected = Table(table.name, MetaData(), autoload_with=inspector)
+        indexes = {index.name: index for index in reflected.indexes}
+        eq_(set(indexes), {"ix_invalid", "ix_valid"})
+        invalid = indexes["ix_invalid"]
+        eq_(
+            invalid.dialect_options["postgresql"].reflected,
+            {"not_valid": True},
+        )
+        eq_(indexes["ix_valid"].dialect_options["postgresql"].reflected, {})
+        assert "postgresql_not_valid" not in invalid.dialect_kwargs
+        self.assert_compile(
+            CreateIndex(invalid),
+            "CREATE UNIQUE INDEX ix_invalid ON invalid_index_table (x)",
+            dialect=connection.dialect,
+        )
+        eq_(inspector.get_indexes(table.name), before)
+
+        # Copy the definition and recreate it. Reflected state belongs to the
+        # original database object, not the newly created index.
+        copied = reflected.to_metadata(MetaData())
+        eq_(
+            next(i for i in copied.indexes if i.name == "ix_invalid")
+            .dialect_options["postgresql"]
+            .reflected,
+            {},
+        )
+        table.drop(connection)
+        copied.create(connection)
+        inspector.clear_cache()
+        assert all(
+            "postgresql_not_valid" not in i.get("dialect_options", {})
+            for i in inspector.get_indexes(table.name)
+        )
+
+    @testing.only_on("postgresql >= 11")
+    def test_partitioned_index(self, metadata, connection):
+        parent = Table(
+            "invalid_parent",
+            metadata,
+            Column("x", Integer),
+            postgresql_partition_by="RANGE (x)",
+        )
+        parent.create(connection)
+        connection.exec_driver_sql(
+            "CREATE TABLE invalid_child PARTITION OF invalid_parent "
+            "FOR VALUES FROM (0) TO (10)"
+        )
+        # Register the child so metadata cleanup drops it before its parent.
+        Table(
+            "invalid_child", metadata, Column("x", Integer)
+        ).add_is_dependent_on(parent)
+        connection.exec_driver_sql(
+            "CREATE INDEX ix_parent ON ONLY invalid_parent (x)"
+        )
+        inspector = inspect(connection)
+        is_true(
+            inspector.get_indexes(parent.name)[0]["dialect_options"][
+                "postgresql_not_valid"
+            ]
+        )
+        reflected = Table(parent.name, MetaData(), autoload_with=connection)
+        eq_(
+            next(iter(reflected.indexes))
+            .dialect_options["postgresql"]
+            .reflected,
+            {"not_valid": True},
+        )
+        connection.exec_driver_sql(
+            "CREATE INDEX ix_child ON invalid_child (x)"
+        )
+        connection.exec_driver_sql(
+            "ALTER INDEX ix_parent ATTACH PARTITION ix_child"
+        )
+        inspector.clear_cache()
+        assert (
+            "postgresql_not_valid"
+            not in inspector.get_indexes(parent.name)[0]["dialect_options"]
+        )
+
+
 class MaterializedViewReflectionTest(
     ReflectionFixtures, fixtures.TablesTest, AssertsExecutionResults
 ):

--- a/test/sql/test_metadata.py
+++ b/test/sql/test_metadata.py
@@ -5998,18 +5998,26 @@ class DialectKWArgTest(fixtures.TestBase):
                 Index.argument_for(
                     dialect, "state", schema.SchemaConst.IGNORE_OPTION
                 )
+            Index.argument_for(
+                "participating",
+                "other_state",
+                schema.SchemaConst.IGNORE_OPTION,
+            )
             original = {
                 "participating_state": value,
+                "participating_other_state": "second value",
                 "participating2_state": "other state",
                 "participating_x": 7,
             }
             options = original.copy()
-            idx = Index._from_reflection("a", "b", dialect_options=options)
+            idx = Index(
+                "a", "b", _dialect_kwargs_from_reflection=True, **options
+            )
             eq_(options, original)
             eq_(idx.dialect_kwargs, {"participating_x": 7})
             eq_(
                 idx.dialect_options["participating"].reflected,
-                {"state": value},
+                {"state": value, "other_state": "second value"},
             )
             eq_(
                 idx.dialect_options["participating2"].reflected,
@@ -6026,7 +6034,7 @@ class DialectKWArgTest(fixtures.TestBase):
             idx.dialect_kwargs["participating_state"] = not value
             eq_(
                 idx.dialect_options["participating"].reflected,
-                {"state": value},
+                {"state": value, "other_state": "second value"},
             )
             eq_(idx.dialect_kwargs, {"participating_x": 7})
 
@@ -6036,13 +6044,12 @@ class DialectKWArgTest(fixtures.TestBase):
                 "participating", "state", schema.SchemaConst.IGNORE_OPTION
             )
             t = Table("t", MetaData(), Column("x", Integer))
-            idx = Index._from_reflection(
+            idx = Index(
                 "ix",
                 t.c.x,
-                dialect_options={
-                    "participating_state": True,
-                    "participating_x": 7,
-                },
+                _dialect_kwargs_from_reflection=True,
+                participating_state=True,
+                participating_x=7,
             )
             pickled = pickle.loads(pickle.dumps(idx))
             eq_(
@@ -6067,8 +6074,8 @@ class DialectKWArgTest(fixtures.TestBase):
                 "participating", "state", schema.SchemaConst.IGNORE_OPTION
             )
             options = {"participating_state": True}
-            inherited = CustomIndex._from_reflection(
-                "a", "b", dialect_options=options
+            inherited = CustomIndex(
+                "a", "b", _dialect_kwargs_from_reflection=True, **options
             )
             eq_(
                 inherited.dialect_options["participating"].reflected,
@@ -6077,33 +6084,35 @@ class DialectKWArgTest(fixtures.TestBase):
 
             # A subclass can replace the marker with an ordinary default.
             CustomIndex.argument_for("participating", "state", False)
-            overridden = CustomIndex._from_reflection(
-                "a", "b", dialect_options=options
+            overridden = CustomIndex(
+                "a", "b", _dialect_kwargs_from_reflection=True, **options
             )
             eq_(overridden.dialect_options["participating"].reflected, {})
             eq_(overridden.dialect_kwargs, options)
 
-    def test_from_reflection_preserves_validation(self):
+    def test_reflection_only_preserves_validation(self):
         with self._fixture():
             with expect_warnings("Can't validate argument 'unknown_y'"):
-                idx = Index._from_reflection(
+                idx = Index(
                     "a",
                     "b",
-                    dialect_options={
-                        "unknown_y": True,
-                        "nonparticipating_x": 7,
-                    },
+                    _dialect_kwargs_from_reflection=True,
+                    unknown_y=True,
+                    nonparticipating_x=7,
                 )
             eq_(
                 idx.dialect_kwargs,
                 {"unknown_y": True, "nonparticipating_x": 7},
             )
             with testing.expect_raises(exc.ArgumentError):
-                Index._from_reflection(
-                    "a", "b", dialect_options={"participating_bad": 1}
+                Index(
+                    "a",
+                    "b",
+                    _dialect_kwargs_from_reflection=True,
+                    participating_bad=1,
                 )
             with testing.expect_raises(TypeError):
-                Index._from_reflection("a", "b", dialect_options={"bad": 1})
+                Index("a", "b", _dialect_kwargs_from_reflection=True, bad=1)
 
 
 class NamingConventionTest(fixtures.TestBase, AssertsCompiledSQL):

--- a/test/sql/test_metadata.py
+++ b/test/sql/test_metadata.py
@@ -5970,6 +5970,141 @@ class DialectKWArgTest(fixtures.TestBase):
                 "fallback",
             )
 
+    @testing.combinations(True, False, argnames="value")
+    def test_reflection_only_constructor_option(self, value):
+        with self._fixture():
+            Index.argument_for(
+                "participating", "state", schema.SchemaConst.IGNORE_OPTION
+            )
+            idx = Index("a", "b", participating_state=value, participating_x=7)
+            options = idx.dialect_options["participating"]
+            eq_(idx.dialect_kwargs, {"participating_x": 7})
+            eq_(options.reflected, {})
+            assert "state" not in options
+            is_(options.get("state"), None)
+
+            # Also exclude the marker from compiler-facing default lookup.
+            dialect = mock.Mock()
+            dialect.name = "participating"
+            eq_(
+                idx.get_dialect_option(dialect, "state", else_="absent"),
+                "absent",
+            )
+
+    @testing.combinations(True, False, argnames="value")
+    def test_reflection_only_options(self, value):
+        with self._fixture():
+            for dialect in ("participating", "participating2"):
+                Index.argument_for(
+                    dialect, "state", schema.SchemaConst.IGNORE_OPTION
+                )
+            original = {
+                "participating_state": value,
+                "participating2_state": "other state",
+                "participating_x": 7,
+            }
+            options = original.copy()
+            idx = Index._from_reflection("a", "b", dialect_options=options)
+            eq_(options, original)
+            eq_(idx.dialect_kwargs, {"participating_x": 7})
+            eq_(
+                idx.dialect_options["participating"].reflected,
+                {"state": value},
+            )
+            eq_(
+                idx.dialect_options["participating2"].reflected,
+                {"state": "other state"},
+            )
+
+            with testing.expect_raises(TypeError):
+                idx.dialect_options["participating"].reflected["state"] = False
+            with testing.expect_raises(AttributeError):
+                idx.dialect_options["participating"].reflected = {}
+
+            # Ordinary option assignment cannot change the reflected snapshot
+            # or leak this state into the flat kwargs view.
+            idx.dialect_kwargs["participating_state"] = not value
+            eq_(
+                idx.dialect_options["participating"].reflected,
+                {"state": value},
+            )
+            eq_(idx.dialect_kwargs, {"participating_x": 7})
+
+    def test_reflection_only_copy_and_pickle(self):
+        with self._fixture():
+            Index.argument_for(
+                "participating", "state", schema.SchemaConst.IGNORE_OPTION
+            )
+            t = Table("t", MetaData(), Column("x", Integer))
+            idx = Index._from_reflection(
+                "ix",
+                t.c.x,
+                dialect_options={
+                    "participating_state": True,
+                    "participating_x": 7,
+                },
+            )
+            pickled = pickle.loads(pickle.dumps(idx))
+            eq_(
+                pickled.dialect_options["participating"].reflected,
+                {"state": True},
+            )
+            copied = t.to_metadata(MetaData())
+            copied_index = next(iter(copied.indexes))
+            eq_(copied_index.dialect_options["participating"].reflected, {})
+            eq_(copied_index.dialect_kwargs, {"participating_x": 7})
+            eq_(
+                idx.dialect_options["participating"].reflected, {"state": True}
+            )
+
+    def test_reflection_only_inheritance(self):
+        with self._fixture():
+
+            class CustomIndex(Index):
+                pass
+
+            Index.argument_for(
+                "participating", "state", schema.SchemaConst.IGNORE_OPTION
+            )
+            options = {"participating_state": True}
+            inherited = CustomIndex._from_reflection(
+                "a", "b", dialect_options=options
+            )
+            eq_(
+                inherited.dialect_options["participating"].reflected,
+                {"state": True},
+            )
+
+            # A subclass can replace the marker with an ordinary default.
+            CustomIndex.argument_for("participating", "state", False)
+            overridden = CustomIndex._from_reflection(
+                "a", "b", dialect_options=options
+            )
+            eq_(overridden.dialect_options["participating"].reflected, {})
+            eq_(overridden.dialect_kwargs, options)
+
+    def test_from_reflection_preserves_validation(self):
+        with self._fixture():
+            with expect_warnings("Can't validate argument 'unknown_y'"):
+                idx = Index._from_reflection(
+                    "a",
+                    "b",
+                    dialect_options={
+                        "unknown_y": True,
+                        "nonparticipating_x": 7,
+                    },
+                )
+            eq_(
+                idx.dialect_kwargs,
+                {"unknown_y": True, "nonparticipating_x": 7},
+            )
+            with testing.expect_raises(exc.ArgumentError):
+                Index._from_reflection(
+                    "a", "b", dialect_options={"participating_bad": 1}
+                )
+            with testing.expect_raises(TypeError):
+                Index._from_reflection("a", "b", dialect_options={"bad": 1})
+
 
 class NamingConventionTest(fixtures.TestBase, AssertsCompiledSQL):
     __dialect__ = "default"


### PR DESCRIPTION
Fixes #13577. PostgreSQL retains invalid indexes after a failed concurrent build, but reflection currently reports them like valid indexes.

Read `indisvalid` and report `postgresql_not_valid=True` for invalid indexes. The shared `SchemaConst.IGNORE_OPTION` marker separates reflected state from DDL options, exposing it through `index.dialect_options["postgresql"].reflected` on reflected tables.

Marked constructor keywords are accepted and discarded because Alembic builds `Index` objects directly from Inspector results. This keeps the flag out of `dialect_kwargs` and generated migrations. Index validity remains informational, including for active builds and partitioned indexes awaiting attachments.
