### PR TITLE
docs: remove duplicate 'a' in insertmanyvalues sentinel docs

### DIFF
--- a/doc/build/core/connections.rst
+++ b/doc/build/core/connections.rst
@@ -2136,7 +2136,7 @@ compatible with the "sentinel" use case, other non-primary key columns may be
 marked as "sentinel" columns assuming they meet certain requirements. A typical
 example is a non-primary key :class:`_sqltypes.Uuid` column with a client side
 default such as the Python ``uuid.uuid4()`` function.  There is also a construct to create
-simple integer columns with a a client side integer counter oriented towards
+simple integer columns with a client side integer counter oriented towards
 the "insertmanyvalues" use case.
 
 Sentinel columns may be indicated by adding :paramref:`_schema.Column.insert_sentinel`


### PR DESCRIPTION
## Summary
- Remove duplicate word in the insertmanyvalues sentinel column docs: "with a a client side" → "with a client side".

## Test plan
- [x] Confirmed the surrounding sentence still reads correctly after the change.